### PR TITLE
feat(cache): size-based eviction + cleanup UI + cache dir reveal

### DIFF
--- a/docs/ipc-contract.md
+++ b/docs/ipc-contract.md
@@ -73,8 +73,7 @@ interface UIConfig {
   history_days: number;          // Days to keep entries in history (0 = forever)
   audio_max_files: number;       // Maximum number of audio files to keep in cache
   audio_regenerated_hours: number; // Hours to keep manually regenerated audio
-  max_cache_size_mb: number;     // Soft limit on total audio cache size in MB
-  auto_cleanup_days: number;     // Auto-delete entries older than N days (0 = disabled)
+  max_cache_size_mb: number;     // Soft limit on audio cache size in MB; drives startup eviction (0 = disabled)
   code_block_mode: string;       // How to handle Markdown code blocks: "skip" | "read"
   read_operators: boolean;       // Whether to speak mathematical/code operators
   theme: string;                 // Color scheme: "light" | "dark" | "auto"
@@ -388,19 +387,38 @@ invoke("get_timestamps", { id: EntryId }): Promise<WordTimestamp[]>
 
 ### `clear_cache`
 
-Delete all audio files older than the configured `auto_cleanup_days`, or forcibly delete all audio files if `force` is true.
+Sweep orphan files in the audio directory, then evict entries (size-based or wholesale) according to `args.mode`. With `delete_texts: true`, evicted entries are removed from `history.json`; otherwise only their audio is dropped and entries are reset to `"pending"`.
 
 ```typescript
-invoke("clear_cache", { force: boolean }): Promise<{ deleted_files: number; freed_bytes: number }>
+type CleanupMode =
+  | { mode: "size_limit"; target_mb: number }
+  | { mode: "all" };
+
+invoke("clear_cache", {
+  args: {
+    mode: CleanupMode;
+    delete_texts: boolean;
+  }
+}): Promise<{
+  deleted_files: number;
+  deleted_entries: number;
+  freed_bytes: number;
+}>
 ```
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `force` | `boolean` | If `true`, delete all audio regardless of age. Entries are kept but reset to `"pending"`. |
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode.size_limit.target_mb` | `number` | Trim oldest entries (by `created_at`) until cache fits in this many MB. `0` is treated as "no limit" — no eviction (orphan sweep still runs). |
+| `mode.all` | — | Drop every entry's audio (and the entries themselves when `delete_texts: true`). |
+| `delete_texts` | `boolean` | `false` keeps entries with `audio_path: null`; `true` removes them from history. |
+
+`processing` entries are skipped — eviction does not interrupt in-flight synthesis. Files in the audio directory modified within the last ~60 seconds are also preserved by the orphan sweep, to avoid racing with synthesis writes that have not yet been recorded in history.
 
 **Errors:** `storage_error` on file system failures.
 
-**Side effects:** Emits `entry_updated` for each entry whose audio was deleted.
+**Side effects:**
+- Emits `entry_updated` for each entry whose audio was reset (`delete_texts: false`).
+- Emits `entry_removed` (`{ id }`) for each entry removed from history (`delete_texts: true`).
 
 ---
 
@@ -410,6 +428,16 @@ Return current cache size information.
 
 ```typescript
 invoke("get_cache_stats"): Promise<{ total_bytes: number; audio_file_count: number }>
+```
+
+---
+
+### `get_cache_dir`
+
+Return the absolute path to the on-disk cache directory (resolved from `dirs::cache_dir()` at startup, typically `~/.cache/ruvox/`). The frontend uses this to display the path in Settings and to feed `revealItemInDir` for opening the folder in the OS file manager.
+
+```typescript
+invoke("get_cache_dir"): Promise<string>
 ```
 
 ---
@@ -437,6 +465,20 @@ Emitted whenever a `TextEntry` is created or its fields change (status, audio_pa
 - When playback starts/stops (status: `"playing"` / `"ready"`).
 - After `delete_audio` (status reset to `"pending"`).
 - After `cancel_synthesis`.
+- After `clear_cache` for each entry whose audio was reset (`delete_texts: false`).
+
+---
+
+### `entry_removed`
+
+Emitted when an entry is removed from `history.json` by a bulk operation (currently `clear_cache` with `delete_texts: true`).
+
+```typescript
+// Payload
+{ id: EntryId }
+```
+
+The frontend should drop the entry from local state — no `entry_updated` follow-up will arrive.
 
 ---
 

--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -222,8 +222,7 @@ interface UIConfig {
   history_days: number;         // Days to keep entries in history
   audio_max_files: number;      // Maximum number of audio files to keep
   audio_regenerated_hours: number; // Hours to keep manually regenerated audio
-  max_cache_size_mb: number;    // Soft limit on total audio cache size in MB
-  auto_cleanup_days: number;    // Auto-delete entries older than N days (0 = disabled)
+  max_cache_size_mb: number;    // Soft limit on audio cache size in MB; drives startup eviction (0 = disabled)
   code_block_mode: string;      // How to handle Markdown code blocks: "skip" | "read"
   read_operators: boolean;      // Whether to speak mathematical/code operators
   theme: string;                // Color scheme: "light" | "dark" | "auto"
@@ -247,7 +246,6 @@ interface UIConfig {
 | `audio_max_files` | `5` |
 | `audio_regenerated_hours` | `24` |
 | `max_cache_size_mb` | `500` |
-| `auto_cleanup_days` | `0` (disabled) |
 | `code_block_mode` | `"read"` |
 | `read_operators` | `true` |
 | `theme` | `"auto"` |
@@ -268,7 +266,6 @@ interface UIConfig {
   "audio_max_files": 5,
   "audio_regenerated_hours": 24,
   "max_cache_size_mb": 500,
-  "auto_cleanup_days": 0,
   "code_block_mode": "read",
   "read_operators": true,
   "theme": "auto",
@@ -325,7 +322,6 @@ Cross-reference between `docs/ipc-contract.md` types and the JSON fields in each
 | Audio max files | `audio_max_files` | — | yes | yes |
 | Audio regen hours | `audio_regenerated_hours` | — | yes | yes |
 | Max cache MB | `max_cache_size_mb` | — | yes | yes |
-| Auto cleanup days | `auto_cleanup_days` | — | yes | yes |
 | Code block mode | `code_block_mode` | — | yes | yes |
 | Read operators | `read_operators` | — | yes | yes |
 | Theme | `theme` | — | yes | yes |

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -115,7 +115,8 @@ src/
 - `@mantine/form::useForm` with initialValues / validation.
 - Loading: `useEffect([opened])` → `commands.getConfig()` → `form.setValues`.
 - Submit → builds a `UIConfigPatch` (only the form fields; the rest of `UIConfig` is left alone) → `commands.updateConfig(patch)` → notification.
-- Fields: speaker, sample_rate, notify_on_ready/error, max_cache_size_mb, auto_cleanup_days, theme, preview_dialog_enabled.
+- Fields: speaker, sample_rate, notify_on_ready/error, max_cache_size_mb, theme, preview_dialog_enabled.
+- Cache cleanup: a "Очистить кэш…" button opens a sub-modal (`CleanupCacheModal`) with a target-MB input, a "Удалять тексты" checkbox, and a "Очистить полностью" checkbox (which disables the input). Confirms via `commands.clearCache({ mode, delete_texts })`.
 
 ### PreviewDialog
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -158,7 +158,7 @@ When the close button (`X`) is clicked, the app **hides into the tray** instead 
 
 - **Speech synthesis:** speaker (`xenia` / `aidar` / `baya` / `kseniya` / `eugene` / `random`), sample rate (8000 / 24000 / 48000).
 - **Notifications:** notify_on_ready, notify_on_error.
-- **Cache:** `max_cache_size_mb` (minimum 100), `auto_cleanup_days` (0 = disabled).
+- **Cache:** `max_cache_size_mb` (minimum 100). On startup, an orphan sweep + size-based eviction trims the oldest entries until total audio fits the limit. Settings → "Очистить кэш…" runs the same eviction on demand, with optional `Удалять тексты` (remove entries from history) and `Очистить полностью` (drop everything).
 - **Interface:** theme (light / dark / auto).
 
 **There are no global hotkeys in the UI** — this is an intentional decision (see RewriteNotes.md § 7). The player's hotkeys only work while the RuVox window is focused.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1079,6 +1079,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,7 +2183,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2660,7 +2674,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2907,6 +2921,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3217,6 +3237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3382,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "dirs",
+ "filetime",
  "hound",
  "libc",
  "ogg",
@@ -3788,7 +3818,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ byteorder = "1.5"
 [dev-dependencies]
 tempfile = "3"
 similar = "2"
+filetime = "0.2"
 
 [profile.release]
 codegen-units = 1

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tauri::{AppHandle, Emitter, Runtime, State, Wry};
 use tracing::{info, warn};
@@ -659,60 +659,84 @@ pub async fn get_timestamps(
     Ok(timestamps)
 }
 
-/// Delete audio files older than auto_cleanup_days, or all if force=true.
-#[tauri::command]
-pub async fn clear_cache(
-    app: AppHandle<Wry>,
-    state: State<'_, AppState>,
-    force: bool,
-) -> CmdResult<ClearCacheResult> {
-    let config = state.storage.load_config().unwrap_or_default();
-    let mut deleted_files: u32 = 0;
-    let mut freed_bytes: u64 = 0;
+/// What "fits in the cache" means for this clear_cache invocation.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum CleanupMode {
+    /// Trim the oldest entries until the cache fits in `target_mb`.
+    SizeLimit { target_mb: u32 },
+    /// Drop everything: every entry's audio (and texts when `delete_texts` is true).
+    All,
+}
 
-    let entries = state.storage.get_all_entries();
-    for entry in entries {
-        let should_delete = if force {
-            entry.audio_path.is_some()
-        } else if config.auto_cleanup_days > 0 {
-            let cutoff = chrono::Local::now().naive_local()
-                - chrono::Duration::days(config.auto_cleanup_days as i64);
-            entry.created_at < cutoff && entry.audio_path.is_some()
-        } else {
-            false
-        };
-
-        if should_delete {
-            // Measure file size before deletion.
-            if let Some(ref filename) = entry.audio_path {
-                let path = state.storage.cache_dir().join("audio").join(filename);
-                if let Ok(meta) = std::fs::metadata(&path) {
-                    freed_bytes += meta.len();
-                }
-                deleted_files += 1;
-            }
-
-            if let Err(e) = state.storage.delete_audio(&entry.id) {
-                warn!("clear_cache: failed to delete audio for {}: {e}", entry.id);
-                continue;
-            }
-
-            if let Some(updated) = state.storage.get_entry(&entry.id) {
-                emit_entry_updated(&app, &updated);
-            }
-        }
-    }
-
-    Ok(ClearCacheResult {
-        deleted_files,
-        freed_bytes,
-    })
+#[derive(Debug, Deserialize)]
+pub struct ClearCacheArgs {
+    pub mode: CleanupMode,
+    /// `false` → keep entries in history with `audio_path: null`.
+    /// `true`  → remove entries from history entirely.
+    #[serde(default)]
+    pub delete_texts: bool,
 }
 
 #[derive(Serialize)]
 pub struct ClearCacheResult {
     pub deleted_files: u32,
+    pub deleted_entries: u32,
     pub freed_bytes: u64,
+}
+
+/// Sweep orphan files in `audio/`, then evict entries (size-based or wholesale)
+/// according to `args.mode`. With `delete_texts = true`, evicted entries are
+/// removed from `history.json`; otherwise only their audio is dropped.
+/// Always sweeps orphans regardless of `mode` / `delete_texts`.
+#[tauri::command]
+pub async fn clear_cache(
+    app: AppHandle<Wry>,
+    state: State<'_, AppState>,
+    args: ClearCacheArgs,
+) -> CmdResult<ClearCacheResult> {
+    let storage = Arc::clone(&state.storage);
+    let mode = args.mode;
+    let delete_texts = args.delete_texts;
+
+    // File I/O is blocking by nature — keep the async runtime free.
+    let (sweep, evict) = tokio::task::spawn_blocking(move || -> Result<_, StorageError> {
+        let sweep = storage.sweep_orphans()?;
+        let evict = match mode {
+            CleanupMode::SizeLimit { target_mb } => {
+                storage.evict_to_size((target_mb as u64) * 1024 * 1024, delete_texts)?
+            }
+            CleanupMode::All => storage.evict_all(delete_texts)?,
+        };
+        Ok((sweep, evict))
+    })
+    .await
+    .map_err(|e| CommandError::Internal {
+        message: format!("clear_cache task panicked: {e}"),
+    })??;
+
+    for id in &evict.updated_ids {
+        if let Some(entry) = state.storage.get_entry(id) {
+            emit_entry_updated(&app, &entry);
+        }
+    }
+    for id in &evict.removed_ids {
+        let _ = app.emit("entry_removed", json!({ "id": id }));
+    }
+
+    info!(
+        "clear_cache: sweep_files={}, evict_files={}, evict_entries={}, freed={} bytes",
+        sweep.deleted_files,
+        evict.deleted_files,
+        evict.deleted_entries,
+        sweep.freed_bytes + evict.freed_bytes,
+    );
+
+    Ok(ClearCacheResult {
+        deleted_files: sweep.deleted_files + evict.deleted_files,
+        deleted_entries: evict.deleted_entries,
+        freed_bytes: sweep.freed_bytes + evict.freed_bytes,
+    })
 }
 
 /// Return current cache size information.
@@ -733,6 +757,15 @@ pub async fn get_cache_stats(state: State<'_, AppState>) -> CmdResult<CacheSizeI
 pub struct CacheSizeInfo {
     pub total_bytes: u64,
     pub audio_file_count: u32,
+}
+
+/// Absolute path to the on-disk cache directory (`~/.cache/ruvox/` by default,
+/// or wherever `XDG_CACHE_HOME`/`dirs::cache_dir()` resolved to at startup).
+/// The frontend uses this to display the path in Settings and to pass it to
+/// `revealItemInDir` for opening the folder in the OS file manager.
+#[tauri::command]
+pub async fn get_cache_dir(state: State<'_, AppState>) -> CmdResult<String> {
+    Ok(state.storage.cache_dir().to_string_lossy().into_owned())
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -773,9 +806,6 @@ fn apply_config_patch(config: &mut UIConfig, patch: UIConfigPatch) {
     }
     if let Some(v) = patch.max_cache_size_mb {
         config.max_cache_size_mb = v;
-    }
-    if let Some(v) = patch.auto_cleanup_days {
-        config.auto_cleanup_days = v;
     }
     if let Some(v) = patch.code_block_mode {
         config.code_block_mode = v;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,9 +100,16 @@ pub fn run() {
             // transcoded to `.opus` in the background. Runs blocking on a
             // dedicated thread so app startup is not delayed; per-entry
             // errors are logged inside the migration routine.
+            //
+            // Once migration finishes the same task runs cache cleanup
+            // (orphan sweep + size-based eviction down to
+            // `max_cache_size_mb`). Keeping the order serialised guarantees
+            // the freshly-renamed `.opus` files are already linked to
+            // their entries before the orphan sweep walks the directory.
             {
                 let storage_for_migration = Arc::clone(&storage);
                 tauri::async_runtime::spawn(async move {
+                    let storage_for_cleanup = Arc::clone(&storage_for_migration);
                     let stats = tokio::task::spawn_blocking(move || {
                         storage_for_migration.migrate_wav_audio_to_opus()
                     })
@@ -119,6 +126,31 @@ pub fn run() {
                         }
                         Err(e) => {
                             tracing::error!("audio migration task panicked: {e}");
+                        }
+                    }
+
+                    let cleanup_result = tokio::task::spawn_blocking(move || {
+                        let cfg = storage_for_cleanup.load_config().unwrap_or_default();
+                        let target_bytes = (cfg.max_cache_size_mb as u64) * 1024 * 1024;
+                        storage_for_cleanup
+                            .run_startup_cleanup(target_bytes)
+                            .map_err(|e| e.to_string())
+                    })
+                    .await;
+                    match cleanup_result {
+                        Ok(Ok(s)) => {
+                            tracing::info!(
+                                "startup cleanup: orphans={}, evicted_files={}, freed={} bytes",
+                                s.sweep.deleted_files,
+                                s.evict.deleted_files,
+                                s.sweep.freed_bytes + s.evict.freed_bytes,
+                            );
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!("startup cleanup failed: {e}");
+                        }
+                        Err(e) => {
+                            tracing::error!("startup cleanup task panicked: {e}");
                         }
                     }
                 });
@@ -266,6 +298,7 @@ pub fn run() {
             get_timestamps,
             clear_cache,
             get_cache_stats,
+            get_cache_dir,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -95,8 +95,6 @@ pub struct UIConfig {
     pub audio_regenerated_hours: u32,
     #[serde(default = "UIConfig::default_max_cache_size_mb")]
     pub max_cache_size_mb: u32,
-    #[serde(default = "UIConfig::default_auto_cleanup_days")]
-    pub auto_cleanup_days: u32,
     /// How to handle Markdown code blocks: `"skip"` | `"read"`. Defaults to `"read"`.
     #[serde(default = "UIConfig::default_code_block_mode")]
     pub code_block_mode: String,
@@ -141,9 +139,6 @@ impl UIConfig {
     fn default_max_cache_size_mb() -> u32 {
         500
     }
-    fn default_auto_cleanup_days() -> u32 {
-        0
-    }
     fn default_code_block_mode() -> String {
         "read".to_string()
     }
@@ -180,7 +175,6 @@ impl Default for UIConfig {
             audio_max_files: Self::default_audio_max_files(),
             audio_regenerated_hours: Self::default_audio_regenerated_hours(),
             max_cache_size_mb: Self::default_max_cache_size_mb(),
-            auto_cleanup_days: Self::default_auto_cleanup_days(),
             code_block_mode: Self::default_code_block_mode(),
             read_operators: true,
             theme: Self::default_theme(),
@@ -205,7 +199,6 @@ pub struct UIConfigPatch {
     pub audio_max_files: Option<u32>,
     pub audio_regenerated_hours: Option<u32>,
     pub max_cache_size_mb: Option<u32>,
-    pub auto_cleanup_days: Option<u32>,
     pub code_block_mode: Option<String>,
     pub read_operators: Option<bool>,
     pub theme: Option<String>,

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use chrono::Local;
 use parking_lot::RwLock;
@@ -13,6 +14,11 @@ use crate::storage::schema::{
 };
 
 const HISTORY_VERSION: u32 = 1;
+
+/// Files modified within this window are skipped by [`StorageService::sweep_orphans`]
+/// and the orphan branches of cache eviction. Protects in-flight synthesis output
+/// that has been written to disk but not yet recorded in `history.json`.
+const RECENT_FILE_GRACE: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Error)]
 pub enum StorageError {
@@ -39,6 +45,37 @@ pub struct AudioMigrationStats {
     pub skipped_missing: usize,
     /// Encode or persist step failed; the source `.wav` is left in place.
     pub failed: usize,
+}
+
+/// Outcome of [`StorageService::sweep_orphans`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SweepStats {
+    /// Files in the audio directory that did not match any entry and were removed.
+    pub deleted_files: u32,
+    /// Total bytes reclaimed.
+    pub freed_bytes: u64,
+}
+
+/// Outcome of [`StorageService::evict_to_size`] / [`StorageService::evict_all`].
+#[derive(Debug, Default, Clone)]
+pub struct EvictStats {
+    /// Files removed (audio + timestamps).
+    pub deleted_files: u32,
+    /// Entries removed from `history.json` (only when `delete_texts = true`).
+    pub deleted_entries: u32,
+    /// Total bytes reclaimed.
+    pub freed_bytes: u64,
+    /// IDs of entries whose audio was reset to `null` (when `delete_texts = false`).
+    pub updated_ids: Vec<EntryId>,
+    /// IDs of entries removed from history (when `delete_texts = true`).
+    pub removed_ids: Vec<EntryId>,
+}
+
+/// Outcome of [`StorageService::run_startup_cleanup`].
+#[derive(Debug, Default, Clone)]
+pub struct StartupCleanupStats {
+    pub sweep: SweepStats,
+    pub evict: EvictStats,
 }
 
 pub struct StorageService {
@@ -364,6 +401,225 @@ impl StorageService {
         }
 
         stats
+    }
+
+    // ── Cache cleanup: orphans + size-based eviction ───────────────────────
+
+    /// Build the set of filenames in `audio/` that belong to a known entry
+    /// (either as `audio_path` or as `timestamps_path`).
+    fn build_valid_filename_set(&self) -> HashSet<String> {
+        let map = self.entries.read();
+        let mut valid: HashSet<String> = HashSet::with_capacity(map.len() * 2);
+        for entry in map.values() {
+            if let Some(ref name) = entry.audio_path {
+                valid.insert(name.clone());
+            }
+            if let Some(ref name) = entry.timestamps_path {
+                valid.insert(name.clone());
+            }
+        }
+        valid
+    }
+
+    /// Remove files in `audio/` that do not correspond to any entry in
+    /// `history.json`. Files modified within [`RECENT_FILE_GRACE`] are
+    /// preserved to avoid racing with active synthesis (the audio is on
+    /// disk but the entry hasn't been updated yet).
+    pub fn sweep_orphans(&self) -> Result<SweepStats> {
+        let valid = self.build_valid_filename_set();
+        let mut stats = SweepStats::default();
+        let now = SystemTime::now();
+
+        for dir_entry in fs::read_dir(&self.audio_dir)? {
+            let dir_entry = dir_entry?;
+            let path = dir_entry.path();
+            let meta = match dir_entry.metadata() {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!("sweep_orphans: stat failed for {:?}: {e}", path);
+                    continue;
+                }
+            };
+            if !meta.is_file() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if valid.contains(name) {
+                continue;
+            }
+            if let Ok(modified) = meta.modified() {
+                if now.duration_since(modified).unwrap_or(Duration::ZERO) < RECENT_FILE_GRACE {
+                    tracing::debug!("sweep_orphans: skipping recent file {name}");
+                    continue;
+                }
+            }
+
+            let size = meta.len();
+            match fs::remove_file(&path) {
+                Ok(()) => {
+                    stats.deleted_files += 1;
+                    stats.freed_bytes += size;
+                    tracing::info!("sweep_orphans: removed orphan {name} ({size} bytes)");
+                }
+                Err(e) => {
+                    tracing::warn!("sweep_orphans: failed to remove {name}: {e}");
+                }
+            }
+        }
+
+        Ok(stats)
+    }
+
+    /// Total on-disk size of an entry's audio + timestamps files (existing files only).
+    fn entry_files_size(&self, entry: &TextEntry) -> u64 {
+        let mut total: u64 = 0;
+        if let Some(ref name) = entry.audio_path {
+            if let Ok(meta) = fs::metadata(self.audio_dir.join(name)) {
+                total += meta.len();
+            }
+        }
+        if let Some(ref name) = entry.timestamps_path {
+            if let Ok(meta) = fs::metadata(self.audio_dir.join(name)) {
+                total += meta.len();
+            }
+        }
+        total
+    }
+
+    /// Sum of sizes of every entry's audio + timestamps files.
+    fn current_entries_size(&self) -> u64 {
+        let entries: Vec<TextEntry> = self.entries.read().values().cloned().collect();
+        entries.iter().map(|e| self.entry_files_size(e)).sum()
+    }
+
+    /// Drop the audio file for one entry as part of an eviction loop.
+    /// Returns the number of bytes reclaimed and the number of files removed.
+    /// `delete_texts = false` keeps the entry in history with audio fields nulled;
+    /// `delete_texts = true` removes the entry entirely.
+    fn evict_one(&self, id: &EntryId, delete_texts: bool) -> Result<(u64, u32)> {
+        let entry = match self.get_entry(id) {
+            Some(e) => e,
+            None => return Ok((0, 0)),
+        };
+        let freed = self.entry_files_size(&entry);
+        let mut files = 0u32;
+        if entry.audio_path.is_some() {
+            files += 1;
+        }
+        if entry.timestamps_path.is_some() {
+            files += 1;
+        }
+
+        if delete_texts {
+            self.delete_entry(id)?;
+        } else {
+            self.delete_audio(id)?;
+        }
+        Ok((freed, files))
+    }
+
+    /// Evict the oldest entries until the cumulative on-disk size of
+    /// all remaining entries' audio + timestamps fits in `target_bytes`.
+    ///
+    /// `delete_texts = false` (the default for startup cleanup) wipes only the
+    /// audio + timestamps files and resets the entry to `pending`.
+    /// `delete_texts = true` removes the entry record from `history.json` too.
+    ///
+    /// `target_bytes = 0` is treated as "limit disabled" — no-op.
+    /// Entries currently `processing` are skipped to avoid clobbering an
+    /// in-flight synthesis.
+    pub fn evict_to_size(&self, target_bytes: u64, delete_texts: bool) -> Result<EvictStats> {
+        let mut stats = EvictStats::default();
+        if target_bytes == 0 {
+            return Ok(stats);
+        }
+
+        let mut total = self.current_entries_size();
+        if total <= target_bytes {
+            return Ok(stats);
+        }
+
+        // Oldest first.
+        let mut candidates: Vec<TextEntry> =
+            self.entries.read().values().cloned().collect::<Vec<_>>();
+        candidates.sort_by_key(|e| e.created_at);
+
+        for entry in candidates {
+            if total <= target_bytes {
+                break;
+            }
+            if entry.status == EntryStatus::Processing {
+                continue;
+            }
+            // Nothing on disk to free — skipping saves a history write.
+            if entry.audio_path.is_none() && entry.timestamps_path.is_none() {
+                continue;
+            }
+            let (freed, files) = match self.evict_one(&entry.id, delete_texts) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!("evict_to_size: failed to evict {}: {e}", entry.id);
+                    continue;
+                }
+            };
+            total = total.saturating_sub(freed);
+            stats.deleted_files += files;
+            stats.freed_bytes += freed;
+            if delete_texts {
+                stats.deleted_entries += 1;
+                stats.removed_ids.push(entry.id);
+            } else {
+                stats.updated_ids.push(entry.id);
+            }
+        }
+
+        Ok(stats)
+    }
+
+    /// Evict every entry's audio. With `delete_texts = true`, every entry is
+    /// removed from `history.json`; otherwise only the audio fields are reset.
+    /// Entries currently `processing` are skipped.
+    pub fn evict_all(&self, delete_texts: bool) -> Result<EvictStats> {
+        let mut stats = EvictStats::default();
+        let candidates: Vec<TextEntry> = self.entries.read().values().cloned().collect();
+
+        for entry in candidates {
+            if entry.status == EntryStatus::Processing {
+                continue;
+            }
+            if !delete_texts && entry.audio_path.is_none() && entry.timestamps_path.is_none() {
+                continue;
+            }
+            let (freed, files) = match self.evict_one(&entry.id, delete_texts) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!("evict_all: failed to evict {}: {e}", entry.id);
+                    continue;
+                }
+            };
+            stats.deleted_files += files;
+            stats.freed_bytes += freed;
+            if delete_texts {
+                stats.deleted_entries += 1;
+                stats.removed_ids.push(entry.id);
+            } else {
+                stats.updated_ids.push(entry.id);
+            }
+        }
+
+        Ok(stats)
+    }
+
+    /// Run on app startup: drop orphan files in `audio/`, then trim the
+    /// cache to fit `target_bytes`. Always uses `delete_texts = false`
+    /// — automatic deletion of texts is too destructive without an explicit
+    /// user gesture.
+    pub fn run_startup_cleanup(&self, target_bytes: u64) -> Result<StartupCleanupStats> {
+        let sweep = self.sweep_orphans()?;
+        let evict = self.evict_to_size(target_bytes, false)?;
+        Ok(StartupCleanupStats { sweep, evict })
     }
 
     // ── Audio / Timestamps ─────────────────────────────────────────────────
@@ -854,5 +1110,212 @@ mod tests {
         let stats = svc.migrate_wav_audio_to_opus();
         assert_eq!(stats.considered, 0);
         assert_eq!(stats.migrated, 0);
+    }
+
+    // ── Cleanup tests ──────────────────────────────────────────────────────
+
+    /// Mark a file's mtime far enough in the past that the orphan sweep won't
+    /// treat it as "recent" and skip it.
+    fn age_file(path: &Path) {
+        let aged = SystemTime::now() - (RECENT_FILE_GRACE * 2);
+        // Setting access time too keeps the call cross-platform; we only care about mtime.
+        let _ = filetime::set_file_mtime(path, filetime::FileTime::from_system_time(aged));
+    }
+
+    /// Helper: create an entry already populated with on-disk audio + timestamps
+    /// of the requested sizes. Returns the entry id.
+    fn make_ready_entry(svc: &StorageService, audio_bytes: usize, ts_words: usize) -> EntryId {
+        let entry = svc.add_entry("test".into()).unwrap();
+        let id = entry.id;
+        let audio_filename = svc.save_audio(&id, &vec![0u8; audio_bytes]).unwrap();
+        let words: Vec<WordTimestamp> = (0..ts_words)
+            .map(|i| WordTimestamp {
+                word: format!("w{i}"),
+                start: i as f64,
+                end: i as f64 + 0.5,
+                original_pos: (0, 1),
+            })
+            .collect();
+        let ts_filename = svc.save_timestamps(&id, &words).unwrap();
+        let mut updated = entry.clone();
+        updated.audio_path = Some(audio_filename);
+        updated.timestamps_path = Some(ts_filename);
+        updated.status = EntryStatus::Ready;
+        svc.update_entry(updated).unwrap();
+        id
+    }
+
+    #[test]
+    fn sweep_orphans_removes_unknown_files_only() {
+        let (svc, _dir) = make_service();
+        let id = make_ready_entry(&svc, 32, 1);
+        let entry = svc.get_entry(&id).unwrap();
+        let audio_dir = svc.cache_dir().join("audio");
+
+        // Stranger file — should be removed.
+        let orphan = audio_dir.join("stranger.opus");
+        fs::write(&orphan, b"orphan").unwrap();
+        age_file(&orphan);
+        // Known files: keep their mtime as-is (recent), should still survive
+        // because they're in the valid set.
+        let stats = svc.sweep_orphans().unwrap();
+        assert_eq!(stats.deleted_files, 1);
+        assert!(stats.freed_bytes > 0);
+        assert!(!orphan.exists());
+        assert!(audio_dir.join(entry.audio_path.unwrap()).exists());
+        assert!(audio_dir.join(entry.timestamps_path.unwrap()).exists());
+    }
+
+    #[test]
+    fn sweep_orphans_preserves_recent_files() {
+        let (svc, _dir) = make_service();
+        let audio_dir = svc.cache_dir().join("audio");
+        // Fresh orphan — sweep must keep it (race with active synthesis).
+        let recent = audio_dir.join("in-flight.opus");
+        fs::write(&recent, b"in flight").unwrap();
+        let stats = svc.sweep_orphans().unwrap();
+        assert_eq!(stats.deleted_files, 0);
+        assert!(recent.exists());
+    }
+
+    #[test]
+    fn sweep_orphans_is_idempotent() {
+        let (svc, _dir) = make_service();
+        let _id = make_ready_entry(&svc, 16, 1);
+        // Run twice — second call must be a no-op.
+        let _ = svc.sweep_orphans().unwrap();
+        let stats = svc.sweep_orphans().unwrap();
+        assert_eq!(stats.deleted_files, 0);
+        assert_eq!(stats.freed_bytes, 0);
+    }
+
+    #[test]
+    fn evict_to_size_drops_oldest_first_keeping_entry() {
+        let (svc, _dir) = make_service();
+
+        // Three entries with distinct created_at (sleep between adds).
+        let id1 = make_ready_entry(&svc, 10_000, 0);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let id2 = make_ready_entry(&svc, 10_000, 0);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let id3 = make_ready_entry(&svc, 10_000, 0);
+
+        // Target is small enough to force at least the oldest two to be evicted.
+        let stats = svc.evict_to_size(15_000, false).unwrap();
+        assert!(stats.deleted_files >= 2, "at least 2 audio files removed");
+        assert!(stats.updated_ids.contains(&id1));
+        assert_eq!(stats.deleted_entries, 0);
+
+        // The newest must still have audio.
+        let e3 = svc.get_entry(&id3).unwrap();
+        assert!(e3.audio_path.is_some());
+        // Older entries: audio cleared, status reset to pending.
+        let e1 = svc.get_entry(&id1).unwrap();
+        assert!(e1.audio_path.is_none());
+        assert_eq!(e1.status, EntryStatus::Pending);
+        // id2 may or may not have been evicted depending on rounding —
+        // assert only the invariant: total <= target.
+        let _ = id2;
+        let total = svc.current_entries_size();
+        assert!(total <= 15_000, "total {total} must fit target");
+    }
+
+    #[test]
+    fn evict_to_size_with_delete_texts_removes_entries() {
+        let (svc, _dir) = make_service();
+        let id1 = make_ready_entry(&svc, 5_000, 0);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let id2 = make_ready_entry(&svc, 5_000, 0);
+
+        let stats = svc.evict_to_size(0_001, true).unwrap();
+        // target 1 byte → both entries must be removed.
+        assert!(stats.deleted_entries >= 1);
+        assert!(stats.removed_ids.contains(&id1));
+        // Newest may survive only if total fit by then; with 0 target both must go.
+        assert!(stats.removed_ids.contains(&id2) || svc.get_entry(&id2).is_none());
+    }
+
+    #[test]
+    fn evict_to_size_target_zero_is_noop() {
+        let (svc, _dir) = make_service();
+        let id = make_ready_entry(&svc, 1_000, 0);
+        let stats = svc.evict_to_size(0, false).unwrap();
+        assert_eq!(stats.deleted_files, 0);
+        assert_eq!(stats.freed_bytes, 0);
+        assert!(svc.get_entry(&id).unwrap().audio_path.is_some());
+    }
+
+    #[test]
+    fn evict_to_size_below_target_is_noop() {
+        let (svc, _dir) = make_service();
+        let id = make_ready_entry(&svc, 1_000, 0);
+        // Target much higher than current total.
+        let stats = svc.evict_to_size(100_000_000, false).unwrap();
+        assert_eq!(stats.deleted_files, 0);
+        assert!(svc.get_entry(&id).unwrap().audio_path.is_some());
+    }
+
+    #[test]
+    fn evict_all_keeps_entries_when_delete_texts_false() {
+        let (svc, _dir) = make_service();
+        let id1 = make_ready_entry(&svc, 200, 0);
+        let id2 = make_ready_entry(&svc, 200, 0);
+
+        let stats = svc.evict_all(false).unwrap();
+        assert!(stats.deleted_files >= 2);
+        assert_eq!(stats.deleted_entries, 0);
+        assert!(svc.get_entry(&id1).unwrap().audio_path.is_none());
+        assert!(svc.get_entry(&id2).unwrap().audio_path.is_none());
+    }
+
+    #[test]
+    fn evict_all_removes_history_when_delete_texts_true() {
+        let (svc, _dir) = make_service();
+        let _id1 = make_ready_entry(&svc, 200, 0);
+        let _id2 = make_ready_entry(&svc, 200, 0);
+
+        let stats = svc.evict_all(true).unwrap();
+        assert!(stats.deleted_entries >= 2);
+        assert!(svc.get_all_entries().is_empty());
+    }
+
+    #[test]
+    fn run_startup_cleanup_combines_sweep_and_evict() {
+        let (svc, _dir) = make_service();
+        let id1 = make_ready_entry(&svc, 5_000, 0);
+        let id2 = make_ready_entry(&svc, 5_000, 0);
+
+        // Plant an aged orphan.
+        let orphan = svc.cache_dir().join("audio").join("ghost.opus");
+        fs::write(&orphan, b"ghost").unwrap();
+        age_file(&orphan);
+
+        let stats = svc.run_startup_cleanup(7_000).unwrap();
+        assert_eq!(stats.sweep.deleted_files, 1);
+        // At least one entry's audio was evicted (oldest first).
+        assert!(stats.evict.deleted_files >= 1);
+        assert!(!orphan.exists());
+        // Both entries still in history (delete_texts=false).
+        assert!(svc.get_entry(&id1).is_some());
+        assert!(svc.get_entry(&id2).is_some());
+    }
+
+    #[test]
+    fn evict_to_size_skips_processing_entries() {
+        let (svc, _dir) = make_service();
+        let id_old = make_ready_entry(&svc, 10_000, 0);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let id_proc = make_ready_entry(&svc, 10_000, 0);
+        // Force the older one into Processing — eviction loop must skip it
+        // even though it would otherwise be picked first.
+        let mut e = svc.get_entry(&id_old).unwrap();
+        e.status = EntryStatus::Processing;
+        svc.update_entry(e).unwrap();
+
+        let _ = svc.evict_to_size(5_000, false).unwrap();
+        // Processing entry's audio must remain.
+        let still = svc.get_entry(&id_old).unwrap();
+        assert!(still.audio_path.is_some());
+        let _ = id_proc;
     }
 }

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -184,6 +184,17 @@ export function QueueList() {
       }),
     );
 
+    unlisteners.push(
+      events.entryRemoved((payload) => {
+        setEntries((prev) => prev.filter((e) => e.id !== payload.id));
+        useSelectedEntry.setState((state) =>
+          state.selectedId === payload.id
+            ? { selectedId: null, selectedEntry: null }
+            : {},
+        );
+      }),
+    );
+
     // Highlight the currently-playing entry.  Paused playback keeps the
     // highlight (user may resume); only stop/finish clears it.
     unlisteners.push(events.playbackStarted((p) => setPlayingId(p.entry_id)));

--- a/src/dialogs/Settings.tsx
+++ b/src/dialogs/Settings.tsx
@@ -1,21 +1,25 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
-  Modal,
-  Stack,
-  Select,
-  Switch,
-  NumberInput,
+  Alert,
   Button,
-  Group,
-  Text,
+  Checkbox,
   Divider,
+  Group,
+  Modal,
+  NumberInput,
+  Select,
+  Stack,
+  Switch,
+  Text,
   useMantineColorScheme,
 } from '@mantine/core';
 import type { MantineColorScheme } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
+import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { commands } from '../lib/tauri';
-import type { UIConfigPatch } from '../lib/tauri';
+import type { CleanupMode, UIConfigPatch } from '../lib/tauri';
+import { formatError } from '../lib/errors';
 
 interface SettingsFormValues {
   speaker: string;
@@ -24,7 +28,6 @@ interface SettingsFormValues {
   notify_on_error: boolean;
   preview_dialog_enabled: boolean;
   max_cache_size_mb: number;
-  auto_cleanup_days: number;
   theme: string;
 }
 
@@ -57,8 +60,131 @@ const THEME_OPTIONS = [
   { value: 'auto', label: 'Авто' },
 ];
 
+function formatMb(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} МБ`;
+}
+
+interface CleanupCacheModalProps {
+  opened: boolean;
+  defaultTargetMb: number;
+  onClose: () => void;
+  /** Fired after a successful clear so callers can refresh stats. */
+  onCleared?: () => void;
+}
+
+function CleanupCacheModal({
+  opened,
+  defaultTargetMb,
+  onClose,
+  onCleared,
+}: CleanupCacheModalProps) {
+  const [targetMb, setTargetMb] = useState<number>(defaultTargetMb);
+  const [deleteTexts, setDeleteTexts] = useState(false);
+  const [cleanFully, setCleanFully] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [stats, setStats] = useState<{ total_bytes: number; audio_file_count: number } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!opened) return;
+    setTargetMb(defaultTargetMb);
+    setDeleteTexts(false);
+    setCleanFully(false);
+    commands.getCacheStats().then(setStats).catch(() => setStats(null));
+  }, [opened, defaultTargetMb]);
+
+  const dangerous = cleanFully && deleteTexts;
+
+  const handleConfirm = async () => {
+    const mode: CleanupMode = cleanFully
+      ? { mode: 'all' }
+      : { mode: 'size_limit', target_mb: targetMb };
+    setSubmitting(true);
+    try {
+      const result = await commands.clearCache({ mode, delete_texts: deleteTexts });
+      const parts: string[] = [];
+      if (result.deleted_entries > 0) {
+        parts.push(`удалено записей: ${result.deleted_entries}`);
+      }
+      parts.push(`файлов: ${result.deleted_files}`);
+      parts.push(`освобождено ${formatMb(result.freed_bytes)}`);
+      notifications.show({
+        title: 'Кэш очищен',
+        message: parts.join(', '),
+        color: 'green',
+      });
+      onCleared?.();
+      onClose();
+    } catch (err) {
+      notifications.show({
+        title: 'Ошибка очистки кэша',
+        message: formatError(err),
+        color: 'red',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Очистить кэш" size="md" centered>
+      <Stack gap="sm">
+        {stats && (
+          <Text size="sm" c="dimmed">
+            Сейчас в кэше: {formatMb(stats.total_bytes)} ({stats.audio_file_count}{' '}
+            файлов)
+          </Text>
+        )}
+
+        <NumberInput
+          label="Очистить до размера, МБ"
+          description="Удаляются самые старые записи, пока кэш не уложится в указанный лимит."
+          min={0}
+          value={targetMb}
+          onChange={(v) =>
+            setTargetMb(typeof v === 'number' ? v : parseInt(String(v || 0), 10) || 0)
+          }
+          disabled={cleanFully}
+        />
+
+        <Checkbox
+          label="Удалять тексты"
+          description="Помимо аудио, удалять и сами записи из истории."
+          checked={deleteTexts}
+          onChange={(e) => setDeleteTexts(e.currentTarget.checked)}
+        />
+
+        <Checkbox
+          label="Очистить полностью"
+          description="Удалить всё аудио (и тексты, если включён флаг выше)."
+          checked={cleanFully}
+          onChange={(e) => setCleanFully(e.currentTarget.checked)}
+        />
+
+        {dangerous && (
+          <Alert color="red" variant="light">
+            Будут удалены все записи и всё аудио. Действие необратимо.
+          </Alert>
+        )}
+
+        <Group justify="flex-end" mt="sm">
+          <Button variant="subtle" onClick={onClose} disabled={submitting}>
+            Отмена
+          </Button>
+          <Button color={dangerous ? 'red' : 'blue'} loading={submitting} onClick={handleConfirm}>
+            {cleanFully ? 'Очистить' : 'Очистить кэш'}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
 export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) {
   const { setColorScheme } = useMantineColorScheme();
+  const [cleanupOpen, setCleanupOpen] = useState(false);
+  const [cacheDir, setCacheDir] = useState<string>('');
   const form = useForm<SettingsFormValues>({
     initialValues: {
       speaker: 'xenia',
@@ -67,12 +193,10 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
       notify_on_error: true,
       preview_dialog_enabled: true,
       max_cache_size_mb: 500,
-      auto_cleanup_days: 30,
       theme: 'auto',
     },
     validate: {
       max_cache_size_mb: (v) => (v < 100 ? 'Минимум 100 МБ' : null),
-      auto_cleanup_days: (v) => (v < 0 ? 'Значение не может быть отрицательным' : null),
     },
   });
 
@@ -86,13 +210,28 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
         notify_on_error: config.notify_on_error,
         preview_dialog_enabled: config.preview_dialog_enabled,
         max_cache_size_mb: config.max_cache_size_mb,
-        auto_cleanup_days: config.auto_cleanup_days,
         theme: config.theme,
       });
     });
