### PR TITLE
chore(rust): translate panic messages in lib.rs to English

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,7 +93,7 @@ pub fn run() {
             let player = Arc::new(Player::new(app.handle().clone())?);
             player::spawn_position_emitter(player.clone(), app.handle().clone());
 
-            let storage = Arc::new(StorageService::new().expect("не удалось открыть хранилище"));
+            let storage = Arc::new(StorageService::new().expect("failed to open storage"));
 
             // Spawn ttsd subprocess.
             // In production: bundled next to the binary (resource_dir/ttsd).
@@ -119,7 +119,7 @@ pub fn run() {
             // explicitly via block_on (the inner spawn returns instantly).
             let tts = Arc::new(
                 tauri::async_runtime::block_on(async move { tts::TtsSubprocess::spawn(ttsd_dir) })
-                    .expect("не удалось запустить ttsd subprocess"),
+                    .expect("failed to spawn ttsd subprocess"),
             );
 
             // Warm up Silero model in background; emit model_loading → model_loaded/model_error.


### PR DESCRIPTION
## Summary

Two `expect(...)` panic messages in `src-tauri/src/lib.rs` were in Russian. They are developer-facing error texts (visible only on stderr / panic backtrace), not UI, so per AGENTS.md "Documentation language" they belong in English.

Replaces:
- "не удалось открыть хранилище" -> "failed to open storage"
- "не удалось запустить ttsd subprocess" -> "failed to spawn ttsd subprocess"

## What stays Russian

- UI strings (tray menu labels `Открыть окно` / `Добавить` / `Выход`, Settings/PreviewDialog labels, notification text).
- TTS test data (Cyrillic samples, normalizer dictionaries, golden fixtures).
- Comments quoting UI labels or pipeline output (e.g. `// "1." -> "первое: "`).

## Why

Final piece of tasks.md task #9 (repo-wide language unification). After this, `rg '[А-Яа-яЁё]'` over `src-tauri/src/`, `src/`, `ttsd/` returns only legitimate UI / test / illustration strings.

## Test plan

- [ ] CI green (Rust job runs fmt → clippy → test).