### PR TITLE
ci: switch CI from Python pipeline to Tauri stack jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,38 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      typescript: ${{ steps.filter.outputs.typescript }}
+      ttsd: ${{ steps.filter.outputs.ttsd }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'src-tauri/**'
+              - '.github/workflows/ci.yml'
+            typescript:
+              - 'src/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig.json'
+              - 'vite.config.ts'
+              - 'index.html'
+              - '.github/workflows/ci.yml'
+            ttsd:
+              - 'ttsd/**'
+              - '.github/workflows/ci.yml'
+
   rust:
     name: Rust (clippy + test)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +60,8 @@ jobs:
 
   typescript:
     name: TypeScript (typecheck)
+    needs: changes
+    if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +77,8 @@ jobs:
 
   ttsd:
     name: ttsd (ruff + pytest)
+    needs: changes
+    if: needs.changes.outputs.ttsd == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,56 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  rust:
+    name: Rust (clippy + test)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev \
+            librsvg2-dev libayatana-appindicator3-dev \
+            libmpv-dev pkg-config build-essential
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - run: cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings
+      - run: cargo test --manifest-path src-tauri/Cargo.toml
 
-  test:
+  typescript:
+    name: TypeScript (typecheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+
+  ttsd:
+    name: ttsd (ruff + pytest)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-      - run: uv sync --group dev
-      - run: uv run mypy src/ruvox/tts_pipeline/
-      - run: uv run pytest tests/tts_pipeline/ --cov
+          python-version: "3.12"
+      - working-directory: ttsd
+        run: uv sync --group dev
+      - working-directory: ttsd
+        run: uv run ruff check
+      - working-directory: ttsd
+        run: uv run python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
   ttsd:
     name: ttsd (ruff + pytest)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # RuVox
 
+[![CI](https://github.com/xilec/RuVox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/xilec/RuVox/actions/workflows/ci.yml)
 ![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-green)
 
 Desktop-приложение для озвучивания технических текстов на русском языке.

--- a/src-tauri/src/pipeline/normalizers/english.rs
+++ b/src-tauri/src/pipeline/normalizers/english.rs
@@ -236,7 +236,7 @@ static MULTI_WORD_PHRASES: Lazy<Vec<(&'static str, &'static str)>> = Lazy::new(|
         ("edge case", "эдж кейс"),
     ];
     // Sort by descending length for longest-match behaviour
-    phrases.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    phrases.sort_by_key(|p| std::cmp::Reverse(p.0.len()));
     phrases
 });
 

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -270,7 +270,7 @@ impl StorageService {
     /// All entries sorted by `created_at`, newest first.
     pub fn get_all_entries(&self) -> Vec<TextEntry> {
         let mut entries: Vec<TextEntry> = self.entries.read().values().cloned().collect();
-        entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        entries.sort_by_key(|e| std::cmp::Reverse(e.created_at));
         entries
     }
 

--- a/ttsd/pyproject.toml
+++ b/ttsd/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
 ttsd = "ttsd.__main__:main"
 
 [tool.pytest.ini_options]
+addopts = "-m 'not slow'"
 markers = [
     "slow: slow tests (network or heavy ML)",
 ]

--- a/ttsd/tests/test_timestamps.py
+++ b/ttsd/tests/test_timestamps.py
@@ -1,7 +1,5 @@
 """Unit tests for timestamps.py — no torch required."""
 
-import pytest
-
 from ttsd.timestamps import estimate_timestamps_chunked, extract_words_with_positions
 
 

--- a/ttsd/ttsd/protocol.py
+++ b/ttsd/ttsd/protocol.py
@@ -9,7 +9,7 @@ The discriminated Request union uses Literal["cmd"] as the discriminator so Pyda
 selects the correct model from a single model_validate_json() call.
 """
 
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, TypeAdapter
 
@@ -67,7 +67,7 @@ class ShutdownRequest(BaseModel):
 
 # Discriminated union: Pydantic reads the "cmd" field to pick the right model.
 Request = Annotated[
-    Union[WarmupRequest, SynthesizeRequest, ShutdownRequest],
+    WarmupRequest | SynthesizeRequest | ShutdownRequest,
     Field(discriminator="cmd"),
 ]
 

--- a/ttsd/ttsd/protocol.py
+++ b/ttsd/ttsd/protocol.py
@@ -13,7 +13,6 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, TypeAdapter
 
-
 # ---------------------------------------------------------------------------
 # Shared sub-types
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Старый workflow тестировал `src/ruvox/tts_pipeline/` и `tests/tts_pipeline/` — путей, удалённых при переходе на Tauri.
- Заменён на три параллельных job'а на нативных GitHub-actions без Nix:
  - **rust** — `clippy -D warnings` + `cargo test`. Tauri-deps ставятся через `apt-get` (webkit2gtk-4.1, soup-3, gtk-3, mpv, …); `target/` кешируется через `Swatinem/rust-cache`.
  - **typescript** — `pnpm install --frozen-lockfile` + `pnpm typecheck` с pnpm-store cache.
  - **ttsd** — `uv sync` + `ruff check` + `pytest`, uv-cache включён.

## Test plan

- [x] PR-run этого workflow — все три job'а зелёные.
- [x] Cache prime: повторный push в эту ветку — job'ы заметно быстрее (cargo target и pnpm store пришли из cache).
- [x] После merge в main: workflow триггерится по `push: main` и тоже зелёный.

## Out of scope

- `cargo fmt --check` — добавим отдельным PR (не уверен что текущий код полностью fmt-clean).
- `nix build .#ruvox` smoke (issue #4) — производственный бандл, отдельная задача с `pnpm.fetchDeps` hash-fixup.