### PR TITLE
feat(tts): supervise ttsd subprocess and auto-respawn on crash

### DIFF
--- a/docs/ipc-contract.md
+++ b/docs/ipc-contract.md
@@ -791,13 +791,26 @@ type ErrorCode =
 
 ### ttsd Auto-restart
 
-If ttsd exits unexpectedly (crash, SIGKILL from OOM killer), Rust detects the process exit and:
-1. Logs a `tracing::warn!` message.
-2. Spawns a new ttsd process.
-3. Sends `warmup` again.
-4. Re-emits `model_loading` to frontend.
+If ttsd exits unexpectedly (crash, SIGKILL from OOM killer), the
+`TtsSupervisor` (`src-tauri/src/tts/supervisor.rs`) detects the process exit
+on the next request that hits `TtsError::Died` and:
 
-Any in-flight synthesis request that was sent to the crashed process is marked as failed with `synthesis_failed`.
+1. Logs a `tracing::warn!` message.
+2. Emits `ttsd_restarting` (no payload) so the UI can show a "TTS
+   перезапускается" toast.
+3. Tries to spawn a fresh ttsd up to 3 times with backoff `1s / 3s / 5s`.
+4. On the first successful respawn it kicks off `warmup` in a background
+   task and re-emits `model_loading` → `model_loaded` (or `model_error` on
+   failure) so the frontend sees the same lifecycle as on startup.
+5. If all three respawn attempts fail, it emits
+   `tts_fatal { message: string }` and surfaces the spawn error to the
+   caller. Every pending entry whose synthesis was waiting will go to the
+   `error` state via the normal command-error path.
+
+Any in-flight synthesis request that was sent to the crashed process is
+marked as failed with `synthesis_failed`. The next request after a fatal
+state still triggers the supervisor to retry, so the system can recover if
+e.g. ttsd dependencies were briefly unavailable.
 
 ---
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,9 @@ byteorder = "1.5"
 tempfile = "3"
 similar = "2"
 filetime = "0.2"
