### PR TITLE
feat(queue): add jump-to-currently-playing button

### DIFF
--- a/src/components/QueueList.module.css
+++ b/src/components/QueueList.module.css
@@ -56,5 +56,22 @@
 }
 
 .scrollArea {
-  height: 100%;
+  flex: 1;
+  min-height: 0;
+}
+
+.container {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.jumpToPlaying {
+  position: absolute;
+  bottom: 12px;
+  right: 16px;
+  z-index: 5;
+  box-shadow: var(--mantine-shadow-md);
 }

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import {
   Stack,
   Group,
@@ -8,13 +8,14 @@ import {
   ScrollArea,
   Loader,
   Menu,
+  Button,
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { commands, events } from '../lib/tauri';
 import type { TextEntry, EntryStatus, EntryId, UnlistenFn } from '../lib/tauri';
 import { useSelectedEntry } from '../stores/selectedEntry';
-import { IconPlay } from './icons';
+import { IconPlay, IconLocate } from './icons';
 import classes from './QueueList.module.css';
 
 function formatDuration(seconds: number): string {
@@ -78,6 +79,7 @@ function QueueItem({ entry, isSelected, isPlaying, onSelect, onPlay, onContextMe
   return (
     <div
       className={itemClass}
+      data-entry-id={entry.id}
       onClick={() => onSelect(entry)}
       onContextMenu={(e) => {
         e.preventDefault();
@@ -137,6 +139,8 @@ function QueueItem({ entry, isSelected, isPlaying, onSelect, onPlay, onContextMe
 export function QueueList() {
   const [entries, setEntries] = useState<TextEntry[]>([]);
   const [playingId, setPlayingId] = useState<EntryId | null>(null);
+  const [playingVisible, setPlayingVisible] = useState(true);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const { selectedId, setSelectedEntry } = useSelectedEntry();
   // Single Menu instance shared by all queue items — cheaper than one per item
   // and avoids stacking many hidden Menu portals that can interfere with other
@@ -207,6 +211,36 @@ export function QueueList() {
     };
   }, [loadEntries]);
 
+  // Track whether the playing entry is currently visible in the viewport so we
+  // only surface the "jump to current" button when the user has scrolled away.
+  useEffect(() => {
+    if (!playingId || !viewportRef.current) {
+      setPlayingVisible(true);
+      return;
+    }
+    const target = viewportRef.current.querySelector<HTMLElement>(
+      `[data-entry-id="${CSS.escape(playingId)}"]`,
+    );
+    if (!target) {
+      setPlayingVisible(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => setPlayingVisible(entry.intersectionRatio >= 1),
+      { root: viewportRef.current, threshold: [0, 1] },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [playingId, entries]);
+
+  const handleJumpToPlaying = useCallback(() => {
+    if (!playingId || !viewportRef.current) return;
+    const target = viewportRef.current.querySelector<HTMLElement>(
+      `[data-entry-id="${CSS.escape(playingId)}"]`,
+    );
+    target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [playingId]);
+
   const handlePlay = useCallback(async (id: string) => {
     await commands.playEntry(id);
   }, []);
@@ -261,8 +295,8 @@ export function QueueList() {
   }
 
   return (
-    <>
-      <ScrollArea className={classes.scrollArea}>
+    <div className={classes.container}>
+      <ScrollArea className={classes.scrollArea} viewportRef={viewportRef}>
         <Stack gap={4}>
           {entries.map((entry) => (
             <QueueItem
@@ -277,6 +311,22 @@ export function QueueList() {
           ))}
         </Stack>
       </ScrollArea>
+
+      {playingId !== null && !playingVisible && (
+        <Button
+          className={classes.jumpToPlaying}
+          size="compact-xs"
+          radius="xl"
+          variant="filled"
+          color="teal"
+          leftSection={<IconLocate />}
+          onClick={handleJumpToPlaying}
+          title="К читаемому"
+          aria-label="К читаемому"
+        >
+          К читаемому
+        </Button>
+      )}
 
       <Menu
         opened={menu !== null}
@@ -327,6 +377,6 @@ export function QueueList() {
           </Menu.Item>
         </Menu.Dropdown>
       </Menu>
-    </>
+    </div>
   );
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -62,6 +62,31 @@ export function IconAppLogo({ size = 26, className }: IconProps) {
   );
 }
 
+export function IconLocate({ size = 14, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      focusable={false}
+      className={className}
+    >
+      <circle cx="12" cy="12" r="8" />
+      <circle cx="12" cy="12" r="2.5" fill="currentColor" stroke="none" />
+      <line x1="12" y1="2" x2="12" y2="5" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+      <line x1="2" y1="12" x2="5" y2="12" />
+      <line x1="19" y1="12" x2="22" y2="12" />
+    </svg>
+  );
+}
+
 export function IconSettings({ size = 18, className }: IconProps) {
   return (
     <svg


### PR DESCRIPTION
## Summary

- Floating "К читаемому" button appears in the queue bottom-right corner whenever audio is playing and the playing entry has been scrolled out of view.
- Visibility is tracked via `IntersectionObserver` against the `ScrollArea` viewport (`viewportRef`).
- Clicking the button smooth-scrolls the entry into the centre of the viewport.
- Replaced the old `height: 100%` shortcut on `.scrollArea` with `flex: 1; min-height: 0`, which is the correct idiom for a scrollable child of a flex column.

## Test plan

- [x] `pnpm typecheck` clean
- [x] Manual: with playback active and the entry scrolled off-screen, the button shows up; clicking it brings the entry into view.
- [x] Manual: button hides when the entry is already visible.
- [x] Manual: button disappears on stop / finish.