### PR TITLE
feat(queue): regenerate audio context-menu item

### DIFF
--- a/docs/ipc-contract.md
+++ b/docs/ipc-contract.md
@@ -230,6 +230,20 @@ invoke("delete_audio", { id: EntryId }): Promise<void>
 
 ---
 
+### `regenerate_entry`
+
+Re-synthesize an existing entry: drop its current audio + timestamps, reset status to `"pending"` (with `was_regenerated: true`, `error_message: null`), then kick off background synthesis using the current config (`speaker`, `speech_rate`, etc.). If the entry is currently playing, playback is stopped first.
+
+```typescript
+invoke("regenerate_entry", { id: EntryId }): Promise<void>
+```
+
+**Errors:** `not_found` if no entry with this ID exists; `synthesis_error` if the entry is already being synthesized (`status === "processing"`); `storage_error` on file deletion failure.
+
+**Side effects:** Emits `entry_updated` (status `"pending"` → later `"processing"` → `"ready"`); may emit `playback_stopped` if the entry was playing; may emit `tts_error` on synthesis failure.
+
+---
+
 ### `cancel_synthesis`
 
 Cancel an in-progress or queued synthesis job. If the entry is currently being synthesized, the job is aborted. Entry status is set to `"pending"`.
@@ -461,6 +475,7 @@ Emitted whenever a `TextEntry` is created or its fields change (status, audio_pa
 - When synthesis fails (status: `"error"`, error_message set).
 - When playback starts/stops (status: `"playing"` / `"ready"`).
 - After `delete_audio` (status reset to `"pending"`).
+- After `regenerate_entry` (status reset to `"pending"` with `was_regenerated: true`, then advances through `"processing"` → `"ready"`).
 - After `cancel_synthesis`.
 - After `clear_cache` for each entry whose audio was reset (`delete_texts: false`).
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -464,6 +464,72 @@ pub async fn delete_audio(
     Ok(())
 }
 
+/// Regenerate audio for an existing entry: drop its current audio + timestamps,
+/// reset status to `Pending`, and re-run the synthesis pipeline. Useful when
+/// the user has changed `speaker`, `speech_rate`, or other normalization
+/// settings and wants the cached audio to reflect them.
+///
+/// Rejects the call if the entry is currently being synthesized — re-entering
+/// `spawn_synthesis` for the same id would race with the in-flight task.
+#[tauri::command]
+pub async fn regenerate_entry(
+    app: AppHandle<Wry>,
+    state: State<'_, AppState>,
+    id: String,
+) -> CmdResult<()> {
+    let uuid = parse_entry_id(&id)?;
+
+    let entry = state
+        .storage
+        .get_entry(&uuid)
+        .ok_or_else(|| CommandError::NotFound {
+            message: format!("entry not found: {id}"),
+        })?;
+
+    if entry.status == EntryStatus::Processing {
+        return Err(CommandError::SynthesisError {
+            message: "запись уже синтезируется".to_string(),
+        });
+    }
+
+    // If this entry is currently playing, stop playback so the about-to-be-
+    // deleted audio file is not held open by the player.
+    if state.player.current_entry_id().as_deref() == Some(&id) {
+        let _ = state.player.stop();
+    }
+
+    state
+        .storage
+        .delete_audio(&uuid)
+        .map_err(CommandError::from)?;
+
+    let mut entry = state
+        .storage
+        .get_entry(&uuid)
+        .ok_or_else(|| CommandError::NotFound {
+            message: format!("entry vanished after delete_audio: {id}"),
+        })?;
+    entry.was_regenerated = true;
+    entry.error_message = None;
+    state
+        .storage
+        .update_entry(entry.clone())
+        .map_err(CommandError::from)?;
+    emit_entry_updated(&app, &entry);
+
+    spawn_synthesis(
+        app,
+        Arc::clone(&state.storage),
+        Arc::clone(&state.tts),
+        Arc::clone(&state.player),
+        Arc::clone(&state.pipeline),
+        uuid,
+        false,
+    );
+
+    Ok(())
+}
+
 /// Cancel an in-progress or queued synthesis job.
 /// Currently marks entry as pending (mid-request abort is not supported since
 /// TtsSubprocess serializes all requests into a single channel).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -285,6 +285,7 @@ pub fn run() {
             get_entry,
             delete_entry,
             delete_audio,
+            regenerate_entry,
             cancel_synthesis,
             play_entry,
             pause_playback,

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -10,6 +10,7 @@ import {
   Menu,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
+import { notifications } from '@mantine/notifications';
 import { commands, events } from '../lib/tauri';
 import type { TextEntry, EntryStatus, EntryId, UnlistenFn } from '../lib/tauri';
 import { useSelectedEntry } from '../stores/selectedEntry';
@@ -210,6 +211,24 @@ export function QueueList() {
     await commands.playEntry(id);
   }, []);
 
+  const handleRegenerate = useCallback(async (id: string) => {
+    try {
+      await commands.regenerateEntry(id);
+      notifications.show({
+        title: 'Перегенерация',
+        message: 'Запущена перегенерация аудио',
+        color: 'blue',
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      notifications.show({
+        title: 'Ошибка',
+        message: `Не удалось запустить перегенерацию: ${message}`,
+        color: 'red',
+      });
+    }
+  }, []);
+
   const handleDelete = useCallback(
     (id: string) => {
       modals.openConfirmModal({
@@ -292,6 +311,12 @@ export function QueueList() {
             onClick={() => menu && handlePlay(menu.entry.id)}
           >
             Воспроизвести
+          </Menu.Item>
+          <Menu.Item
+            disabled={menu === null || menu.entry.status === 'processing'}
+            onClick={() => menu && handleRegenerate(menu.entry.id)}
+          >
+            Перегенерировать аудио
           </Menu.Item>
           <Menu.Divider />
           <Menu.Item

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -90,6 +90,9 @@ export const commands = {
   deleteAudio: (id: EntryId): Promise<void> =>
     tauriInvoke('delete_audio', { id }),
 
+  regenerateEntry: (id: EntryId): Promise<void> =>
+    tauriInvoke('regenerate_entry', { id }),
+
   cancelSynthesis: (id: EntryId): Promise<void> =>
     tauriInvoke('cancel_synthesis', { id }),
 


### PR DESCRIPTION
## Summary
- New `regenerate_entry(id)` Tauri command: drops audio + timestamps, sets `was_regenerated: true`, kicks off background synthesis with the current config (speaker / sample_rate / speech_rate).
- Adds "Перегенерировать аудио" item to the queue right-click menu (disabled when `status === 'processing'`); shows a notification on dispatch.
- Stops playback first if the entry is currently playing, so the audio file is not held open during deletion.
- Documents the new command + flow in `docs/ipc-contract.md`.

## Test plan
- [x] cargo fmt + clippy + test — clean
- [x] pnpm typecheck — clean
- [x] Right-click a `ready` entry → "Перегенерировать аудио" → entry transitions pending → processing → ready with refreshed audio.
- [x] Right-click a `processing` entry → menu item is disabled.
- [x] Right-click the currently playing entry → playback stops before re-synthesis.
- [x] Right-click an `error` entry → regeneration clears `error_message`.

Closes task #10.