### PR TITLE
feat(window): start the main window maximized

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,8 @@
         "title": "RuVox",
         "width": 900,
         "height": 600,
-        "resizable": true
+        "resizable": true,
+        "maximized": true
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary
- Adds `"maximized": true` to the main window in `src-tauri/tauri.conf.json` so RuVox starts maximized on every launch instead of opening at the cramped 900x600 default.

## Test plan
- [x] App launches maximized (verified locally with `pnpm tauri dev`).