+    commands.getCacheDir().then(setCacheDir).catch(() => setCacheDir(''));
     // form is excluded intentionally: setValues is stable, re-running on form change would loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [opened]);
+
+  const handleOpenCacheDir = async () => {
+    if (!cacheDir) return;
+    try {
+      // revealItemInDir always needs an item path, not a bare directory.
+      // history.json is always present, so use it as the marker.
+      await revealItemInDir(`${cacheDir}/history.json`);
+    } catch (err) {
+      notifications.show({
+        title: 'Не удалось открыть папку',
+        message: formatError(err),
+        color: 'red',
+      });
+    }
+  };
 
   const handleSubmit = async (values: SettingsFormValues) => {
     const patch: UIConfigPatch = {
@@ -102,7 +241,6 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
       notify_on_error: values.notify_on_error,
       preview_dialog_enabled: values.preview_dialog_enabled,
       max_cache_size_mb: values.max_cache_size_mb,
-      auto_cleanup_days: values.auto_cleanup_days,
       theme: values.theme as UIConfigPatch['theme'],
     };
 
@@ -193,18 +331,31 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
 
           <NumberInput
             label="Максимальный размер кэша (МБ)"
+            description="При запуске и при ручной очистке самые старые записи удаляются, пока кэш не уложится в этот лимит."
             min={100}
             key={form.key('max_cache_size_mb')}
             {...form.getInputProps('max_cache_size_mb')}
           />
 
-          <NumberInput
-            label="Автоудаление через (дней)"
-            description="0 — отключить автоудаление"
-            min={0}
-            key={form.key('auto_cleanup_days')}
-            {...form.getInputProps('auto_cleanup_days')}
-          />
+          {cacheDir && (
+            <Stack gap={4}>
+              <Text size="xs" c="dimmed">
+                Папка кэша
+              </Text>
+              <Text size="sm" style={{ wordBreak: 'break-all', fontFamily: 'var(--mantine-font-family-monospace)' }}>
+                {cacheDir}
+              </Text>
+            </Stack>
+          )}
+
+          <Group justify="flex-start">
+            <Button variant="default" onClick={handleOpenCacheDir} disabled={!cacheDir}>
+              Открыть папку
+            </Button>
+            <Button variant="default" onClick={() => setCleanupOpen(true)}>
+              Очистить кэш…
+            </Button>
+          </Group>
 
           <Divider />
 
@@ -227,6 +378,12 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
           </Group>
         </Stack>
       </form>
+
+      <CleanupCacheModal
+        opened={cleanupOpen}
+        defaultTargetMb={form.values.max_cache_size_mb}
+        onClose={() => setCleanupOpen(false)}
+      />
     </Modal>
   );
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -43,7 +43,6 @@ export interface UIConfig {
   audio_max_files: number;
   audio_regenerated_hours: number;
   max_cache_size_mb: number;
-  auto_cleanup_days: number;
   code_block_mode: string;
   read_operators: boolean;
   theme: Theme;
@@ -56,6 +55,21 @@ export type UIConfigPatch = Partial<UIConfig>;
 
 export interface PreviewNormalizeResult {
   normalized: string;
+}
+
+export type CleanupMode =
+  | { mode: 'size_limit'; target_mb: number }
+  | { mode: 'all' };
+
+export interface ClearCacheArgs {
+  mode: CleanupMode;
+  delete_texts: boolean;
+}
+
+export interface ClearCacheResult {
+  deleted_files: number;
+  deleted_entries: number;
+  freed_bytes: number;
 }
 
 // --- Commands (frontend → backend) ---
@@ -112,11 +126,14 @@ export const commands = {
   getTimestamps: (id: EntryId): Promise<WordTimestamp[]> =>
     tauriInvoke('get_timestamps', { id }),
 
-  clearCache: (force: boolean): Promise<{ deleted_files: number; freed_bytes: number }> =>
-    tauriInvoke('clear_cache', { force }),
+  clearCache: (args: ClearCacheArgs): Promise<ClearCacheResult> =>
+    tauriInvoke('clear_cache', { args }),
 
   getCacheStats: (): Promise<{ total_bytes: number; audio_file_count: number }> =>
     tauriInvoke('get_cache_stats'),
+
+  getCacheDir: (): Promise<string> =>
+    tauriInvoke('get_cache_dir'),
 
   previewNormalize: (text: string): Promise<PreviewNormalizeResult> =>
     tauriInvoke('preview_normalize', { text }),
@@ -125,6 +142,7 @@ export const commands = {
 // --- Events (backend → frontend) ---
 
 export interface EntryUpdatedPayload { entry: TextEntry; }
+export interface EntryRemovedPayload { id: EntryId; }
 export interface PlaybackPositionPayload { position_sec: number; entry_id: EntryId; duration_sec: number | null; }
 export interface PlaybackStartedPayload { entry_id: EntryId; duration_sec: number | null; }
 export interface PlaybackPausedPayload { entry_id: EntryId; position_sec: number; }
@@ -136,6 +154,9 @@ export interface SynthesisProgressPayload { entry_id: EntryId; progress: number;
 export const events = {
   entryUpdated: (cb: (p: EntryUpdatedPayload) => void): Promise<UnlistenFn> =>
     tauriListen<EntryUpdatedPayload>('entry_updated', (e: Event<EntryUpdatedPayload>) => cb(e.payload)),
+
+  entryRemoved: (cb: (p: EntryRemovedPayload) => void): Promise<UnlistenFn> =>
+    tauriListen<EntryRemovedPayload>('entry_removed', (e: Event<EntryRemovedPayload>) => cb(e.payload)),
 
   playbackPosition: (cb: (p: PlaybackPositionPayload) => void): Promise<UnlistenFn> =>
     tauriListen<PlaybackPositionPayload>('playback_position', (e) => cb(e.payload)),


### PR DESCRIPTION
## Summary

- Replace days-based retention with size-based oldest-first eviction (driven by `max_cache_size_mb`).
- New `clear_cache(args: { mode, delete_texts })` command — `SizeLimit { target_mb }` / `All` modes.
- Settings → "Очистить кэш…" confirm dialog with target-MB input + "Удалять тексты" + "Очистить полностью".
- New `get_cache_dir` + "Открыть папку" button in Settings (uses `revealItemInDir`).
- Drop `auto_cleanup_days` from `UIConfig` (superseded by size eviction).
- Startup orphan-sweep + size-eviction (`StorageService::run_startup_cleanup`).
- New `entry_removed` event so the queue UI can drop rows when `delete_texts: true`.

## Cleanup dialog behavior

| Полностью | Удалять тексты | Effect |
|---|---|---|
| ☐ | ☐ | Audio of oldest entries deleted to N MB; entries stay with `audio_path: null` |
| ☐ | ☑ | Oldest entries deleted entirely (audio + text) until cache ≤ N MB |
| ☑ | ☐ | All audio deleted; entries stay |
| ☑ | ☑ | Full wipe — every entry and every audio file removed |

## Edge cases

- Files modified within the last ~60s are preserved by `sweep_orphans` to avoid racing with active synthesis writes.
- Entries in `processing` status are skipped by all eviction paths.
- `max_cache_size_mb = 0` is treated as "no limit" — orphan sweep still runs, eviction is a no-op.
- Startup cleanup always uses `delete_texts = false`; only the user-triggered Settings dialog can drop entries from history.

## Test plan

- [x] `cargo test` — 690 passed (incl. 11 new sweep/evict tests)
- [x] `cargo clippy --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `pnpm typecheck`
- [x] Manual: dev run, manual cleanup verified by user

## Notes

The other dead config fields (`history_days`, `audio_max_files`, `audio_regenerated_hours`) are out of scope here — tracked as a separate cleanup task.