### PR TITLE
feat(audio): accept 8/12/16/24/48 kHz mono float WAV (was 48 kHz only)

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -137,18 +137,16 @@ An Ogg-Opus file:
 | Container | Ogg |
 | Codec | Opus (RFC 6716, RFC 7845) |
 | Channels | 1 (mono) |
-| Sample rate | 48 000 Hz |
+| Sample rate | One of 8 / 12 / 16 / 24 / 48 kHz — matches `UIConfig.sample_rate` (default 48 kHz) |
 | Bitrate | 32 000 bps (VBR, VOIP application) |
-| Frame size | 20 ms (960 samples) |
-| Pre-skip | 312 samples |
+| Frame size | 20 ms |
+| Pre-skip | Queried from `libopus`'s `lookahead`, scaled to 48 kHz output ticks |
 
 The filename is the entry's UUID, e.g. `550e8400-e29b-41d4-a716-446655440000.opus`.
 
 `audio_path` in `TextEntry` stores the **filename only** (not the full path). The full path is resolved as `~/.cache/ruvox/audio/{audio_path}`.
 
-Encoding pipeline: `ttsd` writes a 48 kHz mono float WAV to disk; the Rust side immediately transcodes it to Opus via `crate::audio::replace_wav_with_opus` and removes the source WAV. The encoder uses the `opus = "0.3"` crate (FFI to system `libopus` 1.x, see [shell.nix](../shell.nix) / [flake.nix](../flake.nix)). On encode failure the source `.wav` is left in place as a fallback so playback keeps working.
-
-> The encoder currently requires a 48 kHz mono float input. If `UIConfig.sample_rate` is set to anything other than 48000, ttsd will produce a non-48k WAV which the encoder rejects — the entry then falls back to keeping `.wav` on disk. The default is 48 000 and that is the only setting that exercises the Opus pipeline.
+Encoding pipeline: `ttsd` writes a mono 32-bit-float WAV at `UIConfig.sample_rate`; the Rust side immediately transcodes it to Opus via `crate::audio::replace_wav_with_opus` and removes the source WAV. The encoder uses the `opus = "0.3"` crate (FFI to system `libopus` 1.x, see [shell.nix](../shell.nix) / [flake.nix](../flake.nix)). The Opus container records the input sample rate verbatim; decoders (mpv, libopusfile, browsers) handle any-to-48 kHz output internally. On encode failure the source `.wav` is left in place as a fallback so playback keeps working.
 
 ### Migration: WAV → Opus
 
