### PR TITLE
style(rust): apply cargo fmt across src-tauri/

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,7 +13,9 @@ use tracing::{info, warn};
 
 use crate::pipeline::tracked_text::CharMapping;
 use crate::state::AppState;
-use crate::storage::schema::{EntryId, EntryStatus, TextEntry, UIConfig, UIConfigPatch, WordTimestamp};
+use crate::storage::schema::{
+    EntryId, EntryStatus, TextEntry, UIConfig, UIConfigPatch, WordTimestamp,
+};
 use crate::storage::service::{StorageError, StorageService};
 use crate::tts::{CharMappingEntry, TtsError};
 
@@ -100,7 +102,15 @@ pub fn spawn_synthesis_pub<R: Runtime + 'static>(
     entry_id: EntryId,
     play_when_ready: bool,
 ) {
-    spawn_synthesis(app, storage, tts, player, pipeline, entry_id, play_when_ready);
+    spawn_synthesis(
+        app,
+        storage,
+        tts,
+        player,
+        pipeline,
+        entry_id,
+        play_when_ready,
+    );
 }
 
 /// Run the full synthesis pipeline for `entry_id` in a background task.
@@ -244,10 +254,7 @@ fn spawn_synthesis<R: Runtime + 'static>(
 
                 // Phase 7: auto-play if requested.
                 if play_when_ready {
-                    let path = storage
-                        .cache_dir()
-                        .join("audio")
-                        .join(&wav_filename);
+                    let path = storage.cache_dir().join("audio").join(&wav_filename);
                     if let Err(e) = player.load(&path, entry_id.to_string()) {
                         warn!("auto-play load failed: {e}");
                     } else if let Err(e) = player.play() {
@@ -343,14 +350,17 @@ pub async fn add_clipboard_entry(
 ) -> CmdResult<String> {
     // Read clipboard on a blocking thread (required on Linux to avoid deadlock).
     let text = tokio::task::spawn_blocking(|| {
-        let mut board = arboard::Clipboard::new()
-            .map_err(|e| CommandError::Internal { message: format!("clipboard init: {e}") })?;
+        let mut board = arboard::Clipboard::new().map_err(|e| CommandError::Internal {
+            message: format!("clipboard init: {e}"),
+        })?;
         board.get_text().map_err(|_| CommandError::Internal {
             message: "в буфере обмена нет текста".to_string(),
         })
     })
     .await
-    .map_err(|e| CommandError::Internal { message: format!("clipboard task panicked: {e}") })??;
+    .map_err(|e| CommandError::Internal {
+        message: format!("clipboard task panicked: {e}"),
+    })??;
 
     ingest_text(app, &state, text, play_when_ready)
 }
@@ -385,28 +395,20 @@ pub struct PreviewNormalizeResult {
 
 /// Return all entries sorted by created_at descending.
 #[tauri::command]
-pub async fn get_entries(
-    state: State<'_, AppState>,
-) -> CmdResult<Vec<TextEntry>> {
+pub async fn get_entries(state: State<'_, AppState>) -> CmdResult<Vec<TextEntry>> {
     Ok(state.storage.get_all_entries())
 }
 
 /// Return a single entry by ID, or null if not found.
 #[tauri::command]
-pub async fn get_entry(
-    state: State<'_, AppState>,
-    id: String,
-) -> CmdResult<Option<TextEntry>> {
+pub async fn get_entry(state: State<'_, AppState>, id: String) -> CmdResult<Option<TextEntry>> {
     let uuid = parse_entry_id(&id)?;
     Ok(state.storage.get_entry(&uuid))
 }
 
 /// Delete an entry and its audio + timestamps files.
 #[tauri::command]
-pub async fn delete_entry(
-    state: State<'_, AppState>,
-    id: String,
-) -> CmdResult<()> {
+pub async fn delete_entry(state: State<'_, AppState>, id: String) -> CmdResult<()> {
     let uuid = parse_entry_id(&id)?;
 
     // Stop playback if this entry is playing.  Player::stop emits
@@ -415,7 +417,10 @@ pub async fn delete_entry(
         let _ = state.player.stop();
     }
 
-    state.storage.delete_entry(&uuid).map_err(CommandError::from)?;
+    state
+        .storage
+        .delete_entry(&uuid)
+        .map_err(CommandError::from)?;
 
     Ok(())
 }
@@ -428,7 +433,10 @@ pub async fn delete_audio(
     id: String,
 ) -> CmdResult<()> {
     let uuid = parse_entry_id(&id)?;
-    state.storage.delete_audio(&uuid).map_err(CommandError::from)?;
+    state
+        .storage
+        .delete_audio(&uuid)
+        .map_err(CommandError::from)?;
 
     if let Some(entry) = state.storage.get_entry(&uuid) {
         emit_entry_updated(&app, &entry);
@@ -449,25 +457,29 @@ pub async fn cancel_synthesis(
     let mut entry = state
         .storage
         .get_entry(&uuid)
-        .ok_or_else(|| CommandError::NotFound { message: format!("entry not found: {id}") })?;
+        .ok_or_else(|| CommandError::NotFound {
+            message: format!("entry not found: {id}"),
+        })?;
 
     entry.status = EntryStatus::Pending;
-    state.storage.update_entry(entry.clone()).map_err(CommandError::from)?;
+    state
+        .storage
+        .update_entry(entry.clone())
+        .map_err(CommandError::from)?;
     emit_entry_updated(&app, &entry);
     Ok(())
 }
 
 /// Start playback of a ready entry.
 #[tauri::command]
-pub async fn play_entry(
-    state: State<'_, AppState>,
-    id: String,
-) -> CmdResult<()> {
+pub async fn play_entry(state: State<'_, AppState>, id: String) -> CmdResult<()> {
     let uuid = parse_entry_id(&id)?;
     let entry = state
         .storage
         .get_entry(&uuid)
-        .ok_or_else(|| CommandError::NotFound { message: format!("entry not found: {id}") })?;
+        .ok_or_else(|| CommandError::NotFound {
+            message: format!("entry not found: {id}"),
+        })?;
 
     if entry.status != EntryStatus::Ready {
         return Err(CommandError::PlaybackError {
@@ -475,19 +487,26 @@ pub async fn play_entry(
         });
     }
 
-    let path = state.storage.get_audio_path(&uuid).ok_or_else(|| {
-        CommandError::PlaybackError { message: format!("audio file missing for entry {id}") }
-    })?;
+    let path = state
+        .storage
+        .get_audio_path(&uuid)
+        .ok_or_else(|| CommandError::PlaybackError {
+            message: format!("audio file missing for entry {id}"),
+        })?;
 
     state
         .player
         .load(&path, id.clone())
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })?;
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })?;
 
     state
         .player
         .play()
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })?;
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })?;
 
     Ok(())
 }
@@ -498,7 +517,9 @@ pub async fn pause_playback(state: State<'_, AppState>) -> CmdResult<()> {
     state
         .player
         .pause()
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })
 }
 
 /// Resume playback from the paused position.
@@ -507,7 +528,9 @@ pub async fn resume_playback(state: State<'_, AppState>) -> CmdResult<()> {
     state
         .player
         .resume()
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })
 }
 
 /// Stop playback entirely.
@@ -516,27 +539,25 @@ pub async fn stop_playback(state: State<'_, AppState>) -> CmdResult<()> {
     state
         .player
         .stop()
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })
 }
 
 /// Seek to an absolute position in the current audio.
 #[tauri::command]
-pub async fn seek_to(
-    state: State<'_, AppState>,
-    position_sec: f64,
-) -> CmdResult<()> {
+pub async fn seek_to(state: State<'_, AppState>, position_sec: f64) -> CmdResult<()> {
     state
         .player
         .seek(position_sec)
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })
 }
 
 /// Set playback speed (0.5–2.0). Persisted to UIConfig.speech_rate.
 #[tauri::command]
