### PR TITLE
refactor(setup): extract helpers from lib.rs setup closure

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use serde_json::json;
-use tauri::{Emitter, Manager, RunEvent};
+use tauri::{AppHandle, Emitter, Manager, RunEvent, Runtime};
 use tauri_plugin_mpv::MpvExt;
 
 use commands::*;
@@ -21,6 +21,8 @@ use player::Player;
 use state::AppState;
 use storage::service::StorageService;
 use tray::TrayCmd;
+
+type SetupError = Box<dyn std::error::Error>;
 
 /// Kill orphan mpv processes left over from a previous crash of this binary.
 ///
@@ -70,6 +72,190 @@ fn reap_orphan_mpv() {
     }
 }
 
+/// Inject the bundled 128×128 PNG as the WebView window icon.
+///
+/// `WindowConfig` in `tauri.conf.json` has no `icon` field, and bundle-level
+/// icons only get wired up by `cargo tauri build`. For dev (and as hardening
+/// for release), set the window icon explicitly so X11 / app switchers / task
+/// bars pick it up. Linux GTK CSD title bars typically don't render this
+/// icon inside the title bar itself — that is a GNOME/KDE chrome decision,
+/// not a Tauri limitation.
+fn install_window_icon<R: Runtime>(app: &AppHandle<R>) -> Result<(), SetupError> {
+    if let Some(window) = app.get_webview_window("main") {
+        let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/128x128.png"))?;
+        let _ = window.set_icon(icon);
+    }
+    Ok(())
+}
+
+/// One-shot WAV→Opus migration followed by a startup cache cleanup, both
+/// running on Tauri's async runtime so app startup is not delayed.
+///
+/// Order matters: migration finishes before the orphan sweep walks the audio
+/// directory, so freshly-renamed `.opus` files are already linked to their
+/// entries by the time the sweep runs.
+fn spawn_audio_migration_and_cleanup(storage: Arc<StorageService>) {
+    tauri::async_runtime::spawn(async move {
+        let storage_for_cleanup = Arc::clone(&storage);
+        let stats = tokio::task::spawn_blocking(move || storage.migrate_wav_audio_to_opus()).await;
+        match stats {
+            Ok(s) if s.considered == 0 => {
+                tracing::debug!("audio migration: nothing to do");
+            }
+            Ok(s) => {
+                tracing::info!(
+                    "audio migration: considered={}, migrated={}, skipped_missing={}, failed={}",
+                    s.considered,
+                    s.migrated,
+                    s.skipped_missing,
+                    s.failed
+                );
+            }
+            Err(e) => {
+                tracing::error!("audio migration task panicked: {e}");
+            }
+        }
+
+        let cleanup_result = tokio::task::spawn_blocking(move || {
+            let cfg = storage_for_cleanup.load_config().unwrap_or_default();
+            let target_bytes = (cfg.max_cache_size_mb as u64) * 1024 * 1024;
+            storage_for_cleanup
+                .run_startup_cleanup(target_bytes)
+                .map_err(|e| e.to_string())
+        })
+        .await;
+        match cleanup_result {
+            Ok(Ok(s)) => {
+                tracing::info!(
+                    "startup cleanup: orphans={}, evicted_files={}, freed={} bytes",
+                    s.sweep.deleted_files,
+                    s.evict.deleted_files,
+                    s.sweep.freed_bytes + s.evict.freed_bytes,
+                );
+            }
+            Ok(Err(e)) => {
+                tracing::warn!("startup cleanup failed: {e}");
+            }
+            Err(e) => {
+                tracing::error!("startup cleanup task panicked: {e}");
+            }
+        }
+    });
+}
+
+/// Resolve `ttsd` directory, build the supervisor's command factory + emitter,
+/// and spawn the subprocess.
+///
+/// `tokio::process::Command::spawn` requires an active tokio runtime context,
+/// so the spawn is driven from `block_on` — the inner future returns instantly.
+fn build_ttsd_supervisor<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<Arc<tts::TtsSupervisor>, SetupError> {
+    // In production: bundled next to the binary (resource_dir/ttsd).
+    // In `cargo tauri dev`: cwd is src-tauri/, so the project ttsd lives
+    // at ../ttsd; fall back to ./ttsd for ad-hoc runs from the repo root.
+    let ttsd_dir = {
+        let res_dir = app
+            .path()
+            .resource_dir()
+            .unwrap_or_else(|_| std::path::PathBuf::from("."))
+            .join("ttsd");
+        if res_dir.exists() {
+            res_dir
+        } else if std::path::Path::new("../ttsd/pyproject.toml").exists() {
+            std::path::PathBuf::from("../ttsd")
+        } else {
+            std::path::PathBuf::from("ttsd")
+        }
+    };
+
+    // Cloning the path captured by value keeps the closure `Fn` (not
+    // `FnOnce`) — required for the `Arc<dyn Fn(...)>` shape.
+    let ttsd_dir_for_factory = ttsd_dir;
+    let factory: tts::supervisor::CommandFactory = Arc::new(move || {
+        let mut cmd = tokio::process::Command::new("uv");
+        cmd.args(["run", "python", "-m", "ttsd"])
+            .current_dir(&ttsd_dir_for_factory);
+        cmd
+    });
+
+    // Emitter for ttsd_restarting / tts_fatal (and the model_* lifecycle
+    // re-emitted from supervisor.spawn_warmup).
+    let app_handle_for_emitter = app.clone();
+    let emitter: tts::supervisor::Emitter = Arc::new(move |event_name, payload| {
+        let _ = app_handle_for_emitter.emit(event_name, payload);
+    });
+
+    let supervisor =
+        tauri::async_runtime::block_on(async move { tts::TtsSupervisor::spawn(factory, emitter) })?;
+    Ok(Arc::new(supervisor))
+}
+
+/// Spawn the tray-command handler loop and return the channel sender.
+///
+/// The tray emits commands for "read clipboard now" / "queue clipboard"; this
+/// loop reads the system clipboard on a blocking thread, creates a history
+/// entry, and kicks off background synthesis.
+fn spawn_tray_handler<R: Runtime + 'static>(
+    storage: Arc<StorageService>,
+    tts: Arc<tts::TtsSupervisor>,
+    player: Arc<Player<R>>,
+    pipeline: Arc<Mutex<TTSPipeline>>,
+    app: AppHandle<R>,
+) -> tokio::sync::mpsc::Sender<TrayCmd> {
+    let (tray_tx, mut tray_rx) = tokio::sync::mpsc::channel::<TrayCmd>(16);
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(cmd) = tray_rx.recv().await {
+            // Read clipboard on a blocking thread (required on Linux).
+            let text_result = tokio::task::spawn_blocking(|| {
+                let mut board = arboard::Clipboard::new()?;
+                board.get_text()
+            })
+            .await;
+
+            let text = match text_result {
+                Ok(Ok(t)) if !t.trim().is_empty() => t,
+                Ok(Ok(_)) => {
+                    tracing::warn!("tray: clipboard is empty");
+                    continue;
+                }
+                Ok(Err(e)) => {
+                    tracing::error!("tray: clipboard read failed: {e}");
+                    continue;
+                }
+                Err(e) => {
+                    tracing::error!("tray: clipboard task panicked: {e}");
+                    continue;
+                }
+            };
+
+            let entry = match storage.add_entry(text) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::error!("tray: failed to add entry: {e}");
+                    continue;
+                }
+            };
+
+            let entry_id = entry.id;
+            let _ = app.emit("entry_updated", json!({ "entry": entry }));
+
+            spawn_synthesis_pub(
+                app.clone(),
+                Arc::clone(&storage),
+                Arc::clone(&tts),
+                Arc::clone(&player),
+                Arc::clone(&pipeline),
+                entry_id,
+                cmd.play_when_ready,
+            );
+        }
+    });
+
+    tray_tx
+}
+
 pub fn run() {
     reap_orphan_mpv();
     tauri::Builder::default()
@@ -78,132 +264,15 @@ pub fn run() {
         .plugin(tauri_plugin_mpv::init())
         .setup(|app| {
             tray::init(app.handle())?;
-
-            // WindowConfig in tauri.conf.json has no `icon` field, and the
-            // bundle-level icons only get wired up by `cargo tauri build`.
-            // For dev (and as a hardening for release), set the window icon
-            // explicitly so X11 / app switchers / task bars pick it up.
-            // Linux GTK CSD title bars typically don't render this icon
-            // inside the title bar itself — that is a GNOME/KDE chrome
-            // decision, not a Tauri limitation.
-            if let Some(window) = app.get_webview_window("main") {
-                let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/128x128.png"))?;
-                let _ = window.set_icon(icon);
-            }
+            install_window_icon(app.handle())?;
 
             let player = Arc::new(Player::new(app.handle().clone())?);
             player::spawn_position_emitter(player.clone(), app.handle().clone());
 
             let storage = Arc::new(StorageService::new().expect("failed to open storage"));
+            spawn_audio_migration_and_cleanup(Arc::clone(&storage));
 
-            // One-shot migration: any pre-Opus `.wav` audio in history gets
-            // transcoded to `.opus` in the background. Runs blocking on a
-            // dedicated thread so app startup is not delayed; per-entry
-            // errors are logged inside the migration routine.
-            //
-            // Once migration finishes the same task runs cache cleanup
-            // (orphan sweep + size-based eviction down to
-            // `max_cache_size_mb`). Keeping the order serialised guarantees
-            // the freshly-renamed `.opus` files are already linked to
-            // their entries before the orphan sweep walks the directory.
-            {
-                let storage_for_migration = Arc::clone(&storage);
-                tauri::async_runtime::spawn(async move {
-                    let storage_for_cleanup = Arc::clone(&storage_for_migration);
-                    let stats = tokio::task::spawn_blocking(move || {
-                        storage_for_migration.migrate_wav_audio_to_opus()
-                    })
-                    .await;
-                    match stats {
-                        Ok(s) if s.considered == 0 => {
-                            tracing::debug!("audio migration: nothing to do");
-                        }
-                        Ok(s) => {
-                            tracing::info!(
-                                "audio migration: considered={}, migrated={}, skipped_missing={}, failed={}",
-                                s.considered, s.migrated, s.skipped_missing, s.failed
-                            );
-                        }
-                        Err(e) => {
-                            tracing::error!("audio migration task panicked: {e}");
-                        }
-                    }
-
-                    let cleanup_result = tokio::task::spawn_blocking(move || {
-                        let cfg = storage_for_cleanup.load_config().unwrap_or_default();
-                        let target_bytes = (cfg.max_cache_size_mb as u64) * 1024 * 1024;
-                        storage_for_cleanup
-                            .run_startup_cleanup(target_bytes)
-                            .map_err(|e| e.to_string())
-                    })
-                    .await;
-                    match cleanup_result {
-                        Ok(Ok(s)) => {
-                            tracing::info!(
-                                "startup cleanup: orphans={}, evicted_files={}, freed={} bytes",
-                                s.sweep.deleted_files,
-                                s.evict.deleted_files,
-                                s.sweep.freed_bytes + s.evict.freed_bytes,
-                            );
-                        }
-                        Ok(Err(e)) => {
-                            tracing::warn!("startup cleanup failed: {e}");
-                        }
-                        Err(e) => {
-                            tracing::error!("startup cleanup task panicked: {e}");
-                        }
-                    }
-                });
-            }
-
-            // Spawn ttsd subprocess.
-            // In production: bundled next to the binary (resource_dir/ttsd).
-            // In `cargo tauri dev`: cwd is src-tauri/, so the project ttsd lives
-            // at ../ttsd; fall back to ./ttsd for ad-hoc runs from the repo root.
-            let ttsd_dir = {
-                let res_dir = app
-                    .path()
-                    .resource_dir()
-                    .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                    .join("ttsd");
-                if res_dir.exists() {
-                    res_dir
-                } else if std::path::Path::new("../ttsd/pyproject.toml").exists() {
-                    std::path::PathBuf::from("../ttsd")
-                } else {
-                    std::path::PathBuf::from("ttsd")
-                }
-            };
-
-            // Build a command factory the supervisor can call on every
-            // (re)spawn. Cloning the path captured by value keeps the closure
-            // `Fn` (not `FnOnce`) — required for the Arc<dyn Fn(...)> shape.
-            let ttsd_dir_for_factory = ttsd_dir.clone();
-            let factory: tts::supervisor::CommandFactory = Arc::new(move || {
-                let mut cmd = tokio::process::Command::new("uv");
-                cmd.args(["run", "python", "-m", "ttsd"])
-                    .current_dir(&ttsd_dir_for_factory);
-                cmd
-            });
-
-            // Emitter for ttsd_restarting / tts_fatal (and the model_*
-            // lifecycle re-emitted from supervisor.spawn_warmup).
-            let app_handle_for_emitter = app.handle().clone();
-            let emitter: tts::supervisor::Emitter =
-                Arc::new(move |event_name, payload| {
-                    let _ = app_handle_for_emitter.emit(event_name, payload);
-                });
-
-            // tokio::process::Command::spawn requires an active tokio runtime
-            // context; setup hook runs synchronously, so enter Tauri's runtime
-            // explicitly via block_on (the inner spawn returns instantly).
-            let tts = Arc::new(
-                tauri::async_runtime::block_on(async move {
-                    tts::TtsSupervisor::spawn(factory, emitter)
-                })
-                .expect("failed to spawn ttsd subprocess"),
-            );
-
+            let tts = build_ttsd_supervisor(app.handle())?;
             // Warm up Silero model in background. The supervisor owns the
             // model_loading → model_loaded/model_error emit sequence so the
             // initial warmup and post-respawn warmup share one code path.
@@ -215,76 +284,22 @@ pub fn run() {
             }
 
             let pipeline = Arc::new(Mutex::new(TTSPipeline::new()));
+            let tray_tx = spawn_tray_handler(
+                Arc::clone(&storage),
+                Arc::clone(&tts),
+                Arc::clone(&player),
+                Arc::clone(&pipeline),
+                app.handle().clone(),
+            );
 
-            // Create a channel for tray menu commands (read_now / read_later).
-            let (tray_tx, mut tray_rx) = tokio::sync::mpsc::channel::<TrayCmd>(16);
-
-            // Spawn the tray command handler loop.
-            {
-                let storage_clone = Arc::clone(&storage);
-                let tts_clone = Arc::clone(&tts);
-                let player_clone = Arc::clone(&player);
-                let pipeline_clone = Arc::clone(&pipeline);
-                let app_handle = app.handle().clone();
-
-                tauri::async_runtime::spawn(async move {
-                    while let Some(cmd) = tray_rx.recv().await {
-                        // Read clipboard on a blocking thread (required on Linux).
-                        let text_result = tokio::task::spawn_blocking(|| {
-                            let mut board = arboard::Clipboard::new()?;
-                            board.get_text()
-                        })
-                        .await;
-
-                        let text = match text_result {
-                            Ok(Ok(t)) if !t.trim().is_empty() => t,
-                            Ok(Ok(_)) => {
-                                tracing::warn!("tray: clipboard is empty");
-                                continue;
-                            }
-                            Ok(Err(e)) => {
-                                tracing::error!("tray: clipboard read failed: {e}");
-                                continue;
-                            }
-                            Err(e) => {
-                                tracing::error!("tray: clipboard task panicked: {e}");
-                                continue;
-                            }
-                        };
-
-                        let entry = match storage_clone.add_entry(text) {
-                            Ok(e) => e,
-                            Err(e) => {
-                                tracing::error!("tray: failed to add entry: {e}");
-                                continue;
-                            }
-                        };
-
-                        let entry_id = entry.id;
-                        let _ = app_handle.emit("entry_updated", json!({ "entry": entry }));
-
-                        spawn_synthesis_pub(
-                            app_handle.clone(),
-                            Arc::clone(&storage_clone),
-                            Arc::clone(&tts_clone),
-                            Arc::clone(&player_clone),
-                            Arc::clone(&pipeline_clone),
-                            entry_id,
-                            cmd.play_when_ready,
-                        );
-                    }
-                });
-            }
-
-            let app_state = AppState {
+            app.manage(AppState {
                 storage,
                 tts,
                 player,
                 pipeline,
                 tray_cmd_tx: Some(tray_tx),
                 user_quit: Arc::new(AtomicBool::new(false)),
-            };
-            app.manage(app_state);
+            });
 
             Ok(())
         })


### PR DESCRIPTION
## Summary
- Split the 220-line `tauri::Builder::setup` callback in `src-tauri/src/lib.rs` into four free functions:
  - `install_window_icon` — bundle-icon injection for the WebView window.
  - `spawn_audio_migration_and_cleanup` — one-shot WAV→Opus migration + startup cache cleanup task.
  - `build_ttsd_supervisor` — `ttsd` directory resolution, factory + emitter wiring, and `block_on` spawn.
  - `spawn_tray_handler` — tray command channel + clipboard read + entry-add + `spawn_synthesis_pub` loop.
- The setup closure shrinks to ~30 lines that wire the helpers together; observable behaviour is unchanged.

## Test plan
- [x] `cargo build --manifest-path src-tauri/Cargo.toml`
- [x] `cargo fmt`
- [x] `cargo clippy --no-deps -- -D warnings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --all-features`
- [ ] manual smoke: app launches, tray works, ttsd warmup emits `model_loading` → `model_loaded`