### PR TITLE
refactor(tts): share recording_emitter via test_helpers feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           workspaces: src-tauri
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings
-      - run: cargo test --manifest-path src-tauri/Cargo.toml
+      - run: cargo test --manifest-path src-tauri/Cargo.toml --all-features
 
   typescript:
     name: TypeScript (typecheck)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,19 @@ rust-version = "1.80"
 name = "ruvox_tauri_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+# Exposes `tts::supervisor::test_helpers` so integration tests can build the
+# same recording emitter that unit tests use. Off by default — the helpers
+# stay out of release/dev binaries.
+test-helpers = []
+
+# Integration tests that depend on the test_helpers module. Cargo skips them
+# unless the corresponding feature is enabled (CI passes --all-features).
+[[test]]
+name = "supervisor"
+path = "tests/supervisor.rs"
+required-features = ["test-helpers"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -258,15 +258,18 @@ impl TtsSupervisor {
     }
 }
 
-#[cfg(test)]
-mod tests {
+/// Helpers shared between unit tests in this module and integration tests
+/// in `tests/supervisor.rs`. Gated on `cfg(test)` (always available to unit
+/// tests in this crate) and `feature = "test-helpers"` (so integration test
+/// crates can opt in without leaking helpers into release builds).
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod test_helpers {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    type EventLog = Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>;
+    pub type EventLog = Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>;
 
     /// Build an emitter that records every event into a shared Vec.
-    fn recording_emitter() -> (Emitter, EventLog) {
+    pub fn recording_emitter() -> (Emitter, EventLog) {
         let log = Arc::new(std::sync::Mutex::new(Vec::new()));
         let log_clone = Arc::clone(&log);
         let emitter: Emitter = Arc::new(move |name, payload| {
@@ -274,6 +277,13 @@ mod tests {
         });
         (emitter, log)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_helpers::recording_emitter;
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Factory that always fails to spawn.  Used to verify the fatal path.
     fn failing_factory() -> CommandFactory {

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -7,12 +7,16 @@
 //!
 //! Run with:
 //!   nix-shell --run "cargo test --manifest-path src-tauri/Cargo.toml \
-//!     --test supervisor"
+//!     --features test-helpers --test supervisor"
+//!
+//! `test-helpers` is required because the recording emitter helper lives in
+//! a feature-gated module so it stays out of release/dev builds.
 
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use ruvox_tauri_lib::tts::supervisor::{CommandFactory, Emitter, TtsSupervisor};
+use ruvox_tauri_lib::tts::supervisor::test_helpers::recording_emitter;
+use ruvox_tauri_lib::tts::supervisor::{CommandFactory, TtsSupervisor};
 use tokio::process::Command;
 
 /// Resolve the mock script path. `cargo test` may be invoked from either
@@ -40,17 +44,6 @@ fn build_factory() -> CommandFactory {
         cmd.arg(&script);
         cmd
     })
-}
-
-type EventLog = Arc<Mutex<Vec<(String, serde_json::Value)>>>;
-
-fn recording_emitter() -> (Emitter, EventLog) {
-    let log = Arc::new(Mutex::new(Vec::new()));
-    let log_clone = Arc::clone(&log);
-    let emitter: Emitter = Arc::new(move |name, payload| {
-        log_clone.lock().unwrap().push((name.to_string(), payload));
-    });
-    (emitter, log)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
- New `pub mod test_helpers` inside `tts::supervisor`, gated on `cfg(any(test, feature = "test-helpers"))`.
- Unit tests and `tests/supervisor.rs` now both call `test_helpers::recording_emitter()` instead of keeping a local copy.
- `Cargo.toml` declares `[[test]] name = "supervisor", required-features = ["test-helpers"]`, so the integration test is skipped (not failed) when the feature is off.
- CI's `cargo test` step now passes `--all-features` so the integration test stays in the matrix.
- Helpers stay out of release / dev binaries: the feature is opt-in.

## Test plan
- [x] `cargo test --all-features` (lib + integration + golden -- all green)
- [x] `cargo test --no-default-features` (integration test skipped, others green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps -- -D warnings`