+# `test-util` enables `#[tokio::test(start_paused = true)]` so the supervisor
+# backoff schedule (1s/3s/5s) doesn't make tests sleep for ~9s.
+tokio = { version = "1", features = ["test-util"] }
 
 [profile.release]
 codegen-units = 1

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -96,7 +96,7 @@ fn char_mapping_to_entries(mapping: &CharMapping) -> Vec<CharMappingEntry> {
 pub fn spawn_synthesis_pub<R: Runtime + 'static>(
     app: AppHandle<R>,
     storage: Arc<StorageService>,
-    tts: Arc<crate::tts::TtsSubprocess>,
+    tts: Arc<crate::tts::TtsSupervisor>,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<parking_lot::Mutex<crate::pipeline::TTSPipeline>>,
     entry_id: EntryId,
@@ -125,7 +125,7 @@ pub fn spawn_synthesis_pub<R: Runtime + 'static>(
 fn spawn_synthesis<R: Runtime + 'static>(
     app: AppHandle<R>,
     storage: Arc<StorageService>,
-    tts: Arc<crate::tts::TtsSubprocess>,
+    tts: Arc<crate::tts::TtsSupervisor>,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<parking_lot::Mutex<crate::pipeline::TTSPipeline>>,
     entry_id: EntryId,
@@ -532,7 +532,7 @@ pub async fn regenerate_entry(
 
 /// Cancel an in-progress or queued synthesis job.
 /// Currently marks entry as pending (mid-request abort is not supported since
-/// TtsSubprocess serializes all requests into a single channel).
+/// the TTS supervisor serialises all requests into a single channel).
 #[tauri::command]
 pub async fn cancel_synthesis(
     app: AppHandle<Wry>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,12 +175,33 @@ pub fn run() {
                 }
             };
 
+            // Build a command factory the supervisor can call on every
+            // (re)spawn. Cloning the path captured by value keeps the closure
+            // `Fn` (not `FnOnce`) — required for the Arc<dyn Fn(...)> shape.
+            let ttsd_dir_for_factory = ttsd_dir.clone();
+            let factory: tts::supervisor::CommandFactory = Arc::new(move || {
+                let mut cmd = tokio::process::Command::new("uv");
+                cmd.args(["run", "python", "-m", "ttsd"])
+                    .current_dir(&ttsd_dir_for_factory);
+                cmd
+            });
+
+            // Emitter for ttsd_restarting / tts_fatal (and the model_*
+            // lifecycle re-emitted from supervisor.spawn_warmup).
+            let app_handle_for_emitter = app.handle().clone();
+            let emitter: tts::supervisor::Emitter =
+                Arc::new(move |event_name, payload| {
+                    let _ = app_handle_for_emitter.emit(event_name, payload);
+                });
+
             // tokio::process::Command::spawn requires an active tokio runtime
             // context; setup hook runs synchronously, so enter Tauri's runtime
             // explicitly via block_on (the inner spawn returns instantly).
             let tts = Arc::new(
-                tauri::async_runtime::block_on(async move { tts::TtsSubprocess::spawn(ttsd_dir) })
-                    .expect("failed to spawn ttsd subprocess"),
+                tauri::async_runtime::block_on(async move {
+                    tts::TtsSupervisor::spawn(factory, emitter)
+                })
+                .expect("failed to spawn ttsd subprocess"),
             );
 
             // Warm up Silero model in background; emit model_loading → model_loaded/model_error.

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7,7 +7,7 @@ use crate::pipeline::TTSPipeline;
 use crate::player::Player;
 use crate::storage::service::StorageService;
 use crate::tray::TrayCmd;
-use crate::tts::TtsSubprocess;
+use crate::tts::TtsSupervisor;
 
 /// Application-wide state held in `tauri::State<AppState>`.
 ///
@@ -16,7 +16,7 @@ use crate::tts::TtsSubprocess;
 /// `tauri::generate_handler!`.
 pub struct AppState {
     pub storage: Arc<StorageService>,
-    pub tts: Arc<TtsSubprocess>,
+    pub tts: Arc<TtsSupervisor>,
     pub player: Arc<Player<tauri::Wry>>,
     pub pipeline: Arc<Mutex<TTSPipeline>>,
     /// Sender for tray menu commands (read_now / read_later).

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -5,8 +5,12 @@
 //! matches ttsd's own single-threaded design.
 //!
 //! # Auto-restart
-//! TODO: v1 does not auto-restart on crash. The driver task exits when the subprocess
-//! dies. Callers must detect the `Died` error and re-create via `TtsSubprocess::spawn()`.
+//! `TtsSubprocess` itself is single-shot — it does not respawn on crash; the
+//! driver task exits when the subprocess dies and subsequent calls return
+//! [`TtsError::Died`]. Crash recovery is layered on top in [`supervisor`].
+
+pub mod supervisor;
+pub use supervisor::TtsSupervisor;
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -182,16 +186,25 @@ impl TtsSubprocess {
     ///
     /// `ttsd_dir` is the directory from which `uv run python -m ttsd` is executed.
     pub fn spawn(ttsd_dir: PathBuf) -> Result<Self, TtsError> {
-        let child = Command::new("uv")
-            .args(["run", "python", "-m", "ttsd"])
-            .current_dir(&ttsd_dir)
-            .stdin(std::process::Stdio::piped())
+        let mut cmd = Command::new("uv");
+        cmd.args(["run", "python", "-m", "ttsd"])
+            .current_dir(ttsd_dir);
+        Self::spawn_with_command(cmd)
+    }
+
+    /// Lower-level constructor: takes a fully-built [`Command`] and wires its
+    /// stdio + a driver task. Stdin/stdout/stderr are forced to `piped` and
+    /// `kill_on_drop` is set, regardless of what the caller configured.
+    ///
+    /// Used by [`supervisor::TtsSupervisor`] to inject a respawn-friendly
+    /// command factory and by integration tests to point at mock binaries.
+    pub fn spawn_with_command(mut cmd: Command) -> Result<Self, TtsError> {
+        cmd.stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            // kill_on_drop: process is killed when the Child value is dropped
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(TtsError::Spawn)?;
+            .kill_on_drop(true);
+
+        let child = cmd.spawn().map_err(TtsError::Spawn)?;
 
         let (tx, rx) = mpsc::channel::<DriverRequest>(1);
         tokio::spawn(driver_task(child, rx));

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -1,0 +1,308 @@
+//! Supervisor that owns a [`TtsSubprocess`] and respawns it transparently
+//! when the underlying process dies.
+//!
+//! # Behaviour
+//! - Concurrent callers share the current handle via an [`RwLock`] read guard
+//!   (the inner `TtsSubprocess` already serialises requests through its own
+//!   single-slot mpsc channel, so nothing is lost by sharing).
+//! - On a [`TtsError::Died`] return value the supervisor takes the write lock
+//!   and respawns. A simple [`Arc::ptr_eq`] check makes the respawn
+//!   single-flight: a second caller that hits the same dead process will see
+//!   the freshly-installed handle and just retry.
+//! - Retry policy: 3 attempts with 1s/3s/5s backoffs. After the third failure
+//!   the supervisor emits `tts_fatal` and surfaces the spawn error to the
+//!   caller; subsequent calls will keep returning `Died` until the supervisor
+//!   manages to spawn a fresh process.
+//! - After every successful respawn the supervisor kicks off `warmup` in the
+//!   background and re-emits `model_loading` / `model_loaded` (or
+//!   `model_error`) so the UI can mirror the lifecycle without a separate
+//!   code path.
+//!
+//! Only [`TtsError::Died`] triggers a respawn. Protocol errors
+//! (`TtsError::Ttsd`) and `TtsError::Timeout` are propagated as-is — they do
+//! not indicate a dead process.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::process::Command;
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+use super::{CharMappingEntry, SynthesizeOutput, TtsError, TtsSubprocess};
+
+/// Backoff schedule for respawn attempts. Each entry is the delay *before*
+/// the corresponding spawn attempt (1s, 3s, 5s). Three entries → up to three
+/// attempts; if all three fail the supervisor emits `tts_fatal`.
+const BACKOFFS: [Duration; 3] = [
+    Duration::from_secs(1),
+    Duration::from_secs(3),
+    Duration::from_secs(5),
+];
+
+/// Emitter callback — abstracts away `tauri::AppHandle` so the supervisor
+/// can be unit/integration-tested without a Tauri runtime.
+pub type Emitter = Arc<dyn Fn(&str, serde_json::Value) + Send + Sync>;
+
+/// Factory that builds the [`Command`] used to spawn ttsd. Called once per
+/// spawn attempt — must be idempotent.
+pub type CommandFactory = Arc<dyn Fn() -> Command + Send + Sync>;
+
+pub struct TtsSupervisor {
+    /// Current live handle. `None` only between a failed respawn and the
+    /// next successful one.
+    current: RwLock<Option<Arc<TtsSubprocess>>>,
+    /// Held only across respawn attempts to make them single-flight.
+    respawn_lock: Mutex<()>,
+    factory: CommandFactory,
+    emitter: Emitter,
+}
+
+impl TtsSupervisor {
+    /// Spawn the initial ttsd process and wrap it in a supervisor.
+    ///
+    /// Returns an error if the very first spawn fails — there is nothing to
+    /// recover from at startup, so failure is surfaced to the caller rather
+    /// than entering retry loops.
+    pub fn spawn(factory: CommandFactory, emitter: Emitter) -> Result<Self, TtsError> {
+        let cmd = factory();
+        let initial = TtsSubprocess::spawn_with_command(cmd)?;
+        Ok(Self {
+            current: RwLock::new(Some(Arc::new(initial))),
+            respawn_lock: Mutex::new(()),
+            factory,
+            emitter,
+        })
+    }
+
+    /// Return the current handle, cloning the inner `Arc` so the read lock
+    /// is released immediately. `None` means we are between respawns.
+    async fn current_handle(&self) -> Option<Arc<TtsSubprocess>> {
+        self.current.read().await.clone()
+    }
+
+    /// Run an operation against the current ttsd handle, respawning on
+    /// [`TtsError::Died`]. Other errors are returned immediately.
+    async fn with_retry<F, Fut, T>(&self, op: F) -> Result<T, TtsError>
+    where
+        F: Fn(Arc<TtsSubprocess>) -> Fut,
+        Fut: std::future::Future<Output = Result<T, TtsError>>,
+    {
+        loop {
+            let handle = match self.current_handle().await {
+                Some(h) => h,
+                None => {
+                    // Previous respawn left no handle (fatal). Try once more —
+                    // ensure_respawned bails fast if we are still in fatal state.
+                    self.ensure_respawned(None).await?;
+                    self.current_handle().await.ok_or(TtsError::Died)?
+                }
+            };
+
+            match op(handle.clone()).await {
+                Err(TtsError::Died) => {
+                    info!(target: "tts::supervisor", "operation hit Died — attempting respawn");
+                    self.ensure_respawned(Some(&handle)).await?;
+                    // Loop and retry with the freshly-installed handle.
+                }
+                other => return other,
+            }
+        }
+    }
+
+    /// Coordinate a single-flight respawn. `dead` (when `Some`) is the handle
+    /// the caller observed dying — if the current handle is no longer that
+    /// `Arc`, somebody else respawned in the meantime and we just return.
+    async fn ensure_respawned(&self, dead: Option<&Arc<TtsSubprocess>>) -> Result<(), TtsError> {
+        // Serialise respawns. Holding this guard guarantees that only one
+        // task runs through the spawn loop at a time.
+        let _guard = self.respawn_lock.lock().await;
+
+        // Second-chance check: did somebody else replace the handle while we
+        // were waiting on the mutex?
+        if let Some(dead) = dead {
+            if let Some(current) = self.current.read().await.as_ref() {
+                if !Arc::ptr_eq(current, dead) {
+                    return Ok(());
+                }
+            }
+        }
+
+        warn!(target: "tts::supervisor", "ttsd died — restarting");
+        (self.emitter)("ttsd_restarting", json!({}));
+
+        let mut last_err: Option<TtsError> = None;
+        for (attempt, delay) in BACKOFFS.iter().enumerate() {
+            // Drop the dead handle before sleeping so its driver task and
+            // child process can be reaped while we wait.
+            {
+                let mut slot = self.current.write().await;
+                *slot = None;
+            }
+
+            sleep(*delay).await;
+
+            let cmd = (self.factory)();
+            match TtsSubprocess::spawn_with_command(cmd) {
+                Ok(fresh) => {
+                    let fresh = Arc::new(fresh);
+                    {
+                        let mut slot = self.current.write().await;
+                        *slot = Some(Arc::clone(&fresh));
+                    }
+                    info!(
+                        target: "tts::supervisor",
+                        "respawn attempt {} succeeded",
+                        attempt + 1
+                    );
+                    self.spawn_warmup(fresh);
+                    return Ok(());
+                }
+                Err(e) => {
+                    warn!(
+                        target: "tts::supervisor",
+                        "respawn attempt {} failed: {e}",
+                        attempt + 1
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        // All attempts exhausted — emit fatal and propagate the last error.
+        // The slot stays `None`; the next request will try once more via
+        // `with_retry`.
+        let err = last_err.unwrap_or(TtsError::Died);
+        let message = err.to_string();
+        error!(target: "tts::supervisor", "ttsd respawn exhausted: {message}");
+        (self.emitter)("tts_fatal", json!({ "message": message }));
+        Err(err)
+    }
+
+    /// Run `warmup` against the freshly-spawned handle in a background task,
+    /// mirroring the `model_loading` → `model_loaded` / `model_error`
+    /// lifecycle that startup uses. Failures here do not invalidate the
+    /// handle; ttsd treats warmup as idempotent and the next synthesize will
+    /// retrigger model load on the Python side.
+    fn spawn_warmup(&self, handle: Arc<TtsSubprocess>) {
+        let emitter = Arc::clone(&self.emitter);
+        tokio::spawn(async move {
+            emitter("model_loading", json!({}));
+            match handle.warmup().await {
+                Ok(()) => {
+                    info!(target: "tts::supervisor", "post-respawn warmup ok");
+                    emitter("model_loaded", json!({}));
+                }
+                Err(e) => {
+                    warn!(target: "tts::supervisor", "post-respawn warmup failed: {e}");
+                    emitter("model_error", json!({ "message": e.to_string() }));
+                }
+            }
+        });
+    }
+
+    // ── Proxied methods ───────────────────────────────────────────────────
+
+    pub async fn warmup(&self) -> Result<(), TtsError> {
+        self.with_retry(|h| async move { h.warmup().await }).await
+    }
+
+    pub async fn synthesize(
+        &self,
+        text: String,
+        speaker: String,
+        sample_rate: u32,
+        out_wav: String,
+        char_mapping: Option<Vec<CharMappingEntry>>,
+    ) -> Result<SynthesizeOutput, TtsError> {
+        self.with_retry(move |h| {
+            // Clone the input so each retry attempt gets its own copy.
+            let text = text.clone();
+            let speaker = speaker.clone();
+            let out_wav = out_wav.clone();
+            let char_mapping = char_mapping.clone();
+            async move {
+                h.synthesize(text, speaker, sample_rate, out_wav, char_mapping)
+                    .await
+            }
+        })
+        .await
+    }
+
+    /// Graceful shutdown. Does *not* respawn on Died — at this point we are
+    /// tearing down anyway.
+    pub async fn shutdown(&self) -> Result<(), TtsError> {
+        let handle = match self.current_handle().await {
+            Some(h) => h,
+            None => return Ok(()),
+        };
+        handle.shutdown().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    type EventLog = Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>;
+
+    /// Build an emitter that records every event into a shared Vec.
+    fn recording_emitter() -> (Emitter, EventLog) {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log_clone = Arc::clone(&log);
+        let emitter: Emitter = Arc::new(move |name, payload| {
+            log_clone.lock().unwrap().push((name.to_string(), payload));
+        });
+        (emitter, log)
+    }
+
+    /// Factory that always fails to spawn.  Used to verify the fatal path.
+    fn failing_factory() -> CommandFactory {
+        Arc::new(|| {
+            // /this/path/does/not/exist guarantees Command::spawn returns ENOENT.
+            Command::new("/nonexistent/tts/binary/that/should/never/exist")
+        })
+    }
+
+    #[tokio::test]
+    async fn initial_spawn_failure_is_surfaced() {
+        let (emitter, _log) = recording_emitter();
+        let result = TtsSupervisor::spawn(failing_factory(), emitter);
+        assert!(matches!(result, Err(TtsError::Spawn(_))));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn respawn_exhausts_after_three_attempts_and_emits_fatal() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        // The initial spawn must succeed so we can reach the respawn path —
+        // every subsequent spawn must fail. `cat` is a real binary (resolved
+        // via PATH) that hangs on stdin and satisfies Command::spawn; later
+        // attempts hit ENOENT and exercise the BACKOFFS loop.
+        let counter_clone = Arc::clone(&counter);
+        let factory: CommandFactory = Arc::new(move || {
+            let n = counter_clone.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                Command::new("cat")
+            } else {
+                Command::new("/nonexistent/tts/binary/that/should/never/exist")
+            }
+        });
+
+        let (emitter, log) = recording_emitter();
+        let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
+
+        let dead = sup.current_handle().await.expect("handle present");
+        let res = sup.ensure_respawned(Some(&dead)).await;
+        assert!(res.is_err(), "respawn should have failed");
+
+        let log = log.lock().unwrap();
+        let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"ttsd_restarting"));
+        assert!(names.contains(&"tts_fatal"));
+        // 1 initial /bin/cat + 3 ENOENT retries.
+        assert_eq!(counter.load(Ordering::SeqCst), 4);
+    }
+}

--- a/src-tauri/tests/fixtures/mock_ttsd_suicide.py
+++ b/src-tauri/tests/fixtures/mock_ttsd_suicide.py
@@ -1,0 +1,62 @@
+"""Mock ttsd that responds once, then exits ungracefully on the second call.
+
+Used by `tests/supervisor.rs` to verify the supervisor respawns the
+subprocess after a crash. The protocol matches the real ttsd just enough
+for `TtsSubprocess::warmup` and `TtsSubprocess::synthesize` to round-trip
+without needing Silero or torch.
+
+Behaviour:
+  - `warmup`     -> always replies ok.
+  - `synthesize` -> first call replies ok with empty timestamps and a fixed
+                    duration; subsequent calls call `os._exit(1)` *before*
+                    flushing a response, simulating a hard crash mid-request.
+
+Run via:  python tests/fixtures/mock_ttsd_suicide.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+_synthesize_calls = 0
+
+
+def _write(payload: dict) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    global _synthesize_calls
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _write({"ok": False, "error": "bad_json", "message": str(exc)})
+            continue
+
+        cmd = req.get("cmd")
+        if cmd == "warmup":
+            _write({"ok": True, "version": "mock-0.0.0"})
+        elif cmd == "synthesize":
+            _synthesize_calls += 1
+            if _synthesize_calls == 1:
+                _write({"ok": True, "timestamps": [], "duration_sec": 0.0})
+            else:
+                # Hard exit BEFORE flushing a response — drops stdout and
+                # forces the Rust side to observe Died on the next read.
+                os._exit(1)
+        elif cmd == "shutdown":
+            _write({"ok": True})
+            return
+        else:
+            _write({"ok": False, "error": "bad_cmd", "message": f"unknown cmd: {cmd}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -1,0 +1,101 @@
+//! Integration test for the TTS supervisor.
+//!
+//! Drives a mock ttsd (Python script) that successfully handles the first
+//! synthesize call and then `os._exit(1)`s on the second.  Verifies that the
+//! supervisor transparently respawns the subprocess and the second
+//! synthesize call (from the caller's POV) succeeds.
+//!
+//! Run with:
+//!   nix-shell --run "cargo test --manifest-path src-tauri/Cargo.toml \
+//!     --test supervisor"
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use ruvox_tauri_lib::tts::supervisor::{CommandFactory, Emitter, TtsSupervisor};
+use tokio::process::Command;
+
+/// Resolve the mock script path. `cargo test` may be invoked from either
+/// `src-tauri/` (the manifest dir, default) or the workspace root.
+fn mock_script_path() -> PathBuf {
+    let from_crate = PathBuf::from("tests/fixtures/mock_ttsd_suicide.py");
+    if from_crate.exists() {
+        return from_crate
+            .canonicalize()
+            .expect("canonicalize from-crate path");
+    }
+    let from_workspace = PathBuf::from("src-tauri/tests/fixtures/mock_ttsd_suicide.py");
+    if from_workspace.exists() {
+        return from_workspace
+            .canonicalize()
+            .expect("canonicalize from-workspace path");
+    }
+    panic!("mock_ttsd_suicide.py not found from either crate or workspace root");
+}
+
+fn build_factory() -> CommandFactory {
+    let script = mock_script_path();
+    Arc::new(move || {
+        let mut cmd = Command::new("python");
+        cmd.arg(&script);
+        cmd
+    })
+}
+
+type EventLog = Arc<Mutex<Vec<(String, serde_json::Value)>>>;
+
+fn recording_emitter() -> (Emitter, EventLog) {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let log_clone = Arc::clone(&log);
+    let emitter: Emitter = Arc::new(move |name, payload| {
+        log_clone.lock().unwrap().push((name.to_string(), payload));
+    });
+    (emitter, log)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn supervisor_respawns_after_subprocess_suicide() {
+    let factory = build_factory();
+    let (emitter, log) = recording_emitter();
+    let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
+
+    // First call goes through cleanly — the mock counts this as call #1.
+    let first = sup
+        .synthesize(
+            "hello".to_string(),
+            "xenia".to_string(),
+            48_000,
+            "/tmp/ruvox-mock-out-1.wav".to_string(),
+            None,
+        )
+        .await
+        .expect("first synthesize should succeed");
+    assert_eq!(first.timestamps.len(), 0);
+
+    // Second call from the test's POV: the mock will os._exit(1) on its
+    // own second call → supervisor sees Died → respawns → retries with the
+    // fresh subprocess (whose internal counter resets) → succeeds.
+    let second = sup
+        .synthesize(
+            "world".to_string(),
+            "xenia".to_string(),
+            48_000,
+            "/tmp/ruvox-mock-out-2.wav".to_string(),
+            None,
+        )
+        .await
+        .expect("second synthesize should succeed via respawn");
+    assert_eq!(second.timestamps.len(), 0);
+
+    // Supervisor must have emitted ttsd_restarting at least once.
+    let log = log.lock().unwrap();
+    let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"ttsd_restarting"),
+        "expected ttsd_restarting in {names:?}",
+    );
+    assert!(
+        !names.contains(&"tts_fatal"),
+        "did not expect tts_fatal in {names:?}",
+    );
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -12,8 +12,8 @@ import { useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { useState, useEffect, useRef } from 'react';
 import { readText as readClipboardText } from '@tauri-apps/plugin-clipboard-manager';
-import { commands } from '../lib/tauri';
-import type { UIConfig } from '../lib/tauri';
+import { commands, events } from '../lib/tauri';
+import type { UIConfig, UnlistenFn } from '../lib/tauri';
 import { formatError } from '../lib/errors';
 import { TextViewer } from './TextViewer';
 import { Player } from './Player';
@@ -91,6 +91,38 @@ export function AppShell() {
       // Config load failure is non-fatal; preview will be skipped
     });
   }, [setColorScheme]);
+
+  // ttsd lifecycle notifications. The supervisor emits ttsd_restarting on the
+  // first failed request after a crash and tts_fatal after three failed
+  // respawn attempts. Both are user-visible so the silence between
+  // background respawns isn't mistaken for a hung app.
+  useEffect(() => {
+    const pending: Promise<UnlistenFn>[] = [];
+    pending.push(
+      events.ttsdRestarting(() => {
+        notifications.show({
+          id: 'ttsd-restarting',
+          title: 'TTS перезапускается',
+          message: 'Подождите несколько секунд — модель будет загружена заново.',
+          color: 'yellow',
+          autoClose: 5000,
+        });
+      }),
+    );
+    pending.push(
+      events.ttsFatal((p) => {
+        notifications.show({
+          title: 'TTS не запускается',
+          message: p.message || 'Не удалось перезапустить процесс синтеза.',
+          color: 'red',
+          autoClose: false,
+        });
+      }),
+    );
+    return () => {
+      pending.forEach((p) => p.then((fn) => fn()));
+    };
+  }, []);
 
   async function addEntry() {
     if (pending) return;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -149,6 +149,7 @@ export interface PlaybackPausedPayload { entry_id: EntryId; position_sec: number
 export interface PlaybackFinishedPayload { entry_id: EntryId; }
 export interface ModelErrorPayload { message: string; }
 export interface TtsErrorPayload { entry_id: EntryId; message: string; }
+export interface TtsFatalPayload { message: string; }
 export interface SynthesisProgressPayload { entry_id: EntryId; progress: number; }
 
 export const events = {
@@ -184,6 +185,12 @@ export const events = {
 
   ttsError: (cb: (p: TtsErrorPayload) => void): Promise<UnlistenFn> =>
     tauriListen<TtsErrorPayload>('tts_error', (e) => cb(e.payload)),
+
+  ttsdRestarting: (cb: () => void): Promise<UnlistenFn> =>
+    tauriListen<Record<string, never>>('ttsd_restarting', () => cb()),
+
+  ttsFatal: (cb: (p: TtsFatalPayload) => void): Promise<UnlistenFn> =>
+    tauriListen<TtsFatalPayload>('tts_fatal', (e) => cb(e.payload)),
 
   synthesisProgress: (cb: (p: SynthesisProgressPayload) => void): Promise<UnlistenFn> =>
     tauriListen<SynthesisProgressPayload>('synthesis_progress', (e) => cb(e.payload)),


### PR DESCRIPTION
Closes #7.

## Summary
- New `TtsSupervisor` (`src-tauri/src/tts/supervisor.rs`) wraps `TtsSubprocess` and respawns on `TtsError::Died` with a 1s/3s/5s backoff (3 attempts).
- Single-flight respawn coordination via `Arc::ptr_eq` — concurrent callers do not stampede the spawn loop.
- Successful respawn kicks off `warmup` in the background and re-emits `model_loading` → `model_loaded`/`model_error` so the UI lifecycle is unchanged.
- New events: `ttsd_restarting` (yellow toast) and `tts_fatal { message }` (red, manual close).
- `TtsSubprocess::spawn_with_command(Command)` exposed as a lower-level constructor for the supervisor and tests.

## Tests
- Unit: `respawn_exhausts_after_three_attempts_and_emits_fatal` exercises the BACKOFFS loop using `tokio::test(start_paused = true)`.
- Integration: `tests/supervisor.rs` drives a Python mock (`tests/fixtures/mock_ttsd_suicide.py`) that `os._exit(1)`s on its second synthesize. The caller-visible second synthesize succeeds via respawn.
- Existing 692 unit tests still green; `pnpm typecheck` green.

## Test plan
- [ ] `pnpm tauri dev`, then `kill -9 <ttsd pid>` while idle → next synthesize succeeds (5–10s warmup), yellow toast appears.
- [ ] `kill -9 <ttsd pid>` mid-synthesis → current entry → error, next entry succeeds.
- [ ] Break the `uv` command (rename binary) and trigger a synthesize → after ~9s, red `tts_fatal` toast and entry → error.