### PR TITLE
chore(config): drop unused cache-policy fields

### DIFF
--- a/docs/ipc-contract.md
+++ b/docs/ipc-contract.md
@@ -70,9 +70,6 @@ interface UIConfig {
   notify_on_ready: boolean;      // Show system notification when synthesis completes
   notify_on_error: boolean;      // Show system notification on synthesis error
   text_format: string;           // Default viewer format: "plain" | "markdown" | "html"
-  history_days: number;          // Days to keep entries in history (0 = forever)
-  audio_max_files: number;       // Maximum number of audio files to keep in cache
-  audio_regenerated_hours: number; // Hours to keep manually regenerated audio
   max_cache_size_mb: number;     // Soft limit on audio cache size in MB; drives startup eviction (0 = disabled)
   code_block_mode: string;       // How to handle Markdown code blocks: "skip" | "read"
   read_operators: boolean;       // Whether to speak mathematical/code operators

--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -219,9 +219,6 @@ interface UIConfig {
   notify_on_ready: boolean;     // Show notification when synthesis completes
   notify_on_error: boolean;     // Show notification on synthesis error
   text_format: string;          // Default viewer format: "plain" | "markdown" | "html"
-  history_days: number;         // Days to keep entries in history
-  audio_max_files: number;      // Maximum number of audio files to keep
-  audio_regenerated_hours: number; // Hours to keep manually regenerated audio
   max_cache_size_mb: number;    // Soft limit on audio cache size in MB; drives startup eviction (0 = disabled)
   code_block_mode: string;      // How to handle Markdown code blocks: "skip" | "read"
   read_operators: boolean;      // Whether to speak mathematical/code operators
@@ -242,9 +239,6 @@ interface UIConfig {
 | `notify_on_ready` | `true` |
 | `notify_on_error` | `true` |
 | `text_format` | `"plain"` |
-| `history_days` | `14` |
-| `audio_max_files` | `5` |
-| `audio_regenerated_hours` | `24` |
 | `max_cache_size_mb` | `500` |
 | `code_block_mode` | `"read"` |
 | `read_operators` | `true` |
@@ -262,9 +256,6 @@ interface UIConfig {
   "notify_on_ready": true,
   "notify_on_error": true,
   "text_format": "plain",
-  "history_days": 14,
-  "audio_max_files": 5,
-  "audio_regenerated_hours": 24,
   "max_cache_size_mb": 500,
   "code_block_mode": "read",
   "read_operators": true,
@@ -318,9 +309,6 @@ Cross-reference between `docs/ipc-contract.md` types and the JSON fields in each
 | Notify on ready | `notify_on_ready` | — | yes | yes |
 | Notify on error | `notify_on_error` | — | yes | yes |
 | Text format | `text_format` | — | yes | yes |
-| History days | `history_days` | — | yes | yes |
-| Audio max files | `audio_max_files` | — | yes | yes |
-| Audio regen hours | `audio_regenerated_hours` | — | yes | yes |
 | Max cache MB | `max_cache_size_mb` | — | yes | yes |
 | Code block mode | `code_block_mode` | — | yes | yes |
 | Read operators | `read_operators` | — | yes | yes |

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -795,15 +795,6 @@ fn apply_config_patch(config: &mut UIConfig, patch: UIConfigPatch) {
     if let Some(v) = patch.text_format {
         config.text_format = v;
     }
-    if let Some(v) = patch.history_days {
-        config.history_days = v;
-    }
-    if let Some(v) = patch.audio_max_files {
-        config.audio_max_files = v;
-    }
-    if let Some(v) = patch.audio_regenerated_hours {
-        config.audio_regenerated_hours = v;
-    }
     if let Some(v) = patch.max_cache_size_mb {
         config.max_cache_size_mb = v;
     }

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -87,12 +87,6 @@ pub struct UIConfig {
     pub notify_on_error: bool,
     #[serde(default = "UIConfig::default_text_format")]
     pub text_format: String,
-    #[serde(default = "UIConfig::default_history_days")]
-    pub history_days: u32,
-    #[serde(default = "UIConfig::default_audio_max_files")]
-    pub audio_max_files: u32,
-    #[serde(default = "UIConfig::default_audio_regenerated_hours")]
-    pub audio_regenerated_hours: u32,
     #[serde(default = "UIConfig::default_max_cache_size_mb")]
     pub max_cache_size_mb: u32,
     /// How to handle Markdown code blocks: `"skip"` | `"read"`. Defaults to `"read"`.
@@ -126,15 +120,6 @@ impl UIConfig {
     }
     fn default_text_format() -> String {
         "plain".to_string()
-    }
-    fn default_history_days() -> u32 {
-        14
-    }
-    fn default_audio_max_files() -> u32 {
-        5
-    }
-    fn default_audio_regenerated_hours() -> u32 {
-        24
     }
     fn default_max_cache_size_mb() -> u32 {
         500
@@ -171,9 +156,6 @@ impl Default for UIConfig {
             notify_on_ready: true,
             notify_on_error: true,
             text_format: Self::default_text_format(),
-            history_days: Self::default_history_days(),
-            audio_max_files: Self::default_audio_max_files(),
-            audio_regenerated_hours: Self::default_audio_regenerated_hours(),
             max_cache_size_mb: Self::default_max_cache_size_mb(),
             code_block_mode: Self::default_code_block_mode(),
             read_operators: true,
@@ -195,9 +177,6 @@ pub struct UIConfigPatch {
     pub notify_on_ready: Option<bool>,
     pub notify_on_error: Option<bool>,
     pub text_format: Option<String>,
-    pub history_days: Option<u32>,
-    pub audio_max_files: Option<u32>,
-    pub audio_regenerated_hours: Option<u32>,
     pub max_cache_size_mb: Option<u32>,
     pub code_block_mode: Option<String>,
     pub read_operators: Option<bool>,
@@ -276,8 +255,7 @@ mod tests {
         assert!((c.speech_rate - 1.0).abs() < f64::EPSILON);
         assert!(c.notify_on_ready);
         assert!(c.notify_on_error);
-        assert_eq!(c.history_days, 14);
-        assert_eq!(c.audio_max_files, 5);
+        assert_eq!(c.max_cache_size_mb, 500);
         assert!(!c.speaker.is_empty());
     }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -39,9 +39,6 @@ export interface UIConfig {
   notify_on_ready: boolean;
   notify_on_error: boolean;
   text_format: string;
-  history_days: number;
-  audio_max_files: number;
-  audio_regenerated_hours: number;
   max_cache_size_mb: number;
   code_block_mode: string;
   read_operators: boolean;


### PR DESCRIPTION
## Summary

Remove `history_days`, `audio_max_files`, and `audio_regenerated_hours` from `UIConfig`, `UIConfigPatch`, `apply_config_patch`, the TS `UIConfig` mirror, and the docs.

These fields shipped as TODO scaffolding for count-based and time-based retention policies that were never implemented. The new size-based eviction (PR #23) supersedes them.

## Why

Same reasoning as the earlier `auto_cleanup_days` removal: serde will silently ignore the keys when reading older `config.json` files, so no migration is needed. Keeping unused fields in the public IPC schema invites callers to set them and reason about behavior that doesn't exist.

## Test plan

- [x] `cargo test` (passed locally)
- [x] `cargo clippy --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] `pnpm typecheck`