### PR TITLE
refactor(tts): wrap synthesize inputs in Arc to skip clones on retry

### DIFF
--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -12,6 +12,7 @@
 pub mod supervisor;
 pub use supervisor::TtsSupervisor;
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -60,18 +61,23 @@ pub enum TtsError {
 // ---------------------------------------------------------------------------
 
 /// Requests sent to the ttsd subprocess over stdin (NDJSON).
+///
+/// Strings and the char_mapping slice are wrapped in `Arc` so the supervisor's
+/// retry loop can pass them through cheaply (atomic refcount bump) instead of
+/// memcpy-cloning on every attempt. Serde serializes `Arc<str>` / `Arc<[T]>`
+/// transparently as `&str` / `&[T]`.
 #[derive(Debug, Serialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum TtsRequest {
     Warmup,
     Synthesize {
-        text: String,
-        speaker: String,
+        text: Arc<str>,
+        speaker: Arc<str>,
         sample_rate: u32,
-        out_wav: String,
+        out_wav: Arc<str>,
         /// Optional char mapping from the Rust pipeline for precise `original_pos` mapping.
         #[serde(skip_serializing_if = "Option::is_none")]
-        char_mapping: Option<Vec<CharMappingEntry>>,
+        char_mapping: Option<Arc<[CharMappingEntry]>>,
     },
     Shutdown,
 }
@@ -233,11 +239,11 @@ impl TtsSubprocess {
     /// Timeout: 5 minutes. Returns timestamps and duration from ttsd.
     pub async fn synthesize(
         &self,
-        text: String,
-        speaker: String,
+        text: Arc<str>,
+        speaker: Arc<str>,
         sample_rate: u32,
-        out_wav: String,
-        char_mapping: Option<Vec<CharMappingEntry>>,
+        out_wav: Arc<str>,
+        char_mapping: Option<Arc<[CharMappingEntry]>>,
     ) -> Result<SynthesizeOutput, TtsError> {
         const SYNTHESIZE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
@@ -392,10 +398,10 @@ mod tests {
     #[test]
     fn synthesize_serializes_all_required_fields() {
         let req = TtsRequest::Synthesize {
-            text: "привет мир".to_string(),
-            speaker: "xenia".to_string(),
+            text: Arc::from("привет мир"),
+            speaker: Arc::from("xenia"),
             sample_rate: 48000,
-            out_wav: "/tmp/test.wav".to_string(),
+            out_wav: Arc::from("/tmp/test.wav"),
             char_mapping: None,
         };
         let json = serde_json::to_string(&req).unwrap();
@@ -412,17 +418,17 @@ mod tests {
 
     #[test]
     fn synthesize_with_char_mapping_includes_it() {
-        let mapping = vec![CharMappingEntry {
+        let mapping: Arc<[CharMappingEntry]> = Arc::from(vec![CharMappingEntry {
             norm_start: 0,
             norm_end: 6,
             orig_start: 0,
             orig_end: 12,
-        }];
+        }]);
         let req = TtsRequest::Synthesize {
-            text: "привет".to_string(),
-            speaker: "xenia".to_string(),
+            text: Arc::from("привет"),
+            speaker: Arc::from("xenia"),
             sample_rate: 48000,
-            out_wav: "/tmp/test.wav".to_string(),
+            out_wav: Arc::from("/tmp/test.wav"),
             char_mapping: Some(mapping),
         };
         let json = serde_json::to_string(&req).unwrap();

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -232,8 +232,7 @@ impl TtsSupervisor {
         let text: Arc<str> = Arc::from(text);
         let speaker: Arc<str> = Arc::from(speaker);
         let out_wav: Arc<str> = Arc::from(out_wav);
-        let char_mapping: Option<Arc<[CharMappingEntry]>> =
-            char_mapping.map(Arc::from);
+        let char_mapping: Option<Arc<[CharMappingEntry]>> = char_mapping.map(Arc::from);
 
         self.with_retry(move |h| {
             let text = Arc::clone(&text);

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -227,11 +227,18 @@ impl TtsSupervisor {
         out_wav: String,
         char_mapping: Option<Vec<CharMappingEntry>>,
     ) -> Result<SynthesizeOutput, TtsError> {
+        // Convert once at the supervisor boundary; each retry below only bumps
+        // the Arc refcount instead of memcpy-cloning the strings/Vec.
+        let text: Arc<str> = Arc::from(text);
+        let speaker: Arc<str> = Arc::from(speaker);
+        let out_wav: Arc<str> = Arc::from(out_wav);
+        let char_mapping: Option<Arc<[CharMappingEntry]>> =
+            char_mapping.map(Arc::from);
+
         self.with_retry(move |h| {
-            // Clone the input so each retry attempt gets its own copy.
-            let text = text.clone();
-            let speaker = speaker.clone();
-            let out_wav = out_wav.clone();
+            let text = Arc::clone(&text);
+            let speaker = Arc::clone(&speaker);
+            let out_wav = Arc::clone(&out_wav);
             let char_mapping = char_mapping.clone();
             async move {
                 h.synthesize(text, speaker, sample_rate, out_wav, char_mapping)


### PR DESCRIPTION
## Summary
- `TtsRequest::Synthesize` now stores `Arc<str>` / `Arc<[CharMappingEntry]>` instead of `String` / `Vec<...>`.
- `TtsSubprocess::synthesize` takes the same `Arc<...>` shape.
- `TtsSupervisor::synthesize` keeps the public `String` / `Vec` API (no callsite churn), converts to `Arc` once before the retry loop, and inside `with_retry` does `Arc::clone` (atomic refcount bump) instead of `String::clone` (memcpy).
- Wire format unchanged -- serde serializes `Arc<T>` like `T`.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib tts`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test supervisor`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings`