### PR TITLE
fix(queue): jump-to-playing also selects the playing entry

### DIFF
--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -242,11 +242,15 @@ export function QueueList() {
 
   const handleJumpToPlaying = useCallback(() => {
     if (!playingId || !viewportRef.current) return;
+    if (selectedId !== playingId) {
+      const playingEntry = entries.find((e) => e.id === playingId);
+      if (playingEntry) setSelectedEntry(playingEntry);
+    }
     const target = viewportRef.current.querySelector<HTMLElement>(
       `[data-entry-id="${CSS.escape(playingId)}"]`,
     );
     target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  }, [playingId]);
+  }, [playingId, selectedId, entries, setSelectedEntry]);
 
   const handlePlay = useCallback(async (id: string) => {
     await commands.playEntry(id);


### PR DESCRIPTION
## Summary

Follow-up tweak to the "К читаемому" button (#30): when the currently selected
queue entry is not the playing one, clicking the button now also moves the
selection to the playing entry (so `TextViewer` swaps to its content) before
smooth-scrolling.

## Test plan

- [x] `pnpm typecheck` clean
- [x] Manual: select a non-playing entry, scroll the queue away, click
      «К читаемому» — playing entry becomes the selected one and gets
      scrolled into view.
- [x] Manual: when the playing entry is already selected, clicking the
      button just scrolls (no selection thrash).