@@ -214,8 +212,9 @@ Stores the application configuration. Written by the Rust storage service.
 interface UIConfig {
   version?: number;             // Config schema version (read but not required)
   speaker: string;              // Silero speaker name: "xenia" | "aidar" | "baya" | "kseniya" | "eugene"
-  sample_rate: number;          // Silero output rate: 8000 | 24000 | 48000. Only 48000 currently
-                                // round-trips through the Opus encoder; other values fall back to .wav.
+  sample_rate: number;          // Silero output rate: 8000 | 24000 | 48000. The Opus encoder
+                                // accepts the same set natively (plus 12/16 kHz) so any of these
+                                // round-trips through the pipeline without resampling.
   speech_rate: number;          // Playback speed multiplier: 0.5–2.0
   notify_on_ready: boolean;     // Show notification when synthesis completes
   notify_on_error: boolean;     // Show notification on synthesis error

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -19,18 +19,28 @@ use ogg::{PacketWriteEndInfo, PacketWriter};
 use opus::{Application, Bitrate, Channels, Encoder};
 use thiserror::Error;
 
-const SAMPLE_RATE: u32 = 48_000;
 const FRAME_MS: u32 = 20;
-const FRAME_SAMPLES: usize = (SAMPLE_RATE as usize) * (FRAME_MS as usize) / 1000; // 960
 const BITRATE_BPS: i32 = 32_000;
-// libopus default warm-up at 48 kHz; required by RFC 7845 §4.2 so decoders
-// know how many leading samples to discard.
-const PRE_SKIP: u16 = 312;
 // Ogg logical-stream serial — arbitrary 32-bit value, "RuVO" in ASCII.
 const SERIAL: u32 = 0x5275_564f;
 // Encoded packet upper bound: 4000 bytes is the max permitted by libopus
 // (`opus_encode` returns at most this for a single 20 ms frame at any bitrate).
 const MAX_PACKET_BYTES: usize = 4000;
+// Sample rates Opus accepts natively (RFC 6716 §2). The encoder is wired up
+// for whichever of these the input WAV uses.
+const SUPPORTED_SAMPLE_RATES: [u32; 5] = [8_000, 12_000, 16_000, 24_000, 48_000];
+// Granule position (RFC 7845 §4.1) is always reported in 48 kHz output ticks
+// regardless of the input rate, so one 20 ms frame advances the granule by
+// exactly 960 ticks.
+const GRANULE_PER_FRAME: u64 = 48_000 * FRAME_MS as u64 / 1000;
+// Fallback when `Encoder::get_lookahead()` is unavailable — the libopus
+// default at 48 kHz / 20 ms / VOIP, expressed in 48 kHz output samples.
+const DEFAULT_PRE_SKIP_48K: u32 = 312;
+
+#[inline]
+fn frame_samples(sample_rate: u32) -> usize {
+    (sample_rate as usize) * (FRAME_MS as usize) / 1000
+}
 
 #[derive(Debug, Error)]
 pub enum AudioError {
@@ -46,16 +56,17 @@ pub enum AudioError {
 
 pub type Result<T> = std::result::Result<T, AudioError>;
 
-/// Encode a 48 kHz mono float WAV at `wav_path` to an Ogg-Opus file at
-/// `opus_path`. Streaming — memory use is bounded regardless of audio length.
+/// Encode a mono 32-bit-float WAV at `wav_path` (sample rate must be one of
+/// 8/12/16/24/48 kHz — the rates Opus supports natively) to an Ogg-Opus file
+/// at `opus_path`. Streaming — memory use is bounded regardless of audio length.
 pub fn encode_wav_to_opus(wav_path: &Path, opus_path: &Path) -> Result<()> {
     let mut reader = hound::WavReader::open(wav_path)?;
     let spec = reader.spec();
 
-    if spec.sample_rate != SAMPLE_RATE {
+    if !SUPPORTED_SAMPLE_RATES.contains(&spec.sample_rate) {
         return Err(AudioError::UnsupportedFormat(format!(
-            "expected sample rate {SAMPLE_RATE}, got {}",
-            spec.sample_rate
+            "expected sample rate in {:?} Hz, got {}",
+            SUPPORTED_SAMPLE_RATES, spec.sample_rate
         )));
     }
     if spec.channels != 1 {
@@ -71,20 +82,40 @@ pub fn encode_wav_to_opus(wav_path: &Path, opus_path: &Path) -> Result<()> {
         )));
     }
 
-    let total_samples = reader.duration() as usize;
-    let total_frames = total_samples.div_ceil(FRAME_SAMPLES);
+    let sample_rate = spec.sample_rate;
+    let frame_samples = frame_samples(sample_rate);
 
-    let mut encoder = Encoder::new(SAMPLE_RATE, Channels::Mono, Application::Voip)?;
+    let mut encoder = Encoder::new(sample_rate, Channels::Mono, Application::Voip)?;
     encoder.set_bitrate(Bitrate::Bits(BITRATE_BPS))?;
+
+    // Pre-skip is the leading-sample count decoders must discard, expressed in
+    // 48 kHz output ticks (RFC 7845 §4.2). Query libopus for its actual
+    // lookahead at the chosen rate and convert; if the bind is unavailable
+    // for any reason fall back to the libopus default at 48 kHz so files
+    // remain decodable, just with a tiny silence offset on lower rates.
+    let pre_skip_48k: u32 = encoder
+        .get_lookahead()
+        .ok()
+        .map(|n| (n as u32).saturating_mul(48_000) / sample_rate)
+        .unwrap_or(DEFAULT_PRE_SKIP_48K);
+    let pre_skip: u16 = pre_skip_48k.min(u16::MAX as u32) as u16;
+
+    let total_samples = reader.duration() as usize;
+    let total_frames = total_samples.div_ceil(frame_samples);
 
     let file = BufWriter::new(File::create(opus_path)?);
     let mut writer = PacketWriter::new(file);
 
-    writer.write_packet(build_opus_head(), SERIAL, PacketWriteEndInfo::EndPage, 0)?;
+    writer.write_packet(
+        build_opus_head(sample_rate, pre_skip),
+        SERIAL,
+        PacketWriteEndInfo::EndPage,
+        0,
+    )?;
     writer.write_packet(build_opus_tags(), SERIAL, PacketWriteEndInfo::EndPage, 0)?;
 
     let mut encoded = vec![0u8; MAX_PACKET_BYTES];
-    let mut frame_buf = vec![0f32; FRAME_SAMPLES];
+    let mut frame_buf = vec![0f32; frame_samples];
     let mut absgp: u64 = 0;
     let mut frame_idx: usize = 0;
     let mut samples = reader.samples::<f32>();
@@ -109,7 +140,7 @@ pub fn encode_wav_to_opus(wav_path: &Path, opus_path: &Path) -> Result<()> {
         }
 
         let n = encoder.encode_float(&frame_buf, &mut encoded)?;
-        absgp += FRAME_SAMPLES as u64;
+        absgp += GRANULE_PER_FRAME;
         frame_idx += 1;
 
         let end = if frame_idx == total_frames {
@@ -137,13 +168,13 @@ pub fn replace_wav_with_opus(wav_path: &Path) -> Result<std::path::PathBuf> {
     Ok(opus_path)
 }
 
-fn build_opus_head() -> Vec<u8> {
+fn build_opus_head(input_sample_rate: u32, pre_skip: u16) -> Vec<u8> {
     let mut buf = Vec::with_capacity(19);
     buf.extend_from_slice(b"OpusHead");
     buf.push(1); // version
     buf.push(1); // channel count (mono)
-    buf.write_u16::<LittleEndian>(PRE_SKIP).unwrap();
-    buf.write_u32::<LittleEndian>(SAMPLE_RATE).unwrap(); // input sample rate
+    buf.write_u16::<LittleEndian>(pre_skip).unwrap();
+    buf.write_u32::<LittleEndian>(input_sample_rate).unwrap();
     buf.write_i16::<LittleEndian>(0).unwrap(); // output gain Q7.8
     buf.push(0); // mapping family 0 (mono / stereo)
     buf
@@ -163,38 +194,86 @@ fn build_opus_tags() -> Vec<u8> {
 mod tests {
     use super::*;
 
-    /// Write a 1 s 48 kHz mono float WAV containing a 440 Hz sine, encode it,
-    /// and assert the result is a non-empty Ogg stream.
+    /// Write a 1-second mono 32-bit-float sine WAV at `rate`. Used by encode
+    /// tests below.
+    fn write_sine_wav(path: &Path, rate: u32, freq_hz: f32) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: rate,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+        for i in 0..rate as usize {
+            let t = i as f32 / rate as f32;
+            writer
+                .write_sample((2.0 * std::f32::consts::PI * freq_hz * t).sin() * 0.25)
+                .expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+    }
+
+    /// Encode a 48 kHz / 1 s sine and confirm the result is a non-empty Ogg
+    /// stream that announces 48 kHz in its OpusHead.
     #[test]
-    fn encode_short_wav_produces_valid_opus() {
+    fn encode_48khz_wav_produces_valid_opus() {
         let dir = tempfile::tempdir().expect("tempdir");
         let wav_path = dir.path().join("in.wav");
         let opus_path = dir.path().join("out.opus");
 
-        let spec = hound::WavSpec {
-            channels: 1,
-            sample_rate: SAMPLE_RATE,
-            bits_per_sample: 32,
-            sample_format: hound::SampleFormat::Float,
-        };
-        let mut writer = hound::WavWriter::create(&wav_path, spec).expect("create wav");
-        let total = SAMPLE_RATE as usize; // 1 second
-        for i in 0..total {
-            let t = i as f32 / SAMPLE_RATE as f32;
-            let s = (2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.25;
-            writer.write_sample(s).expect("write sample");
-        }
-        writer.finalize().expect("finalize wav");
-
+        write_sine_wav(&wav_path, 48_000, 440.0);
         encode_wav_to_opus(&wav_path, &opus_path).expect("encode");
 
         let bytes = std::fs::read(&opus_path).expect("read opus");
         assert!(bytes.len() > 1000, "opus too small: {}", bytes.len());
         assert_eq!(&bytes[..4], b"OggS", "not an Ogg stream");
+        // OpusHead packet: "OggS" page header (27+) then segment table, then
+        // payload starting with "OpusHead". Look for the magic and read the
+        // input-sample-rate field at offset +12 from "OpusHead" (bytes 12-15
+        // of the 19-byte header).
+        let head_off = bytes
+            .windows(8)
+            .position(|w| w == b"OpusHead")
+            .expect("OpusHead present");
+        let rate = u32::from_le_bytes([
+            bytes[head_off + 12],
+            bytes[head_off + 13],
+            bytes[head_off + 14],
+            bytes[head_off + 15],
+        ]);
+        assert_eq!(rate, 48_000, "OpusHead input_sample_rate mismatch");
     }
 
+    /// Same as above but at 24 kHz — the rate the prior 48-kHz-only encoder
+    /// would have rejected. Verifies the multi-rate path end-to-end.
     #[test]
-    fn rejects_wrong_sample_rate() {
+    fn encode_24khz_wav_produces_valid_opus() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wav_path = dir.path().join("in.wav");
+        let opus_path = dir.path().join("out.opus");
+
+        write_sine_wav(&wav_path, 24_000, 440.0);
+        encode_wav_to_opus(&wav_path, &opus_path).expect("encode");
+
+        let bytes = std::fs::read(&opus_path).expect("read opus");
+        assert!(bytes.len() > 500, "opus too small: {}", bytes.len());
+        assert_eq!(&bytes[..4], b"OggS");
+        let head_off = bytes
+            .windows(8)
+            .position(|w| w == b"OpusHead")
+            .expect("OpusHead present");
+        let rate = u32::from_le_bytes([
+            bytes[head_off + 12],
+            bytes[head_off + 13],
+            bytes[head_off + 14],
+            bytes[head_off + 15],
+        ]);
+        assert_eq!(rate, 24_000, "OpusHead must record the input rate");
+    }
+
+    /// Rates outside the Opus-native set must be rejected up front.
+    #[test]
+    fn rejects_unsupported_sample_rate() {
         let dir = tempfile::tempdir().expect("tempdir");
         let wav_path = dir.path().join("in.wav");
         let opus_path = dir.path().join("out.opus");
@@ -224,20 +303,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let wav_path = dir.path().join("clip.wav");
 
-        let spec = hound::WavSpec {
-            channels: 1,
-            sample_rate: SAMPLE_RATE,
-            bits_per_sample: 32,
-            sample_format: hound::SampleFormat::Float,
-        };
-        let mut writer = hound::WavWriter::create(&wav_path, spec).expect("create wav");
-        for i in 0..SAMPLE_RATE as usize {
-            let t = i as f32 / SAMPLE_RATE as f32;
-            writer
-                .write_sample((2.0 * std::f32::consts::PI * 220.0 * t).sin() * 0.2)
-                .expect("write");
-        }
-        writer.finalize().expect("finalize");
+        write_sine_wav(&wav_path, 48_000, 220.0);
 
         let opus_path = replace_wav_with_opus(&wav_path).expect("replace");
         assert!(opus_path.exists(), "opus file missing");


### PR DESCRIPTION
## Summary

Follow-up to #20. The Opus encoder used to hardcode 48 kHz, so any `UIConfig.sample_rate` other than `48000` made ttsd output land on a sample-rate mismatch and fall back to keeping the WAV on disk. This PR lifts the limit by reading the rate from the WAV header and threading it through the encoder, OpusHead, and frame buffer.

## What changed

- **`src-tauri/src/audio/mod.rs`**
  - Replaced the `SAMPLE_RATE` / `FRAME_SAMPLES` / `PRE_SKIP` constants with per-call values derived from `spec.sample_rate`.
  - Validate input rate against `[8 000, 12 000, 16 000, 24 000, 48 000]` (Opus's native set, RFC 6716 §2).
  - `Encoder::new(sample_rate, …)` now follows the WAV header.
  - `OpusHead.input_sample_rate` records the actual input rate.
  - `pre_skip` queried from `Encoder::get_lookahead()` and converted to 48 kHz output ticks (RFC 7845 §4.2). Falls back to 312 if the bind fails.
  - Granule position now uses a separate constant `GRANULE_PER_FRAME = 960` (always 48 kHz output ticks regardless of input rate).
- **Tests**
  - Renamed `encode_short_wav_produces_valid_opus` → `encode_48khz_wav_produces_valid_opus`.
  - **New** `encode_24khz_wav_produces_valid_opus` decodes the OpusHead and asserts `input_sample_rate == 24000` — the rate the prior encoder rejected outright.
  - Renamed `rejects_wrong_sample_rate` → `rejects_unsupported_sample_rate` (still 22 050 Hz, still rejected).
  - Test helper `write_sine_wav(path, rate, freq)` shared across cases.
- **`docs/storage-schema.md`** — drops the "only 48 kHz round-trips" caveat (now stale) and updates the audio file properties table to reflect that any of 8/12/16/24/48 kHz is supported.

## Test plan

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — clean.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings` — clean.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 679 unit + 1 golden, all green (audio module: 4/4).
- [x] Smoke `pnpm tauri dev`: synthesized the same article at 48 / 24 / 8 kHz back-to-back. Each entry persisted with `.opus`, `OpusHead.input_sample_rate` matched the configured rate, and mpv played all three. (8 kHz sounds telephone-band — expected, that's Silero's narrowband output, not a codec issue.)

## Refs

- Builds on #20.
- Refs #19 (the pure-Rust encoder still has its own perf gap to close).