### PR TITLE
ci(rust): enforce cargo fmt --check on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,11 @@ jobs:
             libmpv-dev pkg-config build-essential
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+      - run: cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings
       - run: cargo test --manifest-path src-tauri/Cargo.toml
 


### PR DESCRIPTION
## Summary

- Add `rustfmt` to the rust-toolchain components.
- Run `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` before clippy.

## Why

Now that the tree is formatted (#12), keep it that way: any drift from `cargo fmt`
fails CI on the offending PR, before clippy/test.

## Test plan

- [ ] CI green on this PR (Rust job runs fmt → clippy → test in that order).