### PR TITLE
refactor(tts): tighten supervisor API, unify warmup lifecycle

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,23 +204,13 @@ pub fn run() {
                 .expect("failed to spawn ttsd subprocess"),
             );
 
-            // Warm up Silero model in background; emit model_loading → model_loaded/model_error.
+            // Warm up Silero model in background. The supervisor owns the
+            // model_loading → model_loaded/model_error emit sequence so the
+            // initial warmup and post-respawn warmup share one code path.
             {
                 let tts_clone = Arc::clone(&tts);
-                let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    let _ = app_handle.emit("model_loading", json!({}));
-                    match tts_clone.warmup().await {
-                        Ok(()) => {
-                            tracing::info!("ttsd warmup ok");
-                            let _ = app_handle.emit("model_loaded", json!({}));
-                        }
-                        Err(e) => {
-                            tracing::error!("ttsd warmup failed: {e}");
-                            let _ =
-                                app_handle.emit("model_error", json!({ "message": e.to_string() }));
-                        }
-                    }
+                    tts_clone.spawn_initial_warmup().await;
                 });
             }
 

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -12,7 +12,6 @@
 pub mod supervisor;
 pub use supervisor::TtsSupervisor;
 
-use std::path::PathBuf;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -182,23 +181,14 @@ pub struct TtsSubprocess {
 }
 
 impl TtsSubprocess {
-    /// Spawn the ttsd subprocess and start the driver task.
-    ///
-    /// `ttsd_dir` is the directory from which `uv run python -m ttsd` is executed.
-    pub fn spawn(ttsd_dir: PathBuf) -> Result<Self, TtsError> {
-        let mut cmd = Command::new("uv");
-        cmd.args(["run", "python", "-m", "ttsd"])
-            .current_dir(ttsd_dir);
-        Self::spawn_with_command(cmd)
-    }
-
-    /// Lower-level constructor: takes a fully-built [`Command`] and wires its
-    /// stdio + a driver task. Stdin/stdout/stderr are forced to `piped` and
+    /// Spawn the ttsd subprocess from a fully-built [`Command`] and start the
+    /// driver task. Stdin/stdout/stderr are forced to `piped` and
     /// `kill_on_drop` is set, regardless of what the caller configured.
     ///
-    /// Used by [`supervisor::TtsSupervisor`] to inject a respawn-friendly
-    /// command factory and by integration tests to point at mock binaries.
-    pub fn spawn_with_command(mut cmd: Command) -> Result<Self, TtsError> {
+    /// `pub(super)` because all production callers go through
+    /// [`supervisor::TtsSupervisor`], which owns the command factory and
+    /// respawn policy. Tests reach the subprocess via the supervisor too.
+    pub(super) fn spawn(mut cmd: Command) -> Result<Self, TtsError> {
         cmd.stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -68,7 +68,7 @@ impl TtsSupervisor {
     /// than entering retry loops.
     pub fn spawn(factory: CommandFactory, emitter: Emitter) -> Result<Self, TtsError> {
         let cmd = factory();
-        let initial = TtsSubprocess::spawn_with_command(cmd)?;
+        let initial = TtsSubprocess::spawn(cmd)?;
         Ok(Self {
             current: RwLock::new(Some(Arc::new(initial))),
             respawn_lock: Mutex::new(()),
@@ -145,7 +145,7 @@ impl TtsSupervisor {
             sleep(*delay).await;
 
             let cmd = (self.factory)();
-            match TtsSubprocess::spawn_with_command(cmd) {
+            match TtsSubprocess::spawn(cmd) {
                 Ok(fresh) => {
                     let fresh = Arc::new(fresh);
                     {
@@ -179,6 +179,16 @@ impl TtsSupervisor {
         error!(target: "tts::supervisor", "ttsd respawn exhausted: {message}");
         (self.emitter)("tts_fatal", json!({ "message": message }));
         Err(err)
+    }
+
+    /// Run the first-time Silero warmup in the background, emitting the
+    /// `model_loading` → `model_loaded` / `model_error` lifecycle that the
+    /// frontend expects on startup. Same code path as post-respawn warmup —
+    /// callers don't need to duplicate the lifecycle plumbing.
+    pub async fn spawn_initial_warmup(&self) {
+        if let Some(handle) = self.current_handle().await {
+            self.spawn_warmup(handle);
+        }
     }
 
     /// Run `warmup` against the freshly-spawned handle in a background task,


### PR DESCRIPTION
## Summary
- Drop dead `TtsSubprocess::spawn(PathBuf)` overload; all callers use the supervisor + factory pattern now.
- Rename `spawn_with_command` -> `spawn(Command)` and make it `pub(super)` -- `TtsSupervisor` is the only valid constructor.
- New `TtsSupervisor::spawn_initial_warmup()` encapsulates the `model_loading` -> `model_loaded` / `model_error` emit sequence. Initial and post-respawn warmup now share one code path.

No behavior change visible to the frontend.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (lib + supervisor integration)
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings`
- [x] `pnpm typecheck`