-pub async fn set_speed(
-    state: State<'_, AppState>,
-    speed: f32,
-) -> CmdResult<()> {
+pub async fn set_speed(state: State<'_, AppState>, speed: f32) -> CmdResult<()> {
     if !(0.5..=2.0).contains(&speed) {
         return Err(CommandError::ConfigError {
             message: format!("speed {speed} is out of range [0.5, 2.0]"),
@@ -546,7 +567,9 @@ pub async fn set_speed(
     state
         .player
         .set_speed(speed)
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })?;
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })?;
 
     // Persist to config.
     let mut config = state.storage.load_config().unwrap_or_default();
@@ -560,10 +583,7 @@ pub async fn set_speed(
 
 /// Set playback volume (0.0–1.0). Not persisted.
 #[tauri::command]
-pub async fn set_volume(
-    state: State<'_, AppState>,
-    volume: f32,
-) -> CmdResult<()> {
+pub async fn set_volume(state: State<'_, AppState>, volume: f32) -> CmdResult<()> {
     if !(0.0..=1.0).contains(&volume) {
         return Err(CommandError::ConfigError {
             message: format!("volume {volume} is out of range [0.0, 1.0]"),
@@ -573,7 +593,9 @@ pub async fn set_volume(
     state
         .player
         .set_volume(volume)
-        .map_err(|e| CommandError::PlaybackError { message: e.to_string() })
+        .map_err(|e| CommandError::PlaybackError {
+            message: e.to_string(),
+        })
 }
 
 /// Return the current application configuration.
@@ -584,13 +606,13 @@ pub async fn get_config(state: State<'_, AppState>) -> CmdResult<UIConfig> {
 
 /// Merge a partial config patch into the current configuration and persist.
 #[tauri::command]
-pub async fn update_config(
-    state: State<'_, AppState>,
-    patch: UIConfigPatch,
-) -> CmdResult<()> {
+pub async fn update_config(state: State<'_, AppState>, patch: UIConfigPatch) -> CmdResult<()> {
     let mut config = state.storage.load_config().unwrap_or_default();
     apply_config_patch(&mut config, patch);
-    state.storage.save_config(&config).map_err(CommandError::from)
+    state
+        .storage
+        .save_config(&config)
+        .map_err(CommandError::from)
 }
 
 /// Load and return word timestamps for an entry.
@@ -603,7 +625,9 @@ pub async fn get_timestamps(
 
     // Verify entry exists.
     if state.storage.get_entry(&uuid).is_none() {
-        return Err(CommandError::NotFound { message: format!("entry not found: {id}") });
+        return Err(CommandError::NotFound {
+            message: format!("entry not found: {id}"),
+        });
     }
 
     let timestamps = state
@@ -659,7 +683,10 @@ pub async fn clear_cache(
         }
     }
 
-    Ok(ClearCacheResult { deleted_files, freed_bytes })
+    Ok(ClearCacheResult {
+        deleted_files,
+        freed_bytes,
+    })
 }
 
 #[derive(Serialize)]
@@ -670,12 +697,16 @@ pub struct ClearCacheResult {
 
 /// Return current cache size information.
 #[tauri::command]
-pub async fn get_cache_stats(
-    state: State<'_, AppState>,
-) -> CmdResult<CacheSizeInfo> {
+pub async fn get_cache_stats(state: State<'_, AppState>) -> CmdResult<CacheSizeInfo> {
     let total_bytes = state.storage.get_cache_size().map_err(CommandError::from)?;
-    let audio_file_count = state.storage.get_audio_count().map_err(CommandError::from)?;
-    Ok(CacheSizeInfo { total_bytes, audio_file_count })
+    let audio_file_count = state
+        .storage
+        .get_audio_count()
+        .map_err(CommandError::from)?;
+    Ok(CacheSizeInfo {
+        total_bytes,
+        audio_file_count,
+    })
 }
 
 #[derive(Serialize)]
@@ -693,21 +724,55 @@ fn parse_entry_id(s: &str) -> CmdResult<EntryId> {
 }
 
 fn apply_config_patch(config: &mut UIConfig, patch: UIConfigPatch) {
-    if let Some(v) = patch.speaker { config.speaker = v; }
-    if let Some(v) = patch.sample_rate { config.sample_rate = v; }
-    if let Some(v) = patch.speech_rate { config.speech_rate = v; }
-    if let Some(v) = patch.notify_on_ready { config.notify_on_ready = v; }
-    if let Some(v) = patch.notify_on_error { config.notify_on_error = v; }
-    if let Some(v) = patch.text_format { config.text_format = v; }
-    if let Some(v) = patch.history_days { config.history_days = v; }
-    if let Some(v) = patch.audio_max_files { config.audio_max_files = v; }
-    if let Some(v) = patch.audio_regenerated_hours { config.audio_regenerated_hours = v; }
-    if let Some(v) = patch.max_cache_size_mb { config.max_cache_size_mb = v; }
-    if let Some(v) = patch.auto_cleanup_days { config.auto_cleanup_days = v; }
-    if let Some(v) = patch.code_block_mode { config.code_block_mode = v; }
-    if let Some(v) = patch.read_operators { config.read_operators = v; }
-    if let Some(v) = patch.theme { config.theme = v; }
-    if let Some(v) = patch.player_hotkeys { config.player_hotkeys = v; }
-    if let Some(v) = patch.window_geometry { config.window_geometry = v; }
-    if let Some(v) = patch.preview_dialog_enabled { config.preview_dialog_enabled = v; }
+    if let Some(v) = patch.speaker {
+        config.speaker = v;
+    }
+    if let Some(v) = patch.sample_rate {
+        config.sample_rate = v;
+    }
+    if let Some(v) = patch.speech_rate {
+        config.speech_rate = v;
+    }
+    if let Some(v) = patch.notify_on_ready {
+        config.notify_on_ready = v;
+    }
+    if let Some(v) = patch.notify_on_error {
+        config.notify_on_error = v;
+    }
+    if let Some(v) = patch.text_format {
+        config.text_format = v;
+    }
+    if let Some(v) = patch.history_days {
+        config.history_days = v;
+    }
+    if let Some(v) = patch.audio_max_files {
+        config.audio_max_files = v;
+    }
+    if let Some(v) = patch.audio_regenerated_hours {
+        config.audio_regenerated_hours = v;
+    }
+    if let Some(v) = patch.max_cache_size_mb {
+        config.max_cache_size_mb = v;
+    }
+    if let Some(v) = patch.auto_cleanup_days {
+        config.auto_cleanup_days = v;
+    }
+    if let Some(v) = patch.code_block_mode {
+        config.code_block_mode = v;
+    }
+    if let Some(v) = patch.read_operators {
+        config.read_operators = v;
+    }
+    if let Some(v) = patch.theme {
+        config.theme = v;
+    }
+    if let Some(v) = patch.player_hotkeys {
+        config.player_hotkeys = v;
+    }
+    if let Some(v) = patch.window_geometry {
+        config.window_geometry = v;
+    }
+    if let Some(v) = patch.preview_dialog_enabled {
+        config.preview_dialog_enabled = v;
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,23 +29,39 @@ use tray::TrayCmd;
 /// survived a crash/SIGKILL.  Find those mpv PIDs via `/proc/<pid>/cmdline`
 /// search and send SIGTERM.
 fn reap_orphan_mpv() {
-    let Ok(entries) = std::fs::read_dir("/tmp") else { return };
+    let Ok(entries) = std::fs::read_dir("/tmp") else {
+        return;
+    };
     for entry in entries.flatten() {
         let name = entry.file_name();
         let Some(s) = name.to_str() else { continue };
-        if !s.starts_with("tauri_plugin_mpv_socket_") { continue }
+        if !s.starts_with("tauri_plugin_mpv_socket_") {
+            continue;
+        }
         let parts: Vec<&str> = s.split('_').collect();
-        let Some(parent_pid_str) = parts.get(4) else { continue };
-        let Ok(parent_pid) = parent_pid_str.parse::<u32>() else { continue };
-        if std::path::Path::new(&format!("/proc/{parent_pid}")).exists() { continue; }
+        let Some(parent_pid_str) = parts.get(4) else {
+            continue;
+        };
+        let Ok(parent_pid) = parent_pid_str.parse::<u32>() else {
+            continue;
+        };
+        if std::path::Path::new(&format!("/proc/{parent_pid}")).exists() {
+            continue;
+        }
         // Parent dead → find mpv with this IPC socket arg and kill it.
         if let Ok(procs) = std::fs::read_dir("/proc") {
             for p in procs.flatten() {
-                let Ok(pid) = p.file_name().to_string_lossy().parse::<u32>() else { continue };
-                let Ok(cmdline) = std::fs::read_to_string(format!("/proc/{pid}/cmdline")) else { continue };
+                let Ok(pid) = p.file_name().to_string_lossy().parse::<u32>() else {
+                    continue;
+                };
+                let Ok(cmdline) = std::fs::read_to_string(format!("/proc/{pid}/cmdline")) else {
+                    continue;
+                };
                 if cmdline.contains(&format!("tauri_plugin_mpv_socket_{parent_pid}_")) {
                     tracing::warn!("reaping orphan mpv pid={pid} (parent {parent_pid} dead)");
-                    unsafe { libc::kill(pid as i32, libc::SIGTERM); }
+                    unsafe {
+                        libc::kill(pid as i32, libc::SIGTERM);
+                    }
                 }
             }
         }
@@ -70,19 +86,14 @@ pub fn run() {
             // inside the title bar itself — that is a GNOME/KDE chrome
             // decision, not a Tauri limitation.
             if let Some(window) = app.get_webview_window("main") {
-                let icon = tauri::image::Image::from_bytes(
-                    include_bytes!("../icons/128x128.png"),
-                )?;
+                let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/128x128.png"))?;
                 let _ = window.set_icon(icon);
             }
 
             let player = Arc::new(Player::new(app.handle().clone())?);
             player::spawn_position_emitter(player.clone(), app.handle().clone());
 
-            let storage = Arc::new(
-                StorageService::new()
-                    .expect("не удалось открыть хранилище"),
-            );
+            let storage = Arc::new(StorageService::new().expect("не удалось открыть хранилище"));
 
             // Spawn ttsd subprocess.
             // In production: bundled next to the binary (resource_dir/ttsd).
@@ -107,10 +118,8 @@ pub fn run() {
             // context; setup hook runs synchronously, so enter Tauri's runtime
             // explicitly via block_on (the inner spawn returns instantly).
             let tts = Arc::new(
-                tauri::async_runtime::block_on(async move {
-                    tts::TtsSubprocess::spawn(ttsd_dir)
-                })
-                .expect("не удалось запустить ttsd subprocess"),
+                tauri::async_runtime::block_on(async move { tts::TtsSubprocess::spawn(ttsd_dir) })
+                    .expect("не удалось запустить ttsd subprocess"),
             );
 
             // Warm up Silero model in background; emit model_loading → model_loaded/model_error.
@@ -126,7 +135,8 @@ pub fn run() {
                         }
                         Err(e) => {
                             tracing::error!("ttsd warmup failed: {e}");
-                            let _ = app_handle.emit("model_error", json!({ "message": e.to_string() }));
+                            let _ =
+                                app_handle.emit("model_error", json!({ "message": e.to_string() }));
                         }
                     }
                 });

--- a/src-tauri/src/pipeline/html_extractor.rs
+++ b/src-tauri/src/pipeline/html_extractor.rs
@@ -85,17 +85,46 @@ impl TrackedHtml {
 /// Tags whose entire subtree is excluded from TTS output (navigation, chrome,
 /// non-prose).
 const EXCLUDED_TAGS: &[&str] = &[
-    "nav", "footer", "aside", "script", "style", "head", "noscript", "template",
-    "svg", "math", "button", "select", "option", "optgroup", "datalist",
+    "nav", "footer", "aside", "script", "style", "head", "noscript", "template", "svg", "math",
+    "button", "select", "option", "optgroup", "datalist",
 ];
 
 /// Block-level tags that should be preceded by a newline in the output when
 /// they contain visible text.
 const BLOCK_TAGS: &[&str] = &[
-    "p", "div", "section", "article", "main", "header", "h1", "h2", "h3", "h4",
-    "h5", "h6", "blockquote", "pre", "ul", "ol", "li", "dt", "dd", "dl",
-    "figure", "figcaption", "table", "thead", "tbody", "tfoot", "tr", "th",
-    "td", "details", "summary", "br", "hr",
+    "p",
+    "div",
+    "section",
+    "article",
+    "main",
+    "header",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "blockquote",
+    "pre",
+    "ul",
+    "ol",
+    "li",
+    "dt",
+    "dd",
+    "dl",
+    "figure",
+    "figcaption",
+    "table",
+    "thead",
+    "tbody",
+    "tfoot",
+    "tr",
+    "th",
+    "td",
+    "details",
+    "summary",
+    "br",
+    "hr",
 ];
 
 fn is_excluded(tag: &str) -> bool {
@@ -365,7 +394,10 @@ mod tests {
     fn test_nav_excluded() {
         let html = "<nav><a href='/'>Домой</a></nav><p>Основное содержимое.</p>";
         let out = extract(html);
-        assert!(!out.contains("Домой"), "nav content must be excluded: {out:?}");
+        assert!(
+            !out.contains("Домой"),
+            "nav content must be excluded: {out:?}"
+        );
         assert!(out.contains("Основное содержимое."));
     }
 
@@ -375,7 +407,10 @@ mod tests {
     fn test_footer_excluded() {
         let html = "<p>Тело страницы.</p><footer><p>Копирайт 2026</p></footer>";
         let out = extract(html);
-        assert!(!out.contains("Копирайт"), "footer must be excluded: {out:?}");
+        assert!(
+            !out.contains("Копирайт"),
+            "footer must be excluded: {out:?}"
+        );
         assert!(out.contains("Тело страницы."));
     }
 
@@ -385,7 +420,10 @@ mod tests {
     fn test_aside_excluded() {
         let html = "<p>Главный текст.</p><aside><p>Боковая заметка</p></aside>";
         let out = extract(html);
-        assert!(!out.contains("Боковая заметка"), "aside must be excluded: {out:?}");
+        assert!(
+            !out.contains("Боковая заметка"),
+            "aside must be excluded: {out:?}"
+        );
         assert!(out.contains("Главный текст."));
     }
 
@@ -395,7 +433,10 @@ mod tests {
     fn test_script_style_excluded() {
         let html = r#"<style>body{color:red}</style><script>alert(1)</script><p>Виден</p>"#;
         let out = extract(html);
-        assert!(!out.contains("body{color:red}"), "style content must be excluded");
+        assert!(
+            !out.contains("body{color:red}"),
+            "style content must be excluded"
+        );
         assert!(!out.contains("alert"), "script content must be excluded");
         assert!(out.contains("Виден"));
     }
@@ -427,14 +468,18 @@ mod tests {
     fn test_inline_code() {
         let html = "<p>Вызови функцию <code>getUserData()</code> для получения данных.</p>";
         let out = extract(html);
-        assert!(out.contains("getUserData()"), "code content missing: {out:?}");
+        assert!(
+            out.contains("getUserData()"),
+            "code content missing: {out:?}"
+        );
     }
 
     // ── 12. Pre/code block ───────────────────────────────────────────────────
 
     #[test]
     fn test_pre_code_block() {
-        let html = r#"<pre><code class="language-rust">fn main() { println!("hello"); }</code></pre>"#;
+        let html =
+            r#"<pre><code class="language-rust">fn main() { println!("hello"); }</code></pre>"#;
         let out = extract(html);
         assert!(out.contains("fn main()"), "pre/code block missing: {out:?}");
     }
@@ -477,7 +522,10 @@ mod tests {
         let html = "<p>Текст   с   лишними   пробелами.</p>";
         let out = extract(html);
         // Multiple spaces in HTML source collapse to a single space in text.
-        assert!(!out.contains("   "), "multiple spaces should collapse: {out:?}");
+        assert!(
+            !out.contains("   "),
+            "multiple spaces should collapse: {out:?}"
+        );
         assert!(out.contains("Текст"), "text missing: {out:?}");
     }
 
@@ -489,7 +537,11 @@ mod tests {
         let tracked = extract_text_for_tts(html);
         // Spans must cover the extracted text.
         assert!(!tracked.spans.is_empty(), "spans should not be empty");
-        let total_coverage: usize = tracked.spans.iter().map(|s| s.text_end - s.text_start).sum();
+        let total_coverage: usize = tracked
+            .spans
+            .iter()
+            .map(|s| s.text_end - s.text_start)
+            .sum();
         assert!(
             total_coverage >= tracked.text.trim().len(),
             "spans should cover at least the trimmed text length"
@@ -522,7 +574,10 @@ mod tests {
     fn test_blockquote_preserved() {
         let html = "<blockquote><p>Цитата из источника.</p></blockquote>";
         let out = extract(html);
-        assert!(out.contains("Цитата из источника."), "blockquote missing: {out:?}");
+        assert!(
+            out.contains("Цитата из источника."),
+            "blockquote missing: {out:?}"
+        );
     }
 
     // ── 19. table cells concatenated ─────────────────────────────────────────
@@ -541,6 +596,9 @@ mod tests {
     fn test_empty_html() {
         let tracked = extract_text_for_tts("");
         let out = normalise_extracted(&tracked.text);
-        assert!(out.is_empty(), "empty HTML should yield empty text: {out:?}");
+        assert!(
+            out.is_empty(),
+            "empty HTML should yield empty text: {out:?}"
+        );
     }
 }

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -22,8 +22,10 @@ use crate::pipeline::tracked_text::{CharMapping, TrackedText};
 fn re_url() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r#"https?://[^\s<>"'\)]+|ftp://[^\s<>"'\)]+|ssh://[^\s<>"'\)]+|git://[^\s<>"'\)]+"#)
-            .expect("valid regex")
+        Regex::new(
+            r#"https?://[^\s<>"'\)]+|ftp://[^\s<>"'\)]+|ssh://[^\s<>"'\)]+|git://[^\s<>"'\)]+"#,
+        )
+        .expect("valid regex")
     })
 }
 
@@ -36,9 +38,7 @@ fn re_email() -> &'static Regex {
 
 fn re_ip() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b").expect("valid regex")
-    })
+    RE.get_or_init(|| Regex::new(r"\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b").expect("valid regex"))
 }
 
 fn re_path() -> &'static Regex {
@@ -63,10 +63,8 @@ fn re_size() -> &'static Regex {
 fn re_version() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(
-            r"(?i)\bv?(\d+\.\d+(?:\.\d+)?(?:-(?:alpha|beta|rc|dev|stable|release)\d*)?)\b",
-        )
-        .expect("valid regex")
+        Regex::new(r"(?i)\bv?(\d+\.\d+(?:\.\d+)?(?:-(?:alpha|beta|rc|dev|stable|release)\d*)?)\b")
+            .expect("valid regex")
     })
 }
 
@@ -87,9 +85,7 @@ fn re_inline_code() -> &'static Regex {
 
 fn re_heading() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"(?m)^#{1,6}\s+").expect("valid regex")
-    })
+    RE.get_or_init(|| Regex::new(r"(?m)^#{1,6}\s+").expect("valid regex"))
 }
 
 fn re_md_link_full() -> &'static Regex {
@@ -183,9 +179,8 @@ fn re_tilde_approx() -> &'static Regex {
 /// partial matches (e.g. "===" must be checked before "==").
 /// Single `=` is intentionally excluded — it would corrupt math formulas
 /// like "α = β".
-const TRACKED_OPERATOR_KEYS: &[&str] = &[
-    "===", "!==", "->", "=>", ">=", "<=", "!=", "==", "&&", "||",
-];
+const TRACKED_OPERATOR_KEYS: &[&str] =
+    &["===", "!==", "->", "=>", ">=", "<=", "!=", "==", "&&", "||"];
 
 // ── TTSPipeline ────────────────────────────────────────────────────────────────
 
@@ -286,7 +281,9 @@ impl TTSPipeline {
             let num = &self.number_normalizer;
             let eng = &self.english_normalizer;
             let url_norm = URLPathNormalizer::new(eng, num);
-            tracked.sub(re_url(), |caps| url_norm.normalize_url(caps.get(0).unwrap().as_str()));
+            tracked.sub(re_url(), |caps| {
+                url_norm.normalize_url(caps.get(0).unwrap().as_str())
+            });
             tracked.sub(re_email(), |caps| {
                 url_norm.normalize_email(caps.get(0).unwrap().as_str())
             });
@@ -504,7 +501,7 @@ impl TTSPipeline {
                     // "[" is a 1-byte ASCII char.
                     let bracket_start = full_m.start();
                     let bracket_end = bracket_start + 1; // just "["
-                    // "](url)" starts right after the link text.
+                                                         // "](url)" starts right after the link text.
                     let suffix_start = text_m.end(); // byte after last char of link text
                     let suffix_end = full_m.end();
                     (bracket_start, bracket_end, suffix_start, suffix_end)
@@ -573,9 +570,8 @@ impl TTSPipeline {
                 } else if crate::pipeline::normalizers::abbreviations::as_word()
                     .contains_key(word_lower.as_str())
                 {
-                    crate::pipeline::normalizers::abbreviations::as_word()
-                        [word_lower.as_str()]
-                    .to_string()
+                    crate::pipeline::normalizers::abbreviations::as_word()[word_lower.as_str()]
+                        .to_string()
                 } else {
                     self.english_normalizer.normalize(word, true)
                 };
@@ -616,7 +612,8 @@ impl TTSPipeline {
                     let next_byte = bytes[end];
                     let next_str = &snapshot[end..];
                     let next_ch = next_str.chars().next().unwrap();
-                    next_byte != b'.' && !next_ch.is_ascii_digit()
+                    next_byte != b'.'
+                        && !next_ch.is_ascii_digit()
                         && !next_ch.is_ascii_alphabetic()
                         && !next_ch.is_alphabetic()
                 };

--- a/src-tauri/src/pipeline/normalizers/code.rs
+++ b/src-tauri/src/pipeline/normalizers/code.rs
@@ -666,12 +666,18 @@ mod tests {
 
     #[test]
     fn camel_get_user_data() {
-        assert_eq!(normalizer().normalize_camel_case("getUserData"), "гет юзер дата");
+        assert_eq!(
+            normalizer().normalize_camel_case("getUserData"),
+            "гет юзер дата"
+        );
     }
 
     #[test]
     fn camel_my_variable() {
-        assert_eq!(normalizer().normalize_camel_case("myVariable"), "май вэриабл");
+        assert_eq!(
+            normalizer().normalize_camel_case("myVariable"),
+            "май вэриабл"
+        );
     }
 
     #[test]
@@ -696,7 +702,10 @@ mod tests {
 
     #[test]
     fn camel_handle_submit() {
-        assert_eq!(normalizer().normalize_camel_case("handleSubmit"), "хендл сабмит");
+        assert_eq!(
+            normalizer().normalize_camel_case("handleSubmit"),
+            "хендл сабмит"
+        );
     }
 
     #[test]
@@ -706,7 +715,10 @@ mod tests {
 
     #[test]
     fn camel_parse_json() {
-        assert_eq!(normalizer().normalize_camel_case("parseJSON"), "парс джейсон");
+        assert_eq!(
+            normalizer().normalize_camel_case("parseJSON"),
+            "парс джейсон"
+        );
     }
 
     #[test]
@@ -772,34 +784,52 @@ mod tests {
 
     #[test]
     fn camel_get_user2_data() {
-        assert_eq!(normalizer().normalize_camel_case("getUser2Data"), "гет юзер два дата");
+        assert_eq!(
+            normalizer().normalize_camel_case("getUser2Data"),
+            "гет юзер два дата"
+        );
     }
 
     #[test]
     fn camel_item1_name() {
-        assert_eq!(normalizer().normalize_camel_case("item1Name"), "айтем один нейм");
+        assert_eq!(
+            normalizer().normalize_camel_case("item1Name"),
+            "айтем один нейм"
+        );
     }
 
     // --- PascalCase ---
 
     #[test]
     fn pascal_user_service() {
-        assert_eq!(normalizer().normalize_camel_case("UserService"), "юзер сервис");
+        assert_eq!(
+            normalizer().normalize_camel_case("UserService"),
+            "юзер сервис"
+        );
     }
 
     #[test]
     fn pascal_data_repository() {
-        assert_eq!(normalizer().normalize_camel_case("DataRepository"), "дата репозитори");
+        assert_eq!(
+            normalizer().normalize_camel_case("DataRepository"),
+            "дата репозитори"
+        );
     }
 
     #[test]
     fn pascal_http_client() {
-        assert_eq!(normalizer().normalize_camel_case("HttpClient"), "эйч ти ти пи клиент");
+        assert_eq!(
+            normalizer().normalize_camel_case("HttpClient"),
+            "эйч ти ти пи клиент"
+        );
     }
 
     #[test]
     fn pascal_api_controller() {
-        assert_eq!(normalizer().normalize_camel_case("ApiController"), "эй пи ай контроллер");
+        assert_eq!(
+            normalizer().normalize_camel_case("ApiController"),
+            "эй пи ай контроллер"
+        );
     }
 
     #[test]
@@ -812,29 +842,44 @@ mod tests {
 
     #[test]
     fn pascal_event_handler() {
-        assert_eq!(normalizer().normalize_camel_case("EventHandler"), "ивент хендлер");
+        assert_eq!(
+            normalizer().normalize_camel_case("EventHandler"),
+            "ивент хендлер"
+        );
     }
 
     #[test]
     fn pascal_file_manager() {
-        assert_eq!(normalizer().normalize_camel_case("FileManager"), "файл менеджер");
+        assert_eq!(
+            normalizer().normalize_camel_case("FileManager"),
+            "файл менеджер"
+        );
     }
 
     #[test]
     fn pascal_config_loader() {
-        assert_eq!(normalizer().normalize_camel_case("ConfigLoader"), "конфиг лоудер");
+        assert_eq!(
+            normalizer().normalize_camel_case("ConfigLoader"),
+            "конфиг лоудер"
+        );
     }
 
     // --- SnakeCase ---
 
     #[test]
     fn snake_get_user_data() {
-        assert_eq!(normalizer().normalize_snake_case("get_user_data"), "гет юзер дата");
+        assert_eq!(
+            normalizer().normalize_snake_case("get_user_data"),
+            "гет юзер дата"
+        );
     }
 
     #[test]
     fn snake_my_variable() {
-        assert_eq!(normalizer().normalize_snake_case("my_variable"), "май вэриабл");
+        assert_eq!(
+            normalizer().normalize_snake_case("my_variable"),
+            "май вэриабл"
+        );
     }
 
     #[test]
@@ -854,7 +899,10 @@ mod tests {
 
     #[test]
     fn snake_handle_submit() {
-        assert_eq!(normalizer().normalize_snake_case("handle_submit"), "хендл сабмит");
+        assert_eq!(
+            normalizer().normalize_snake_case("handle_submit"),
+            "хендл сабмит"
+        );
     }
 
     #[test]
@@ -864,7 +912,10 @@ mod tests {
 
     #[test]
     fn snake_parse_json() {
-        assert_eq!(normalizer().normalize_snake_case("parse_json"), "парс джейсон");
+        assert_eq!(
+            normalizer().normalize_snake_case("parse_json"),
+            "парс джейсон"
+        );
     }
 
     #[test]
@@ -885,12 +936,18 @@ mod tests {
 
     #[test]
     fn snake_user_2_data() {
-        assert_eq!(normalizer().normalize_snake_case("user_2_data"), "юзер два дата");
+        assert_eq!(
+            normalizer().normalize_snake_case("user_2_data"),
+            "юзер два дата"
+        );
     }
 
     #[test]
     fn snake_item_1_name() {
-        assert_eq!(normalizer().normalize_snake_case("item_1_name"), "айтем один нейм");
+        assert_eq!(
+            normalizer().normalize_snake_case("item_1_name"),
+            "айтем один нейм"
+        );
     }
 
     #[test]
@@ -915,24 +972,36 @@ mod tests {
 
     #[test]
     fn snake_private_method() {
-        assert_eq!(normalizer().normalize_snake_case("_private_method"), "прайвит метод");
+        assert_eq!(
+            normalizer().normalize_snake_case("_private_method"),
+            "прайвит метод"
+        );
     }
 
     #[test]
     fn snake_private_attr() {
-        assert_eq!(normalizer().normalize_snake_case("__private_attr"), "прайвит аттр");
+        assert_eq!(
+            normalizer().normalize_snake_case("__private_attr"),
+            "прайвит аттр"
+        );
     }
 
     // --- KebabCase ---
 
     #[test]
     fn kebab_my_component() {
-        assert_eq!(normalizer().normalize_kebab_case("my-component"), "май компонент");
+        assert_eq!(
+            normalizer().normalize_kebab_case("my-component"),
+            "май компонент"
+        );
     }
 
     #[test]
     fn kebab_button_primary() {
-        assert_eq!(normalizer().normalize_kebab_case("button-primary"), "баттон праймари");
+        assert_eq!(
+            normalizer().normalize_kebab_case("button-primary"),
+            "баттон праймари"
+        );
     }
 
     #[test]
@@ -947,22 +1016,34 @@ mod tests {
 
     #[test]
     fn kebab_header_logo() {
-        assert_eq!(normalizer().normalize_kebab_case("header-logo"), "хедер лого");
+        assert_eq!(
+            normalizer().normalize_kebab_case("header-logo"),
+            "хедер лого"
+        );
     }
 
     #[test]
     fn kebab_footer_links() {
-        assert_eq!(normalizer().normalize_kebab_case("footer-links"), "футер линкс");
+        assert_eq!(
+            normalizer().normalize_kebab_case("footer-links"),
+            "футер линкс"
+        );
     }
 
     #[test]
     fn kebab_output_dir() {
-        assert_eq!(normalizer().normalize_kebab_case("output-dir"), "аутпут дир");
+        assert_eq!(
+            normalizer().normalize_kebab_case("output-dir"),
+            "аутпут дир"
+        );
     }
 
     #[test]
     fn kebab_config_file() {
-        assert_eq!(normalizer().normalize_kebab_case("config-file"), "конфиг файл");
+        assert_eq!(
+            normalizer().normalize_kebab_case("config-file"),
+            "конфиг файл"
+        );
     }
 
     #[test]
@@ -990,7 +1071,10 @@ mod tests {
 
     #[test]
     fn kebab_vue_router() {
-        assert_eq!(normalizer().normalize_kebab_case("vue-router"), "вью роутер");
+        assert_eq!(
+            normalizer().normalize_kebab_case("vue-router"),
+            "вью роутер"
+        );
     }
 
     // --- SCREAMING_SNAKE_CASE (MixedIdentifiers) ---
@@ -1002,7 +1086,10 @@ mod tests {
 
     #[test]
     fn screaming_default_timeout() {
-        assert_eq!(normalizer().normalize_snake_case("DEFAULT_TIMEOUT"), "дефолт таймаут");
+        assert_eq!(
+            normalizer().normalize_snake_case("DEFAULT_TIMEOUT"),
+            "дефолт таймаут"
+        );
     }
 
     #[test]

--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -223,8 +223,8 @@ impl CodeBlockHandler {
 
         // Remove mode-switch directives from the output (they are control markers,
         // not content that should be spoken).
-        let directive_pattern = Regex::new(r"<!--\s*ruvox-code:\s*(?:full|brief)\s*-->")
-            .expect("valid regex");
+        let directive_pattern =
+            Regex::new(r"<!--\s*ruvox-code:\s*(?:full|brief)\s*-->").expect("valid regex");
         tracked.sub(&directive_pattern, |_| String::new());
     }
 
@@ -266,7 +266,11 @@ impl CodeBlockHandler {
             .into_iter()
             .filter_map(|t| {
                 let n = self.normalize_token(t);
-                if n.is_empty() { None } else { Some(n) }
+                if n.is_empty() {
+                    None
+                } else {
+                    Some(n)
+                }
             })
             .collect();
         normalized.join(" ")
@@ -304,10 +308,7 @@ impl CodeBlockHandler {
             Regex::new(&pattern).expect("valid tokeniser regex")
         });
 
-        RE_TOKENS
-            .find_iter(code)
-            .map(|m| m.as_str())
-            .collect()
+        RE_TOKENS.find_iter(code).map(|m| m.as_str()).collect()
     }
 
     fn normalize_token(&self, token: &str) -> String {
@@ -590,7 +591,8 @@ mod tests {
 
     #[test]
     fn full_python_def_hello() {
-        let result = full_handler().process_block("def hello():\n    print('world')", Some("python"));
+        let result =
+            full_handler().process_block("def hello():\n    print('world')", Some("python"));
         let lower = result.to_lowercase();
         for expected in &["деф", "хелло", "принт", "ворлд"] {
             assert!(
@@ -814,8 +816,16 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        assert!(result.contains("далее следует пример кода на пайтон"), "got: {:?}", result);
-        assert!(!result.contains("```"), "backticks should be gone, got: {:?}", result);
+        assert!(
+            result.contains("далее следует пример кода на пайтон"),
+            "got: {:?}",
+            result
+        );
+        assert!(
+            !result.contains("```"),
+            "backticks should be gone, got: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -825,20 +835,31 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        assert!(result.contains("Тут мермэйд диаграмма"), "got: {:?}", result);
+        assert!(
+            result.contains("Тут мермэйд диаграмма"),
+            "got: {:?}",
+            result
+        );
     }
 
     #[test]
     fn process_mode_directive_switches_to_full() {
-        let text =
-            "<!-- ruvox-code: full -->\n```python\nprint('world')\n```";
+        let text = "<!-- ruvox-code: full -->\n```python\nprint('world')\n```";
         let mut tracked = TrackedText::new(text);
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
         // Full mode should contain "принт" and "ворлд"
-        assert!(result.contains("принт"), "expected full mode, got: {:?}", result);
-        assert!(result.contains("ворлд"), "expected full mode, got: {:?}", result);
+        assert!(
+            result.contains("принт"),
+            "expected full mode, got: {:?}",
+            result
+        );
+        assert!(
+            result.contains("ворлд"),
+            "expected full mode, got: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -852,6 +873,10 @@ mod tests {
         h.process(&mut tracked);
         let result = tracked.text();
         // Second block should be brief
-        assert!(result.contains("далее следует пример кода на пайтон"), "got: {:?}", result);
+        assert!(
+            result.contains("далее следует пример кода на пайтон"),
+            "got: {:?}",
+            result
+        );
     }
 }

--- a/src-tauri/src/pipeline/normalizers/numbers.rs
+++ b/src-tauri/src/pipeline/normalizers/numbers.rs
@@ -817,8 +817,9 @@ impl NumberNormalizer {
     /// Convert size string (e.g. "100MB", "16px") to Russian words.
     pub fn normalize_size(&self, size_str: &str) -> String {
         static RE_SIZE_PARSE: OnceLock<Regex> = OnceLock::new();
-        let re = RE_SIZE_PARSE
-            .get_or_init(|| Regex::new(r"^([\d.,]+)\s*([a-zA-Zа-яА-Я]+)$").expect("static pattern"));
+        let re = RE_SIZE_PARSE.get_or_init(|| {
+            Regex::new(r"^([\d.,]+)\s*([a-zA-Zа-яА-Я]+)$").expect("static pattern")
+        });
         let s = size_str.trim();
 
         let caps = match re.captures(s) {
@@ -829,7 +830,9 @@ impl NumberNormalizer {
         let num_str = &caps[1];
         let unit_lower = caps[2].to_lowercase();
 
-        let unit_data = SIZE_UNITS.iter().find(|(key, _)| *key == unit_lower.as_str());
+        let unit_data = SIZE_UNITS
+            .iter()
+            .find(|(key, _)| *key == unit_lower.as_str());
         let unit = match unit_data {
             Some((_, u)) => u,
             None => return size_str.to_string(),
@@ -843,8 +846,7 @@ impl NumberNormalizer {
         match num_str.parse::<i64>() {
             Ok(n) => {
                 let num_words = int_to_words_with_gender(n, unit.gender);
-                let unit_word =
-                    get_declension(n, (unit.nom_sg, unit.gen_sg, unit.gen_pl));
+                let unit_word = get_declension(n, (unit.nom_sg, unit.gen_sg, unit.gen_pl));
                 format!("{} {}", num_words, unit_word)
             }
             Err(_) => size_str.to_string(),
@@ -897,8 +899,9 @@ impl NumberNormalizer {
                         let suffix_name = caps[1].to_lowercase();
                         let suffix_num = &caps[2];
 
-                        if let Some(&(_, word)) =
-                            VERSION_SUFFIXES.iter().find(|(k, _)| *k == suffix_name.as_str())
+                        if let Some(&(_, word)) = VERSION_SUFFIXES
+                            .iter()
+                            .find(|(k, _)| *k == suffix_name.as_str())
                         {
                             result.push(word.to_string());
                             if !suffix_num.is_empty() {
@@ -1119,7 +1122,10 @@ mod tests {
 
     #[test]
     fn test_integer_1234() {
-        assert_eq!(nn().normalize_number("1234"), "одна тысяча двести тридцать четыре");
+        assert_eq!(
+            nn().normalize_number("1234"),
+            "одна тысяча двести тридцать четыре"
+        );
     }
 
     #[test]
@@ -1295,7 +1301,10 @@ mod tests {
 
     #[test]
     fn test_range_en_dash() {
-        assert_eq!(nn().normalize_range("10\u{2013}20"), "от десяти до двадцати");
+        assert_eq!(
+            nn().normalize_range("10\u{2013}20"),
+            "от десяти до двадцати"
+        );
     }
 
     #[test]
@@ -1419,7 +1428,10 @@ mod tests {
 
     #[test]
     fn test_version_1_0_0() {
-        assert_eq!(nn().normalize_version("1.0.0"), "один точка ноль точка ноль");
+        assert_eq!(
+            nn().normalize_version("1.0.0"),
+            "один точка ноль точка ноль"
+        );
     }
 
     #[test]

--- a/src-tauri/src/pipeline/normalizers/urls.rs
+++ b/src-tauri/src/pipeline/normalizers/urls.rs
@@ -45,17 +45,26 @@ const DRIVE_LETTERS: &[(&str, &str)] = &[
 
 fn lookup_tld(tld: &str) -> Option<&'static str> {
     let lower = tld.to_lowercase();
-    TLD_MAP.iter().find(|(k, _)| *k == lower.as_str()).map(|(_, v)| *v)
+    TLD_MAP
+        .iter()
+        .find(|(k, _)| *k == lower.as_str())
+        .map(|(_, v)| *v)
 }
 
 fn lookup_protocol(scheme: &str) -> Option<&'static str> {
     let lower = scheme.to_lowercase();
-    PROTOCOLS.iter().find(|(k, _)| *k == lower.as_str()).map(|(_, v)| *v)
+    PROTOCOLS
+        .iter()
+        .find(|(k, _)| *k == lower.as_str())
+        .map(|(_, v)| *v)
 }
 
 fn lookup_drive(letter: &str) -> Option<&'static str> {
     let lower = letter.to_lowercase();
-    DRIVE_LETTERS.iter().find(|(k, _)| *k == lower.as_str()).map(|(_, v)| *v)
+    DRIVE_LETTERS
+        .iter()
+        .find(|(k, _)| *k == lower.as_str())
+        .map(|(_, v)| *v)
 }
 
 /// Normalizes URLs, emails, IP addresses, and file paths to speakable Russian text.
@@ -82,7 +91,10 @@ impl<'a> URLPathNormalizer<'a> {
     /// Matches Python behavior when `english_normalizer=None` — used in tests and
     /// contexts where downstream processing will handle transliteration separately.
     pub fn new_without_english(numbers: &'a NumberNormalizer) -> Self {
-        Self { numbers, english: None }
+        Self {
+            numbers,
+            english: None,
+        }
     }
 
     fn transliterate_word(&self, word: &str) -> String {
@@ -643,42 +655,54 @@ mod tests {
     fn test_protocol_https() {
         let (_, nn) = mk_normalizer();
         let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.com").starts_with("эйч ти ти пи эс"));
+        assert!(n
+            .normalize_url("https://example.com")
+            .starts_with("эйч ти ти пи эс"));
     }
 
     #[test]
     fn test_protocol_http() {
         let (_, nn) = mk_normalizer();
         let n = norm_no_en(&nn);
-        assert!(n.normalize_url("http://example.com").starts_with("эйч ти ти пи"));
+        assert!(n
+            .normalize_url("http://example.com")
+            .starts_with("эйч ти ти пи"));
     }
 
     #[test]
     fn test_protocol_ftp() {
         let (_, nn) = mk_normalizer();
         let n = norm_no_en(&nn);
-        assert!(n.normalize_url("ftp://files.example.com").starts_with("эф ти пи"));
+        assert!(n
+            .normalize_url("ftp://files.example.com")
+            .starts_with("эф ти пи"));
     }
 
     #[test]
     fn test_protocol_ssh() {
         let (_, nn) = mk_normalizer();
         let n = norm_no_en(&nn);
-        assert!(n.normalize_url("ssh://server.example.com").starts_with("эс эс эйч"));
+        assert!(n
+            .normalize_url("ssh://server.example.com")
+            .starts_with("эс эс эйч"));
     }
 
     #[test]
     fn test_protocol_git() {
         let (_, nn) = mk_normalizer();
         let n = norm_no_en(&nn);
-        assert!(n.normalize_url("git://github.com/repo.git").starts_with("гит"));
+        assert!(n
+            .normalize_url("git://github.com/repo.git")
+            .starts_with("гит"));
     }
 
     #[test]
     fn test_protocol_file() {
         let (_, nn) = mk_normalizer();
         let n = norm_no_en(&nn);
-        assert!(n.normalize_url("file:///home/user/doc.txt").starts_with("файл"));
+        assert!(n
+            .normalize_url("file:///home/user/doc.txt")
+            .starts_with("файл"));
     }
 
     // ---- TestEmailNormalization ----
@@ -1000,12 +1024,7 @@ mod tests {
         let n = norm_no_en(&nn);
         let result = n.normalize_url("https://example.com/search?q=test");
         for part in &["example", "search", "q", "test"] {
-            assert!(
-                result.contains(part),
-                "missing '{}' in '{}'",
-                part,
-                result
-            );
+            assert!(result.contains(part), "missing '{}' in '{}'", part, result);
         }
     }
 

--- a/src-tauri/src/pipeline/tracked_text.rs
+++ b/src-tauri/src/pipeline/tracked_text.rs
@@ -184,8 +184,8 @@ impl TrackedText {
         let char_end = byte_to_char_idx(&self.current, byte_end);
 
         // Skip if any codepoint in the match is inside an existing replacement.
-        let already_replaced = (char_start..char_end)
-            .any(|pos| self.is_current_char_pos_inside_replacement(pos));
+        let already_replaced =
+            (char_start..char_end).any(|pos| self.is_current_char_pos_inside_replacement(pos));
         if already_replaced {
             return;
         }
@@ -197,7 +197,10 @@ impl TrackedText {
             orig_start
         };
 
-        if self.find_containing_replacement(orig_start, orig_end).is_some() {
+        if self
+            .find_containing_replacement(orig_start, orig_end)
+            .is_some()
+        {
             return;
         }
 
@@ -280,7 +283,10 @@ impl TrackedText {
             };
 
             // Skip if this range overlaps an existing replacement in original coords.
-            if self.find_containing_replacement(orig_start, orig_end).is_some() {
+            if self
+                .find_containing_replacement(orig_start, orig_end)
+                .is_some()
+            {
                 continue;
             }
 
@@ -319,8 +325,7 @@ impl TrackedText {
         let trans_char_len = char_len(&self.current);
 
         if self.replacements.is_empty() {
-            let char_map: Vec<(usize, usize)> =
-                (0..trans_char_len).map(|i| (i, i + 1)).collect();
+            let char_map: Vec<(usize, usize)> = (0..trans_char_len).map(|i| (i, i + 1)).collect();
             return CharMapping {
                 original: self.original,
                 transformed: self.current,
@@ -885,7 +890,11 @@ mod tests {
         assert_eq!(mir_orig_cp, 9);
 
         // In transformed: "Привет мир" → "мир" at codepoint 7
-        let mir_norm_cp = mapping.transformed.find("мир").map(|b| byte_to_char_idx(&mapping.transformed, b)).unwrap();
+        let mir_norm_cp = mapping
+            .transformed
+            .find("мир")
+            .map(|b| byte_to_char_idx(&mapping.transformed, b))
+            .unwrap();
         assert_eq!(mir_norm_cp, 7);
 
         let (orig_start, _orig_end) = mapping.get_original_range(mir_norm_cp, mir_norm_cp + 3);
@@ -921,7 +930,11 @@ mod tests {
         for i in 0..char_len(&mapping.transformed) {
             let (orig_start, orig_end) = mapping.get_original_range(i, i + 1);
             assert!(orig_start < 3 || (orig_start == 0 && orig_end <= 3));
-            assert!(orig_end <= 3, "orig_end {} should be <= 3 (len of 'API')", orig_end);
+            assert!(
+                orig_end <= 3,
+                "orig_end {} should be <= 3 (len of 'API')",
+                orig_end
+            );
         }
     }
 
@@ -961,7 +974,10 @@ mod tests {
 
         // BOM is 1 codepoint; "Привет" starts at codepoint 1 in original
         let bom_cp = 1usize;
-        let privet_norm_cp = byte_to_char_idx(&mapping.transformed, mapping.transformed.find("Привет").unwrap());
+        let privet_norm_cp = byte_to_char_idx(
+            &mapping.transformed,
+            mapping.transformed.find("Привет").unwrap(),
+        );
         assert_eq!(privet_norm_cp, 0);
 
         let (orig_start, _) = mapping.get_original_range(0, 6);

--- a/src-tauri/src/player/mod.rs
+++ b/src-tauri/src/player/mod.rs
@@ -277,8 +277,7 @@ impl<R: Runtime> Player<R> {
         self.mpv_command(json!(["seek", position_sec, "absolute"]))?;
         let (entry_id, duration_sec) = {
             let mut s = self.state.lock();
-            s.seek_suppress_until =
-                Some(Instant::now() + Duration::from_millis(300));
+            s.seek_suppress_until = Some(Instant::now() + Duration::from_millis(300));
             (s.current_entry_id.clone(), s.duration_sec)
         };
         if let Some(id) = entry_id {
@@ -355,10 +354,7 @@ impl<R: Runtime> Player<R> {
             return Err(PlayerError::Op("mpv instance destroyed".into()));
         }
         let cmd = MpvCommand {
-            command: command
-                .as_array()
-                .cloned()
-                .unwrap_or_default(),
+            command: command.as_array().cloned().unwrap_or_default(),
             request_id: None,
         };
         // tauri-plugin-mpv panics with `Option::unwrap()` in its command
@@ -366,13 +362,14 @@ impl<R: Runtime> Player<R> {
         // its own CloseRequested handler destroyed mpv).  Catch that, mark
         // mpv as dead so subsequent calls short-circuit, and surface as Err.
         let app = self.app.clone();
-        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-            app.mpv().command(cmd, WINDOW_LABEL)
-        }));
+        let result =
+            std::panic::catch_unwind(AssertUnwindSafe(|| app.mpv().command(cmd, WINDOW_LABEL)));
         match result {
             Err(_) => {
                 self.mpv_alive.store(false, Ordering::SeqCst);
-                Err(PlayerError::Op("mpv command panicked (instance gone?)".into()))
+                Err(PlayerError::Op(
+                    "mpv command panicked (instance gone?)".into(),
+                ))
             }
             Ok(Err(e)) => Err(PlayerError::Op(e.to_string())),
             Ok(Ok(_)) => Ok(()),
@@ -384,10 +381,7 @@ impl<R: Runtime> Player<R> {
             return Err(PlayerError::Op("mpv instance destroyed".into()));
         }
         let cmd = MpvCommand {
-            command: vec![
-                json!("get_property"),
-                json!(property),
-            ],
+            command: vec![json!("get_property"), json!(property)],
             request_id: Some(1),
         };
         let app = self.app.clone();
@@ -433,10 +427,7 @@ impl<R: Runtime> Drop for Player<R> {
 /// Spawns a Tokio task that emits `playback_position` every 100 ms while
 /// something is playing.  Also detects EOF (position ≥ duration) and emits
 /// `playback_finished` + `playback_stopped`.
-pub fn spawn_position_emitter<R: Runtime + 'static>(
-    player: Arc<Player<R>>,
-    app: AppHandle<R>,
-) {
+pub fn spawn_position_emitter<R: Runtime + 'static>(player: Arc<Player<R>>, app: AppHandle<R>) {
     // tauri::async_runtime::spawn works inside the setup hook where the
     // bare tokio runtime context is not yet active.
     tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -324,7 +324,11 @@ impl StorageService {
         let map = self.entries.read();
         let filename = map.get(id)?.audio_path.as_ref()?.clone();
         let full = self.audio_dir.join(filename);
-        if full.exists() { Some(full) } else { None }
+        if full.exists() {
+            Some(full)
+        } else {
+            None
+        }
     }
 
     // ── Stats ──────────────────────────────────────────────────────────────

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -18,16 +18,7 @@ pub fn init<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let sep2 = PredefinedMenuItem::separator(app)?;
     let quit = MenuItem::with_id(app, "quit", "Выход", true, None::<&str>)?;
 
-    let menu = Menu::with_items(
-        app,
-        &[
-            &show,
-            &sep1,
-            &add,
-            &sep2,
-            &quit,
-        ],
-    )?;
+    let menu = Menu::with_items(app, &[&show, &sep1, &add, &sep2, &quit])?;
 
     let _tray = TrayIconBuilder::with_id("main")
         .tooltip("RuVox")
@@ -41,7 +32,9 @@ pub fn init<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
             "show" => show_main_window(app),
             "quit" => {
                 if let Some(state) = app.try_state::<AppState>() {
-                    state.user_quit.store(true, std::sync::atomic::Ordering::SeqCst);
+                    state
+                        .user_quit
+                        .store(true, std::sync::atomic::Ordering::SeqCst);
                 }
                 app.exit(0);
             }
@@ -122,7 +115,11 @@ fn invoke_add_clipboard_entry<R: Runtime>(app: &AppHandle<R>, play_when_ready: b
         let _ = sender.try_send(TrayCmd { play_when_ready });
     } else {
         // No channel yet — emit an event for the frontend to pick up.
-        let event = if play_when_ready { "tray_read_now" } else { "tray_read_later" };
+        let event = if play_when_ready {
+            "tray_read_now"
+        } else {
+            "tray_read_later"
+        };
         let _ = app.emit(event, ());
     }
 }

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -203,7 +203,10 @@ impl TtsSubprocess {
     async fn send(&self, req: TtsRequest) -> Result<TtsResponse, TtsError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
-            .send(DriverRequest { payload: req, reply: reply_tx })
+            .send(DriverRequest {
+                payload: req,
+                reply: reply_tx,
+            })
             .await
             .map_err(|_| TtsError::Died)?;
 
@@ -215,7 +218,10 @@ impl TtsSubprocess {
         let resp = self.send(TtsRequest::Warmup).await?;
         match resp {
             TtsResponse::Ok(_) => Ok(()),
-            TtsResponse::Err(e) => Err(TtsError::Ttsd { code: e.error, message: e.message }),
+            TtsResponse::Err(e) => Err(TtsError::Ttsd {
+                code: e.error,
+                message: e.message,
+            }),
         }
     }
 
@@ -232,7 +238,13 @@ impl TtsSubprocess {
     ) -> Result<SynthesizeOutput, TtsError> {
         const SYNTHESIZE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
-        let req = TtsRequest::Synthesize { text, speaker, sample_rate, out_wav, char_mapping };
+        let req = TtsRequest::Synthesize {
+            text,
+            speaker,
+            sample_rate,
+            out_wav,
+            char_mapping,
+        };
         let resp = timeout(SYNTHESIZE_TIMEOUT, self.send(req))
             .await
             .map_err(|_| TtsError::Timeout)??;
@@ -243,7 +255,10 @@ impl TtsSubprocess {
                     serde_json::from_value(ok.extra).map_err(TtsError::Json)?;
                 Ok(output)
             }
-            TtsResponse::Err(e) => Err(TtsError::Ttsd { code: e.error, message: e.message }),
+            TtsResponse::Err(e) => Err(TtsError::Ttsd {
+                code: e.error,
+                message: e.message,
+            }),
         }
     }
 
@@ -259,7 +274,10 @@ impl TtsSubprocess {
             .map_err(|_| TtsError::Timeout)??;
         match resp {
             TtsResponse::Ok(_) => Ok(()),
-            TtsResponse::Err(e) => Err(TtsError::Ttsd { code: e.error, message: e.message }),
+            TtsResponse::Err(e) => Err(TtsError::Ttsd {
+                code: e.error,
+                message: e.message,
+            }),
         }
     }
 }
@@ -325,7 +343,10 @@ async fn handle_one_request(
     let mut line = serde_json::to_string(&req).map_err(TtsError::Json)?;
     line.push('\n');
 
-    stdin.write_all(line.as_bytes()).await.map_err(TtsError::Ipc)?;
+    stdin
+        .write_all(line.as_bytes())
+        .await
+        .map_err(TtsError::Ipc)?;
     stdin.flush().await.map_err(TtsError::Ipc)?;
 
     // Read the response line. None means the subprocess closed stdout (i.e. died).
@@ -405,7 +426,9 @@ mod tests {
         let v: Value = serde_json::from_str(&json).unwrap();
 
         assert_eq!(v["cmd"], "synthesize");
-        let cm = v["char_mapping"].as_array().expect("char_mapping should be present");
+        let cm = v["char_mapping"]
+            .as_array()
+            .expect("char_mapping should be present");
         assert_eq!(cm.len(), 1);
         assert_eq!(cm[0]["norm_start"], 0);
         assert_eq!(cm[0]["norm_end"], 6);

--- a/src-tauri/tests/golden.rs
+++ b/src-tauri/tests/golden.rs
@@ -89,11 +89,7 @@ fn text_diff(expected: &str, actual: &str) -> String {
 }
 
 /// Show the first `limit` mismatched char_map entries with context.
-fn char_map_diff(
-    expected: &[[usize; 2]],
-    actual: &[(usize, usize)],
-    limit: usize,
-) -> String {
+fn char_map_diff(expected: &[[usize; 2]], actual: &[(usize, usize)], limit: usize) -> String {
     let mut output = String::new();
     let max_len = expected.len().max(actual.len());
     let mut shown = 0;


### PR DESCRIPTION
## Summary

- Mechanical `cargo fmt` over `src-tauri/`.
- 14 files touched, +561 / -261 — purely whitespace and line wrapping.
- `cargo test` and `cargo clippy --no-deps -- -D warnings` are green locally.

## Why

Preparing the tree for a follow-up PR that adds `cargo fmt --check` to CI.

## Test plan

- [ ] CI green (Rust + TS + ttsd jobs).