### PR TITLE
feat(ux): morph ttsd_restarting toast through model lifecycle

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -12,8 +12,8 @@ import { useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { useState, useEffect, useRef } from 'react';
 import { readText as readClipboardText } from '@tauri-apps/plugin-clipboard-manager';
-import { commands, events } from '../lib/tauri';
-import type { UIConfig, UnlistenFn } from '../lib/tauri';
+import { commands } from '../lib/tauri';
+import type { UIConfig } from '../lib/tauri';
 import { formatError } from '../lib/errors';
 import { TextViewer } from './TextViewer';
 import { Player } from './Player';
@@ -91,38 +91,6 @@ export function AppShell() {
       // Config load failure is non-fatal; preview will be skipped
     });
   }, [setColorScheme]);
-
-  // ttsd lifecycle notifications. The supervisor emits ttsd_restarting on the
-  // first failed request after a crash and tts_fatal after three failed
-  // respawn attempts. Both are user-visible so the silence between
-  // background respawns isn't mistaken for a hung app.
-  useEffect(() => {
-    const pending: Promise<UnlistenFn>[] = [];
-    pending.push(
-      events.ttsdRestarting(() => {
-        notifications.show({
-          id: 'ttsd-restarting',
-          title: 'TTS перезапускается',
-          message: 'Подождите несколько секунд — модель будет загружена заново.',
-          color: 'yellow',
-          autoClose: 5000,
-        });
-      }),
-    );
-    pending.push(
-      events.ttsFatal((p) => {
-        notifications.show({
-          title: 'TTS не запускается',
-          message: p.message || 'Не удалось перезапустить процесс синтеза.',
-          color: 'red',
-          autoClose: false,
-        });
-      }),
-    );
-    return () => {
-      pending.forEach((p) => p.then((fn) => fn()));
-    };
-  }, []);
 
   async function addEntry() {
     if (pending) return;

--- a/src/lib/notificationBridge.ts
+++ b/src/lib/notificationBridge.ts
@@ -9,8 +9,56 @@ import { events } from './tauri';
 export async function setupNotificationBridge(): Promise<() => void> {
   const unlisteners: UnlistenFn[] = [];
 
+  // Toast routing for the model_loading → model_loaded/model_error sequence:
+  // - Cold-start path uses id 'model-loading'.
+  // - Post-respawn path uses id 'ttsd-restart' so the yellow "перезапускается"
+  //   toast morphs into "загружаю модель..." → "TTS восстановлен" / error
+  //   without ever disappearing silently. `restartActive` flips on
+  //   ttsd_restarting and back off when the post-respawn warmup completes
+  //   (success, model_error, or tts_fatal).
+  let restartActive = false;
+  const RESTART_TOAST_ID = 'ttsd-restart';
+
+  unlisteners.push(
+    await events.ttsdRestarting(() => {
+      restartActive = true;
+      notifications.show({
+        id: RESTART_TOAST_ID,
+        title: 'TTS перезапускается',
+        message: 'Подождите несколько секунд — процесс будет запущен заново.',
+        color: 'yellow',
+        loading: true,
+        autoClose: false,
+      });
+    }),
+  );
+
+  unlisteners.push(
+    await events.ttsFatal((p) => {
+      restartActive = false;
+      notifications.hide(RESTART_TOAST_ID);
+      notifications.show({
+        title: 'TTS не запускается',
+        message: p.message || 'Не удалось перезапустить процесс синтеза.',
+        color: 'red',
+        autoClose: false,
+      });
+    }),
+  );
+
   unlisteners.push(
     await events.modelLoading(() => {
+      if (restartActive) {
+        notifications.update({
+          id: RESTART_TOAST_ID,
+          title: 'Загружаю модель TTS',
+          message: 'Перезапуск завершён, повторная загрузка модели...',
+          color: 'yellow',
+          loading: true,
+          autoClose: false,
+        });
+        return;
+      }
       notifications.show({
         id: 'model-loading',
         title: 'Загрузка модели TTS',
@@ -23,6 +71,18 @@ export async function setupNotificationBridge(): Promise<() => void> {
 
   unlisteners.push(
     await events.modelLoaded(() => {
+      if (restartActive) {
+        restartActive = false;
+        notifications.update({
+          id: RESTART_TOAST_ID,
+          title: 'TTS восстановлен',
+          message: 'Синтез речи снова доступен.',
+          color: 'green',
+          loading: false,
+          autoClose: 3000,
+        });
+        return;
+      }
       notifications.update({
         id: 'model-loading',
         title: 'Модель TTS загружена',
@@ -36,6 +96,18 @@ export async function setupNotificationBridge(): Promise<() => void> {
 
   unlisteners.push(
     await events.modelError((p) => {
+      if (restartActive) {
+        restartActive = false;
+        notifications.update({
+          id: RESTART_TOAST_ID,
+          title: 'Ошибка загрузки модели TTS',
+          message: p.message,
+          color: 'red',
+          loading: false,
+          autoClose: 8000,
+        });
+        return;
+      }
       notifications.update({
         id: 'model-loading',
         title: 'Ошибка загрузки модели TTS',


### PR DESCRIPTION
## Summary
- The `ttsd_restarting` toast stays pinned (`autoClose: false`) until the post-respawn warmup actually completes.
- After `ttsd_restarting`, the same toast morphs through `model_loading` ("Загружаю модель TTS") -> `model_loaded` (green "TTS восстановлен", 3 s autoClose).
- `model_error` and `tts_fatal` flip the same toast to red.
- Cold-start path unchanged: without a prior restart, model_loading uses the original `model-loading` toast id.
- Centralizes the lifecycle in `notificationBridge.ts`; AppShell no longer keeps a parallel subscription.

## Test plan
- [x] `pnpm typecheck`
- [ ] Manual: kill ttsd -> yellow toast morphs to green "TTS восстановлен"
- [ ] Manual: cold start -> existing 'Загрузка модели TTS' toast unchanged