### PR TITLE
feat(queue): add text search filter to queue navbar

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,14 @@
-import { AppShell as MantineAppShell, Title, Group, Button, useMantineColorScheme } from '@mantine/core';
+import {
+  AppShell as MantineAppShell,
+  Title,
+  Group,
+  Button,
+  TextInput,
+  CloseButton,
+  useMantineColorScheme,
+} from '@mantine/core';
 import type { MantineColorScheme } from '@mantine/core';
+import { useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { useState, useEffect, useRef } from 'react';
 import { readText as readClipboardText } from '@tauri-apps/plugin-clipboard-manager';
@@ -10,8 +19,10 @@ import { TextViewer } from './TextViewer';
 import { Player } from './Player';
 import { QueueList } from './QueueList';
 import { useSelectedEntry } from '../stores/selectedEntry';
+import { useSearchQuery } from '../stores/searchQuery';
 import { PreviewDialog } from '../dialogs/PreviewDialog';
 import { SettingsModal } from '../dialogs/Settings';
+import { IconSearch } from './icons';
 
 export function AppShell() {
   const { selectedEntry } = useSelectedEntry();
@@ -28,6 +39,19 @@ export function AppShell() {
     startX: number;
     originW: number;
   } | null>(null);
+  const { query, setQuery } = useSearchQuery();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Ctrl+F / Cmd+F focuses the queue search field. preventDefault stops the
+  // webview's built-in "find in page" behaviour so the hotkey is consistent
+  // across platforms.
+  useHotkeys([
+    [
+      'mod+F',
+      () => searchInputRef.current?.focus(),
+      { preventDefault: true },
+    ],
+  ]);
 
   function onNavResizeDown(e: React.PointerEvent<HTMLDivElement>) {
     e.preventDefault();
@@ -198,6 +222,32 @@ export function AppShell() {
               Add
             </Button>
           </Group>
+          <TextInput
+            ref={searchInputRef}
+            placeholder="Поиск по записям"
+            value={query}
+            onChange={(e) => setQuery(e.currentTarget.value)}
+            leftSection={<IconSearch />}
+            rightSection={
+              query ? (
+                <CloseButton
+                  size="sm"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setQuery('')}
+                  aria-label="Очистить поиск"
+                />
+              ) : null
+            }
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setQuery('');
+                e.currentTarget.blur();
+              }
+            }}
+            size="xs"
+            mb="xs"
+          />
           <QueueList />
           <div
             onPointerDown={onNavResizeDown}

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import {
   Stack,
   Group,
@@ -15,6 +15,7 @@ import { notifications } from '@mantine/notifications';
 import { commands, events } from '../lib/tauri';
 import type { TextEntry, EntryStatus, EntryId, UnlistenFn } from '../lib/tauri';
 import { useSelectedEntry } from '../stores/selectedEntry';
+import { useSearchQuery } from '../stores/searchQuery';
 import { IconPlay, IconLocate } from './icons';
 import classes from './QueueList.module.css';
 
@@ -142,6 +143,12 @@ export function QueueList() {
   const [playingVisible, setPlayingVisible] = useState(true);
   const viewportRef = useRef<HTMLDivElement>(null);
   const { selectedId, setSelectedEntry } = useSelectedEntry();
+  const { query } = useSearchQuery();
+  const filteredEntries = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter((e) => e.original_text.toLowerCase().includes(q));
+  }, [entries, query]);
   // Single Menu instance shared by all queue items — cheaper than one per item
   // and avoids stacking many hidden Menu portals that can interfere with other
   // popovers (e.g. the theme dropdown in the header).
@@ -231,7 +238,7 @@ export function QueueList() {
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [playingId, entries]);
+  }, [playingId, filteredEntries]);
 
   const handleJumpToPlaying = useCallback(() => {
     if (!playingId || !viewportRef.current) return;
@@ -286,31 +293,33 @@ export function QueueList() {
     [selectedId, setSelectedEntry],
   );
 
-  if (entries.length === 0) {
-    return (
-      <Text c="dimmed" size="sm" ta="center" mt="md">
-        Скопируйте текст и нажмите Add
-      </Text>
-    );
-  }
-
   return (
     <div className={classes.container}>
-      <ScrollArea className={classes.scrollArea} viewportRef={viewportRef}>
-        <Stack gap={4}>
-          {entries.map((entry) => (
-            <QueueItem
-              key={entry.id}
-              entry={entry}
-              isSelected={selectedId === entry.id}
-              isPlaying={playingId === entry.id}
-              onSelect={setSelectedEntry}
-              onPlay={handlePlay}
-              onContextMenu={(e, x, y) => setMenu({ entry: e, x, y })}
-            />
-          ))}
-        </Stack>
-      </ScrollArea>
+      {entries.length === 0 ? (
+        <Text c="dimmed" size="sm" ta="center" mt="md">
+          Скопируйте текст и нажмите Add
+        </Text>
+      ) : filteredEntries.length === 0 ? (
+        <Text c="dimmed" size="sm" ta="center" mt="md">
+          Ничего не найдено
+        </Text>
+      ) : (
+        <ScrollArea className={classes.scrollArea} viewportRef={viewportRef}>
+          <Stack gap={4}>
+            {filteredEntries.map((entry) => (
+              <QueueItem
+                key={entry.id}
+                entry={entry}
+                isSelected={selectedId === entry.id}
+                isPlaying={playingId === entry.id}
+                onSelect={setSelectedEntry}
+                onPlay={handlePlay}
+                onContextMenu={(e, x, y) => setMenu({ entry: e, x, y })}
+              />
+            ))}
+          </Stack>
+        </ScrollArea>
+      )}
 
       {playingId !== null && !playingVisible && (
         <Button

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -62,6 +62,27 @@ export function IconAppLogo({ size = 26, className }: IconProps) {
   );
 }
 
+export function IconSearch({ size = 14, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      focusable={false}
+      className={className}
+    >
+      <circle cx="11" cy="11" r="7" />
+      <line x1="20" y1="20" x2="16.65" y2="16.65" />
+    </svg>
+  );
+}
+
 export function IconLocate({ size = 14, className }: IconProps) {
   return (
     <svg

--- a/src/stores/searchQuery.ts
+++ b/src/stores/searchQuery.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface SearchQueryState {
+  query: string;
+  setQuery: (q: string) => void;
+}
+
+export const useSearchQuery = create<SearchQueryState>((set) => ({
+  query: '',
+  setQuery: (query) => set({ query }),
+}));


### PR DESCRIPTION
Closes #9.

## Summary

- New search field above the queue list (`AppShell` navbar) — Mantine `TextInput` with a magnifier icon, X button to clear, placeholder «Поиск по записям».
- Case-insensitive substring filtering against `original_text` in `QueueList`. Sort order is unchanged; empty field shows the full list.
- Query lives in a tiny Zustand store (`src/stores/searchQuery.ts`) so input and list stay in sync without prop drilling.
- `Ctrl+F` / `Cmd+F` focuses the field globally and suppresses the webview's built-in find-in-page. `Esc` while focused clears the field and blurs.
- Empty-state «Ничего не найдено» when the filter matches nothing; the old «Скопируйте текст и нажмите Add» still shows when there are no entries at all.

## Test plan

- [x] `pnpm typecheck` clean
- [x] Manual: search field renders, lupe icon and X clear button work as expected.
- [x] Manual: typing «getUser» (any case) filters the list to matching entries; clearing restores everything.
- [x] Manual: `Ctrl+F` focuses the field from anywhere; webview "find in page" no longer pops up.
- [x] Manual: `Esc` in the field clears + blurs.
- [x] Manual: «Ничего не найдено» shows when filter matches nothing; original empty-state still works.