### PR TITLE
refactor(ui): extract useTauriEvents hook

### DIFF
--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { ActionIcon, Group, Slider, Text, NumberInput, Tooltip } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
-import type { UnlistenFn } from '@tauri-apps/api/event';
 import { commands, events } from '../lib/tauri';
 import type { EntryId } from '../lib/tauri';
+import { useTauriEvents } from '../lib/useTauriEvents';
 import { IconPlay, IconPause, IconSettings, IconAppLogo } from './icons';
 import classes from './Player.module.css';
 
@@ -50,10 +50,8 @@ export function Player({ onOpenSettings }: PlayerProps = {}) {
   const speedRef = useRef(state.speed);
   useEffect(() => { speedRef.current = state.speed; }, [state.speed]);
 
-  useEffect(() => {
-    const unlisteners: Promise<UnlistenFn>[] = [];
-
-    unlisteners.push(
+  useTauriEvents([
+    () =>
       events.playbackStarted((p) => {
         setState((prev) => ({
           ...prev,
@@ -66,9 +64,7 @@ export function Player({ onOpenSettings }: PlayerProps = {}) {
           duration: p.duration_sec ?? prev.duration,
         }));
       }),
-    );
-
-    unlisteners.push(
+    () =>
       events.playbackPaused((p) => {
         setState((prev) => ({
           ...prev,
@@ -77,9 +73,7 @@ export function Player({ onOpenSettings }: PlayerProps = {}) {
           position: p.position_sec,
         }));
       }),
-    );
-
-    unlisteners.push(
+    () =>
       events.playbackStopped(() => {
         setState((prev) => ({
           ...prev,
@@ -89,9 +83,7 @@ export function Player({ onOpenSettings }: PlayerProps = {}) {
           currentEntryId: null,
         }));
       }),
-    );
-
-    unlisteners.push(
+    () =>
       events.playbackFinished(() => {
         setState((prev) => ({
           ...prev,
@@ -100,9 +92,7 @@ export function Player({ onOpenSettings }: PlayerProps = {}) {
           position: 0,
         }));
       }),
-    );
-
-    unlisteners.push(
+    () =>
       events.playbackPosition((p) => {
         setState((prev) => {
           const next: PlayerState = { ...prev, currentEntryId: p.entry_id };
@@ -117,10 +107,7 @@ export function Player({ onOpenSettings }: PlayerProps = {}) {
           return next;
         });
       }),
-    );
-
-    // Sync duration from entry_updated events
-    unlisteners.push(
+    () =>
       events.entryUpdated((p) => {
         setState((prev) => {
           if (
@@ -132,12 +119,7 @@ export function Player({ onOpenSettings }: PlayerProps = {}) {
           return prev;
         });
       }),
-    );
-
-    return () => {
-      unlisteners.forEach((p) => p.then((fn) => fn()));
-    };
-  }, []);
+  ]);
 
   const handlePlayPause = useCallback(async () => {
     if (state.isPlaying) {

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -13,7 +13,8 @@ import {
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { commands, events } from '../lib/tauri';
-import type { TextEntry, EntryStatus, EntryId, UnlistenFn } from '../lib/tauri';
+import type { TextEntry, EntryStatus, EntryId } from '../lib/tauri';
+import { useTauriEvents } from '../lib/useTauriEvents';
 import { useSelectedEntry } from '../stores/selectedEntry';
 import { useSearchQuery } from '../stores/searchQuery';
 import { IconPlay, IconLocate } from './icons';
@@ -165,11 +166,11 @@ export function QueueList() {
   }, []);
 
   useEffect(() => {
-    const unlisteners: Promise<UnlistenFn>[] = [];
-
     loadEntries();
+  }, [loadEntries]);
 
-    unlisteners.push(
+  useTauriEvents([
+    () =>
       events.entryUpdated((payload) => {
         setEntries((prev) => {
           const idx = prev.findIndex((e) => e.id === payload.entry.id);
@@ -194,9 +195,7 @@ export function QueueList() {
           return {};
         });
       }),
-    );
-
-    unlisteners.push(
+    () =>
       events.entryRemoved((payload) => {
         setEntries((prev) => prev.filter((e) => e.id !== payload.id));
         useSelectedEntry.setState((state) =>
@@ -205,18 +204,12 @@ export function QueueList() {
             : {},
         );
       }),
-    );
-
     // Highlight the currently-playing entry.  Paused playback keeps the
     // highlight (user may resume); only stop/finish clears it.
-    unlisteners.push(events.playbackStarted((p) => setPlayingId(p.entry_id)));
-    unlisteners.push(events.playbackStopped(() => setPlayingId(null)));
-    unlisteners.push(events.playbackFinished(() => setPlayingId(null)));
-
-    return () => {
-      unlisteners.forEach((p) => p.then((fn) => fn()));
-    };
-  }, [loadEntries]);
+    () => events.playbackStarted((p) => setPlayingId(p.entry_id)),
+    () => events.playbackStopped(() => setPlayingId(null)),
+    () => events.playbackFinished(() => setPlayingId(null)),
+  ]);
 
   // Track whether the playing entry is currently visible in the viewport so we
   // only surface the "jump to current" button when the user has scrolled away.

--- a/src/lib/useTauriEvents.ts
+++ b/src/lib/useTauriEvents.ts
@@ -1,0 +1,23 @@
+import { useEffect, type DependencyList } from 'react';
+import type { UnlistenFn } from '@tauri-apps/api/event';
+
+export type EventSubscription = () => Promise<UnlistenFn>;
+
+/**
+ * Subscribe to multiple Tauri events; auto-unsubscribes on unmount.
+ *
+ * The factories close over current state — pass `deps` so the effect
+ * re-subscribes when the captured values change, mirroring `useEffect` rules.
+ */
+export function useTauriEvents(
+  subscriptions: EventSubscription[],
+  deps: DependencyList = [],
+): void {
+  useEffect(() => {
+    const pending = subscriptions.map((sub) => sub());
+    return () => {
+      pending.forEach((p) => p.then((fn) => fn()).catch(() => {}));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/useTauriEvents.ts` — a thin wrapper around `useEffect` that runs an array of subscription factories on mount and disposes their unlisteners on unmount.
- Migrate `Player.tsx` and `QueueList.tsx` event subscription blocks onto the hook, dropping ~25 lines of pending/cleanup boilerplate per component.
- `notificationBridge.ts` is intentionally left as-is (not a React hook).

## Test plan
- [x] `pnpm typecheck`
- [ ] manual smoke: dev run, verify player/queue updates and clean unmount