### PR TITLE
feat(audio): store synthesized audio as Ogg-Opus instead of raw WAV

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,11 @@
             librsvg
             openssl
             mpv-unwrapped
+            # libopus: storage::audio encodes WAV → Ogg-Opus via the
+            # `opus = "0.3"` FFI crate, which links against C libopus 1.x.
+            # buildInputs is enough — wrapGAppsHook3 picks it up for the
+            # runtime LD_LIBRARY_PATH automatically.
+            libopus
           ];
 
           # Single target is enough for Nix — we only want a usable binary,

--- a/shell.nix
+++ b/shell.nix
@@ -57,6 +57,11 @@ pkgs.mkShell {
     # mpv-unwrapped provides both the library and pkg-config .pc file
     mpv-unwrapped
 
+    # ── libopus (Opus encoder for storage::audio) ─────────────────────────
+    # The `opus = "0.3"` Rust crate is an FFI binding to libopus 1.x; needs
+    # the C library at link time and at runtime.
+    libopus
+
     # ── Wayland + X11 support ──────────────────────────────────────────────
     wayland
     wayland-protocols
@@ -98,6 +103,7 @@ pkgs.mkShell {
     pkgs.libxkbcommon
     pkgs.alsa-lib
     pkgs.libpulseaudio
+    pkgs.libopus
   ];
 
   # Runtime library path (for Python + Tauri + mpv)
@@ -128,6 +134,7 @@ pkgs.mkShell {
     pkgs.libdrm
     pkgs.libayatana-appindicator
     pkgs.librsvg
+    pkgs.libopus
   ];
 
   # Help Rust openssl-sys crate find OpenSSL

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -242,6 +242,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1617,6 +1637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "html5ever"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,6 +2550,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ogg"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2581,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -3306,10 +3350,14 @@ version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "arboard",
+ "byteorder",
  "chrono",
  "dirs",
+ "hound",
  "libc",
+ "ogg",
  "once_cell",
+ "opus",
  "parking_lot",
  "regex",
  "scraper",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,15 @@ tracing = "0.1"
 arboard = "3"
 libc = "0.2"
 
+# Opus encoding pipeline (WAV → Ogg-Opus). `opus` is the FFI binding to the
+# C reference libopus 1.x (system dep — see shell.nix / flake.nix). A
+# pure-Rust port (`opus-rs`) was evaluated and is currently ~2× slower on
+# our 32 kbps VOIP profile; tracked in issue #19.
+opus = "0.3"
+ogg = "0.9"
+hound = "3.5"
+byteorder = "1.5"
+
 [dev-dependencies]
 tempfile = "3"
 similar = "2"

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,0 +1,247 @@
+//! WAV → Ogg-Opus streaming encoder.
+//!
+//! Inputs are 48 kHz mono 32-bit float WAV files (the format ttsd writes via
+//! Silero). Output is a valid Ogg-Opus stream at 32 kbps VOIP, 20 ms frames.
+//! The implementation is streaming — samples are read from the WAV in 960-
+//! sample chunks and fed straight to the encoder, so memory use stays
+//! constant regardless of audio length.
+//!
+//! See `tmp/opus_compare/` for the prototype this was ported from and the
+//! benchmarks that motivated the choice of `opus = "0.3"` (FFI to C libopus)
+//! over the pure-Rust `opus-rs` (issue #19).
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+use ogg::{PacketWriteEndInfo, PacketWriter};
+use opus::{Application, Bitrate, Channels, Encoder};
+use thiserror::Error;
+
+const SAMPLE_RATE: u32 = 48_000;
+const FRAME_MS: u32 = 20;
+const FRAME_SAMPLES: usize = (SAMPLE_RATE as usize) * (FRAME_MS as usize) / 1000; // 960
+const BITRATE_BPS: i32 = 32_000;
+// libopus default warm-up at 48 kHz; required by RFC 7845 §4.2 so decoders
+// know how many leading samples to discard.
+const PRE_SKIP: u16 = 312;
+// Ogg logical-stream serial — arbitrary 32-bit value, "RuVO" in ASCII.
+const SERIAL: u32 = 0x5275_564f;
+// Encoded packet upper bound: 4000 bytes is the max permitted by libopus
+// (`opus_encode` returns at most this for a single 20 ms frame at any bitrate).
+const MAX_PACKET_BYTES: usize = 4000;
+
+#[derive(Debug, Error)]
+pub enum AudioError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("wav error: {0}")]
+    Wav(#[from] hound::Error),
+    #[error("opus error: {0}")]
+    Opus(#[from] opus::Error),
+    #[error("unsupported wav format: {0}")]
+    UnsupportedFormat(String),
+}
+
+pub type Result<T> = std::result::Result<T, AudioError>;
+
+/// Encode a 48 kHz mono float WAV at `wav_path` to an Ogg-Opus file at
+/// `opus_path`. Streaming — memory use is bounded regardless of audio length.
+pub fn encode_wav_to_opus(wav_path: &Path, opus_path: &Path) -> Result<()> {
+    let mut reader = hound::WavReader::open(wav_path)?;
+    let spec = reader.spec();
+
+    if spec.sample_rate != SAMPLE_RATE {
+        return Err(AudioError::UnsupportedFormat(format!(
+            "expected sample rate {SAMPLE_RATE}, got {}",
+            spec.sample_rate
+        )));
+    }
+    if spec.channels != 1 {
+        return Err(AudioError::UnsupportedFormat(format!(
+            "expected mono (1 channel), got {} channels",
+            spec.channels
+        )));
+    }
+    if spec.sample_format != hound::SampleFormat::Float || spec.bits_per_sample != 32 {
+        return Err(AudioError::UnsupportedFormat(format!(
+            "expected 32-bit float PCM, got {:?} {}-bit",
+            spec.sample_format, spec.bits_per_sample
+        )));
+    }
+
+    let total_samples = reader.duration() as usize;
+    let total_frames = total_samples.div_ceil(FRAME_SAMPLES);
+
+    let mut encoder = Encoder::new(SAMPLE_RATE, Channels::Mono, Application::Voip)?;
+    encoder.set_bitrate(Bitrate::Bits(BITRATE_BPS))?;
+
+    let file = BufWriter::new(File::create(opus_path)?);
+    let mut writer = PacketWriter::new(file);
+
+    writer.write_packet(build_opus_head(), SERIAL, PacketWriteEndInfo::EndPage, 0)?;
+    writer.write_packet(build_opus_tags(), SERIAL, PacketWriteEndInfo::EndPage, 0)?;
+
+    let mut encoded = vec![0u8; MAX_PACKET_BYTES];
+    let mut frame_buf = vec![0f32; FRAME_SAMPLES];
+    let mut absgp: u64 = 0;
+    let mut frame_idx: usize = 0;
+    let mut samples = reader.samples::<f32>();
+
+    loop {
+        let mut n_read = 0usize;
+        for slot in frame_buf.iter_mut() {
+            match samples.next() {
+                Some(Ok(s)) => {
+                    *slot = s;
+                    n_read += 1;
+                }
+                Some(Err(e)) => return Err(AudioError::Wav(e)),
+                None => break,
+            }
+        }
+        if n_read == 0 {
+            break;
+        }
+        for slot in &mut frame_buf[n_read..] {
+            *slot = 0.0;
+        }
+
+        let n = encoder.encode_float(&frame_buf, &mut encoded)?;
+        absgp += FRAME_SAMPLES as u64;
+        frame_idx += 1;
+
+        let end = if frame_idx == total_frames {
+            PacketWriteEndInfo::EndStream
+        } else {
+            PacketWriteEndInfo::NormalPacket
+        };
+        writer.write_packet(encoded[..n].to_vec(), SERIAL, end, absgp)?;
+    }
+
+    let mut file = writer.into_inner();
+    file.flush()?;
+    Ok(())
+}
+
+/// Convenience wrapper: encode `wav_path` to `<wav_path with .opus extension>`,
+/// then delete the source `.wav`. Returns the Opus file path.
+///
+/// On encode failure the source `.wav` is left untouched so the caller can
+/// fall back to it.
+pub fn replace_wav_with_opus(wav_path: &Path) -> Result<std::path::PathBuf> {
+    let opus_path = wav_path.with_extension("opus");
+    encode_wav_to_opus(wav_path, &opus_path)?;
+    fs::remove_file(wav_path)?;
+    Ok(opus_path)
+}
+
+fn build_opus_head() -> Vec<u8> {
+    let mut buf = Vec::with_capacity(19);
+    buf.extend_from_slice(b"OpusHead");
+    buf.push(1); // version
+    buf.push(1); // channel count (mono)
+    buf.write_u16::<LittleEndian>(PRE_SKIP).unwrap();
+    buf.write_u32::<LittleEndian>(SAMPLE_RATE).unwrap(); // input sample rate
+    buf.write_i16::<LittleEndian>(0).unwrap(); // output gain Q7.8
+    buf.push(0); // mapping family 0 (mono / stereo)
+    buf
+}
+
+fn build_opus_tags() -> Vec<u8> {
+    let vendor = b"RuVox";
+    let mut buf = Vec::with_capacity(8 + 4 + vendor.len() + 4);
+    buf.extend_from_slice(b"OpusTags");
+    buf.write_u32::<LittleEndian>(vendor.len() as u32).unwrap();
+    buf.extend_from_slice(vendor);
+    buf.write_u32::<LittleEndian>(0).unwrap(); // user comment list length
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write a 1 s 48 kHz mono float WAV containing a 440 Hz sine, encode it,
+    /// and assert the result is a non-empty Ogg stream.
+    #[test]
+    fn encode_short_wav_produces_valid_opus() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wav_path = dir.path().join("in.wav");
+        let opus_path = dir.path().join("out.opus");
+
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: SAMPLE_RATE,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(&wav_path, spec).expect("create wav");
+        let total = SAMPLE_RATE as usize; // 1 second
+        for i in 0..total {
+            let t = i as f32 / SAMPLE_RATE as f32;
+            let s = (2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.25;
+            writer.write_sample(s).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+
+        encode_wav_to_opus(&wav_path, &opus_path).expect("encode");
+
+        let bytes = std::fs::read(&opus_path).expect("read opus");
+        assert!(bytes.len() > 1000, "opus too small: {}", bytes.len());
+        assert_eq!(&bytes[..4], b"OggS", "not an Ogg stream");
+    }
+
+    #[test]
+    fn rejects_wrong_sample_rate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wav_path = dir.path().join("in.wav");
+        let opus_path = dir.path().join("out.opus");
+
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 22_050,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(&wav_path, spec).expect("create wav");
+        for _ in 0..1000 {
+            writer.write_sample(0.0f32).expect("write sample");
+        }
+        writer.finalize().expect("finalize");
+
+        let err =
+            encode_wav_to_opus(&wav_path, &opus_path).expect_err("should reject 22.05 kHz wav");
+        match err {
+            AudioError::UnsupportedFormat(_) => {}
+            other => panic!("expected UnsupportedFormat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replace_wav_with_opus_removes_source() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wav_path = dir.path().join("clip.wav");
+
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: SAMPLE_RATE,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(&wav_path, spec).expect("create wav");
+        for i in 0..SAMPLE_RATE as usize {
+            let t = i as f32 / SAMPLE_RATE as f32;
+            writer
+                .write_sample((2.0 * std::f32::consts::PI * 220.0 * t).sin() * 0.2)
+                .expect("write");
+        }
+        writer.finalize().expect("finalize");
+
+        let opus_path = replace_wav_with_opus(&wav_path).expect("replace");
+        assert!(opus_path.exists(), "opus file missing");
+        assert!(!wav_path.exists(), "source wav should be gone");
+        assert_eq!(opus_path.extension().and_then(|e| e.to_str()), Some("opus"));
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -178,14 +178,11 @@ fn spawn_synthesis<R: Runtime + 'static>(
         }
         emit_entry_updated(&app, &processing_entry);
 
-        // Phase 3: determine output WAV path.
+        // Phase 3: determine output WAV path. ttsd writes WAV; we transcode
+        // to Opus right after (see Phase 5b).
         let wav_filename = format!("{entry_id}.wav");
-        let out_wav = storage
-            .cache_dir()
-            .join("audio")
-            .join(&wav_filename)
-            .to_string_lossy()
-            .into_owned();
+        let out_wav_path = storage.cache_dir().join("audio").join(&wav_filename);
+        let out_wav = out_wav_path.to_string_lossy().into_owned();
 
         // Load config for speaker / sample_rate.
         let config = storage.load_config().unwrap_or_default();
@@ -230,13 +227,36 @@ fn spawn_synthesis<R: Runtime + 'static>(
                     }
                 };
 
+                // Phase 5b: transcode WAV → Opus, then drop the WAV. CPU-
+                // bound, off the async runtime. On failure we log and fall
+                // back to keeping the WAV so playback still works.
+                let wav_path_for_encode = out_wav_path.clone();
+                let encode_result = tokio::task::spawn_blocking(move || {
+                    crate::audio::replace_wav_with_opus(&wav_path_for_encode)
+                })
+                .await;
+                let audio_filename = match encode_result {
+                    Ok(Ok(opus_path)) => opus_path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| wav_filename.clone()),
+                    Ok(Err(e)) => {
+                        warn!("opus encode failed for {entry_id}, keeping wav: {e}");
+                        wav_filename.clone()
+                    }
+                    Err(e) => {
+                        warn!("opus encode task panicked for {entry_id}, keeping wav: {e}");
+                        wav_filename.clone()
+                    }
+                };
+
                 // Phase 6: update entry → ready.
                 let mut ready_entry = match storage.get_entry(&entry_id) {
                     Some(e) => e,
                     None => return,
                 };
                 ready_entry.status = EntryStatus::Ready;
-                ready_entry.audio_path = Some(wav_filename.clone());
+                ready_entry.audio_path = Some(audio_filename.clone());
                 ready_entry.timestamps_path = if ts_filename.is_empty() {
                     None
                 } else {
@@ -254,7 +274,7 @@ fn spawn_synthesis<R: Runtime + 'static>(
 
                 // Phase 7: auto-play if requested.
                 if play_when_ready {
-                    let path = storage.cache_dir().join("audio").join(&wav_filename);
+                    let path = storage.cache_dir().join("audio").join(&audio_filename);
                     if let Err(e) = player.load(&path, entry_id.to_string()) {
                         warn!("auto-play load failed: {e}");
                     } else if let Err(e) = player.play() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod audio;
 pub mod commands;
 pub mod pipeline;
 pub mod player;
@@ -94,6 +95,34 @@ pub fn run() {
             player::spawn_position_emitter(player.clone(), app.handle().clone());
 
             let storage = Arc::new(StorageService::new().expect("failed to open storage"));
+
+            // One-shot migration: any pre-Opus `.wav` audio in history gets
+            // transcoded to `.opus` in the background. Runs blocking on a
+            // dedicated thread so app startup is not delayed; per-entry
+            // errors are logged inside the migration routine.
+            {
+                let storage_for_migration = Arc::clone(&storage);
+                tauri::async_runtime::spawn(async move {
+                    let stats = tokio::task::spawn_blocking(move || {
+                        storage_for_migration.migrate_wav_audio_to_opus()
+                    })
+                    .await;
+                    match stats {
+                        Ok(s) if s.considered == 0 => {
+                            tracing::debug!("audio migration: nothing to do");
+                        }
+                        Ok(s) => {
+                            tracing::info!(
+                                "audio migration: considered={}, migrated={}, skipped_missing={}, failed={}",
+                                s.considered, s.migrated, s.skipped_missing, s.failed
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!("audio migration task panicked: {e}");
+                        }
+                    }
+                });
+            }
 
             // Spawn ttsd subprocess.
             // In production: bundled next to the binary (resource_dir/ttsd).

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -28,6 +28,19 @@ pub enum StorageError {
 
 pub type Result<T> = std::result::Result<T, StorageError>;
 
+/// Outcome of a [`StorageService::migrate_wav_audio_to_opus`] sweep.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AudioMigrationStats {
+    /// Entries whose `audio_path` still pointed at a `.wav`.
+    pub considered: usize,
+    /// Successfully transcoded → entry updated → source `.wav` removed.
+    pub migrated: usize,
+    /// Entry pointed at a `.wav` that was no longer on disk.
+    pub skipped_missing: usize,
+    /// Encode or persist step failed; the source `.wav` is left in place.
+    pub failed: usize,
+}
+
 pub struct StorageService {
     cache_dir: PathBuf,
     audio_dir: PathBuf,
@@ -274,11 +287,92 @@ impl StorageService {
         entries
     }
 
+    // ── Migration: legacy `.wav` → Ogg-Opus ────────────────────────────────
+
+    /// Walk every entry whose `audio_path` still points at a `.wav` file and
+    /// transcode it to Ogg-Opus in place: encode → update entry → delete the
+    /// source `.wav`. Idempotent — already-`.opus` and missing files are
+    /// skipped silently. Per-entry failures are logged but do not abort the
+    /// walk; the returned [`AudioMigrationStats`] tells the caller how many
+    /// items fell into each bucket.
+    ///
+    /// Blocking: encoding is CPU-bound — call this from a blocking context
+    /// (e.g. `tokio::task::spawn_blocking`).
+    pub fn migrate_wav_audio_to_opus(&self) -> AudioMigrationStats {
+        let mut stats = AudioMigrationStats::default();
+
+        let candidates: Vec<TextEntry> = self
+            .entries
+            .read()
+            .values()
+            .filter(|e| e.audio_path.as_deref().is_some_and(|p| p.ends_with(".wav")))
+            .cloned()
+            .collect();
+
+        for entry in candidates {
+            stats.considered += 1;
+            let Some(wav_filename) = entry.audio_path.as_deref() else {
+                continue;
+            };
+            let wav_path = self.audio_dir.join(wav_filename);
+            if !wav_path.exists() {
+                tracing::warn!(
+                    "migration: entry {} has audio_path={wav_filename} but file is missing — skipping",
+                    entry.id
+                );
+                stats.skipped_missing += 1;
+                continue;
+            }
+
+            let opus_path = match crate::audio::replace_wav_with_opus(&wav_path) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::error!(
+                        "migration: failed to encode {wav_filename} for entry {}: {e}",
+                        entry.id
+                    );
+                    stats.failed += 1;
+                    continue;
+                }
+            };
+
+            let opus_filename = match opus_path.file_name().and_then(|n| n.to_str()) {
+                Some(name) => name.to_string(),
+                None => {
+                    tracing::error!(
+                        "migration: produced opus path {:?} has no usable filename",
+                        opus_path
+                    );
+                    stats.failed += 1;
+                    continue;
+                }
+            };
+
+            let mut updated = entry.clone();
+            updated.audio_path = Some(opus_filename.clone());
+            if let Err(e) = self.update_entry(updated) {
+                tracing::error!(
+                    "migration: failed to persist updated audio_path for {}: {e}",
+                    entry.id
+                );
+                stats.failed += 1;
+                continue;
+            }
+
+            stats.migrated += 1;
+            tracing::info!("migration: {} → {}", wav_filename, opus_filename);
+        }
+
+        stats
+    }
+
     // ── Audio / Timestamps ─────────────────────────────────────────────────
 
-    /// Write raw WAV bytes. Returns the relative filename (for `TextEntry.audio_path`).
+    /// Write raw audio bytes. Returns the relative filename (for `TextEntry.audio_path`).
+    /// On-disk format is Ogg-Opus (transcoded by `crate::audio` before this is called
+    /// in production paths); the extension is fixed to `.opus`.
     pub fn save_audio(&self, id: &EntryId, audio_bytes: &[u8]) -> Result<String> {
-        let filename = format!("{id}.wav");
+        let filename = format!("{id}.opus");
         let path = self.audio_dir.join(&filename);
         fs::write(path, audio_bytes)?;
         Ok(filename)
@@ -346,13 +440,14 @@ impl StorageService {
         Ok(total)
     }
 
-    /// Number of `.wav` files in the audio directory.
+    /// Number of audio files (`.wav` legacy + `.opus`) in the audio directory.
     pub fn get_audio_count(&self) -> Result<u32> {
         let mut count: u32 = 0;
         for entry in fs::read_dir(&self.audio_dir)? {
             let entry = entry?;
-            if entry.path().extension().and_then(|e| e.to_str()) == Some("wav") {
-                count += 1;
+            match entry.path().extension().and_then(|e| e.to_str()) {
+                Some("opus") | Some("wav") => count += 1,
+                _ => {}
             }
         }
         Ok(count)
@@ -491,8 +586,8 @@ mod tests {
         let entry = svc.add_entry("audio test".to_string()).unwrap();
         let id = entry.id;
 
-        let filename = svc.save_audio(&id, b"RIFF fake").unwrap();
-        assert_eq!(filename, format!("{id}.wav"));
+        let filename = svc.save_audio(&id, b"OggS fake").unwrap();
+        assert_eq!(filename, format!("{id}.opus"));
 
         let mut updated = entry.clone();
         updated.audio_path = Some(filename);
@@ -698,5 +793,66 @@ mod tests {
         let size = svc.get_cache_size().unwrap();
         // history.json and timestamps may also be in the audio dir — we only need size > 0.
         assert!(size > 0);
+    }
+
+    /// Create an entry with a real (1 s, 48 kHz mono float) `.wav` on disk,
+    /// run the migration, assert the entry now points at `.opus` and the
+    /// source `.wav` is gone.
+    #[test]
+    fn migrate_wav_audio_to_opus_replaces_wav_in_history() {
+        let (svc, _dir) = make_service();
+        let entry = svc.add_entry("legacy wav".to_string()).unwrap();
+        let id = entry.id;
+
+        // Write a valid 1-second WAV directly to the audio dir under the
+        // legacy `.wav` filename so the migration finds something to encode.
+        let wav_filename = format!("{id}.wav");
+        let wav_path = svc.cache_dir().join("audio").join(&wav_filename);
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 48_000,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(&wav_path, spec).unwrap();
+        for i in 0..48_000usize {
+            let t = i as f32 / 48_000.0;
+            writer
+                .write_sample((2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.2)
+                .unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let mut updated = entry.clone();
+        updated.audio_path = Some(wav_filename.clone());
+        updated.status = EntryStatus::Ready;
+        svc.update_entry(updated).unwrap();
+
+        let stats = svc.migrate_wav_audio_to_opus();
+        assert_eq!(stats.considered, 1);
+        assert_eq!(stats.migrated, 1);
+        assert_eq!(stats.failed, 0);
+
+        let after = svc.get_entry(&id).unwrap();
+        let new_filename = after.audio_path.expect("audio_path must remain set");
+        assert!(new_filename.ends_with(".opus"), "got {new_filename}");
+        assert!(svc.cache_dir().join("audio").join(&new_filename).exists());
+        assert!(!wav_path.exists(), "source .wav should be removed");
+    }
+
+    /// Re-running the migration after everything is already `.opus` must be
+    /// a no-op (no entries considered, no files touched).
+    #[test]
+    fn migrate_wav_audio_to_opus_is_idempotent() {
+        let (svc, _dir) = make_service();
+        let entry = svc.add_entry("already opus".to_string()).unwrap();
+        let id = entry.id;
+        let mut updated = entry.clone();
+        updated.audio_path = Some(format!("{id}.opus"));
+        svc.update_entry(updated).unwrap();
+
+        let stats = svc.migrate_wav_audio_to_opus();
+        assert_eq!(stats.considered, 0);
+        assert_eq!(stats.migrated, 0);
     }
 }


### PR DESCRIPTION
## Summary

- Replace raw 32-bit float `.wav` storage with Ogg-Opus (32 kbps VOIP, 20 ms frames) for synthesized audio. ~40x smaller cache; quality verified beforehand.
- New module `src-tauri/src/audio/` exposes a streaming `encode_wav_to_opus` (constant memory regardless of audio length) and a `replace_wav_with_opus` convenience wrapper.
- Synthesis flow (`commands::spawn_synthesis`) now transcodes after every ttsd run and stores `.opus` in history.json.
- Startup migration sweep transcodes any pre-existing `.wav` referenced in history.json; idempotent and per-entry error-tolerant.
- `libopus` added to `shell.nix` and `flake.nix` (system dep for the `opus` FFI crate).

## Why

`.wav` storage was wasteful — 22 minutes of float PCM = ~250 MB; the same content in 32 kbps Opus is ~5 MB. On a real 35-entry history this PR reduces the on-disk audio cache from ~1.5 GB to ~40 MB (~38x smaller). Speech quality at 32 kbps VOIP is indistinguishable for our use case (verified on the 22:49 sample).

We chose `opus = "0.3"` (FFI to C libopus 1.x) over the pure-Rust `opus-rs` because the latter was ~2x slower on our 32 kbps VOIP / 48 kHz / 20 ms profile. That gap is tracked in #19; if it closes, swapping is a ~5-line change in `audio/mod.rs`.

## What changed

- **`src-tauri/Cargo.toml`** — add `opus`, `ogg`, `hound`, `byteorder`.
- **`src-tauri/src/audio/mod.rs`** (new) — streaming encoder, `AudioError`, three unit tests (encode roundtrip, format rejection, replace-and-delete).
- **`src-tauri/src/lib.rs`** — register `audio` module; spawn migration task in `setup`.
- **`src-tauri/src/commands/mod.rs`** — Phase 5b: transcode WAV → Opus after ttsd, with fallback to WAV on encode error.
- **`src-tauri/src/storage/service.rs`** — `save_audio` writes `.opus`; `get_audio_count` accepts both extensions; `migrate_wav_audio_to_opus` walks history and transcodes each entry; `AudioMigrationStats` reports outcome buckets. Two new tests (idempotency + real-WAV roundtrip).
- **`shell.nix`** / **`flake.nix`** — add `libopus` to buildInputs (and to `PKG_CONFIG_PATH` / `LD_LIBRARY_PATH` in shell.nix).
- **`schema.rs:246`** — left untouched intentionally: that test asserts legacy on-disk `.wav` history still parses, which must keep working forever.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 678 unit + 1 golden, all green.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings` — clean.
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — clean.
- [x] Smoke (`pnpm tauri dev`): all 35 pre-existing `.wav` in `~/.cache/ruvox/audio/` migrated to `.opus`, history.json updated (0 wav refs / 35 opus refs), mpv plays the migrated files. Audio dir size dropped from pre-migration GBs to **39.77 MB**.

## Closes / refs

- Refs #19 (opus-rs profiling).