### PR TITLE
feat(tts): Piper as primary engine, Silero opt-in (#42)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,14 @@
             # buildInputs is enough — wrapGAppsHook3 picks it up for the
             # runtime LD_LIBRARY_PATH automatically.
             libopus
+            # espeak-ng — present for its data files only (see preFixup).
+            # piper-rs uses espeak-rs-sys's vendored libespeak-ng for
+            # phonemization, but its data dir lives in the cargo OUT_DIR
+            # which espeak-rs doesn't search at runtime. Pointing
+            # PIPER_ESPEAKNG_DATA_DIRECTORY at the nixpkgs share/ dir loads
+            # the full ru_dict / phondata / intonations files instead of
+            # the skeleton defaults that produce wrong Russian stress.
+            espeak-ng
           ];
 
           # Single target is enough for Nix — we only want a usable binary,
@@ -134,6 +142,7 @@
               --prefix PATH : ${lib.makeBinPath [ ttsd pkgs.mpv ]}
               --prefix LD_LIBRARY_PATH : ${extraRuntimeLibPath}
               --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1
+              --set-default PIPER_ESPEAKNG_DATA_DIRECTORY ${pkgs.espeak-ng}/share
             )
           '';
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
   },
   "dependencies": {
     "@mantine/core": "^8.0.0",
@@ -39,6 +41,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@22.19.17)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)
 
 packages:
 
@@ -195,16 +198,34 @@ packages:
   '@chevrotain/utils@12.0.0':
     resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -213,16 +234,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -231,10 +270,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -243,10 +294,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -255,10 +318,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -267,10 +342,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -279,16 +366,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -303,6 +408,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -313,6 +424,12 @@ packages:
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -327,11 +444,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -339,10 +468,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -789,6 +930,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -796,6 +966,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
@@ -807,8 +981,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.4.1:
     resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
@@ -1014,6 +1200,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
@@ -1033,6 +1223,14 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1041,6 +1239,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1129,8 +1334,14 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   markdown-it-highlightjs@4.3.0:
     resolution: {integrity: sha512-dTEXpTV2J9WJiO8TA/FJ4DxidrYtTNcfBAdl+CLjQ3UFWj8s4dJyCPTcvoXNLmN5U5ZTCGu7TSkSvBvi4fUqkQ==}
@@ -1174,8 +1385,15 @@ packages:
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1310,15 +1528,30 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -1327,6 +1560,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -1413,6 +1658,42 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -1453,6 +1734,31 @@ packages:
       yaml:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -1472,6 +1778,11 @@ packages:
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1632,52 +1943,103 @@ snapshots:
 
   '@chevrotain/utils@12.0.0': {}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -1686,10 +2048,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1698,13 +2066,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -2130,9 +2510,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   acorn@8.16.0: {}
 
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   baseline-browser-mapping@2.10.20: {}
 
@@ -2144,7 +2566,19 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001788: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
     dependencies:
@@ -2369,6 +2803,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
@@ -2387,6 +2823,34 @@ snapshots:
   electron-to-chromium@1.5.340: {}
 
   entities@4.5.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2418,6 +2882,12 @@ snapshots:
       '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2481,9 +2951,15 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-it-highlightjs@4.3.0:
     dependencies:
@@ -2545,7 +3021,11 @@ snapshots:
 
   path-data-parser@0.1.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2712,11 +3192,21 @@ snapshots:
 
   semver@6.3.1: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stylis@4.4.0: {}
 
   tabbable@6.4.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.1.1: {}
 
@@ -2724,6 +3214,12 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   ts-dedent@2.2.0: {}
 
@@ -2783,6 +3279,33 @@ snapshots:
 
   uuid@11.1.0: {}
 
+  vite-node@2.1.9(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
   vite@6.4.2(@types/node@22.19.17):
     dependencies:
       esbuild: 0.25.12
@@ -2794,6 +3317,41 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.17):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 2.1.9(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -2811,6 +3369,11 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}
 

--- a/shell.nix
+++ b/shell.nix
@@ -40,11 +40,17 @@ pkgs.mkShell {
 
     # ── Piper TTS native runtime ───────────────────────────────────────────
     # piper-rs links libonnxruntime via `ort` with the `load-dynamic` feature
-    # (set ORT_DYLIB_PATH below). espeak-ng is *not* listed: espeak-rs-sys
-    # vendors the espeak-ng source under its own `espeak-ng/` directory and
-    # builds it via cmake — both the C library and the phoneme data ship
-    # inside the dependency.
+    # (set ORT_DYLIB_PATH below). espeak-rs-sys vendors libespeak-ng and
+    # builds it via cmake, so we don't need the package for linking — but
+    # the cmake build's espeak-ng-data ends up in target/debug/build/.../out
+    # which espeak-rs never looks at (it checks $CWD/espeak-ng-data and
+    # $exe_dir/espeak-ng-data only). Without PIPER_ESPEAKNG_DATA_DIRECTORY
+    # (set in shellHook) the library initialises with NULL data path, the
+    # ru_dict / phondata / intonations files are not loaded, and Russian
+    # phonemization falls back to skeleton defaults — manifesting as
+    # consistently wrong word stress on every Piper voice.
     onnxruntime
+    espeak-ng
 
     # ── Tauri 2 Linux system dependencies ─────────────────────────────────
     # WebKit with ABI 4.1 (required by Tauri 2; 4.0 was removed)
@@ -157,6 +163,11 @@ pkgs.mkShell {
 
   # `ort` with the `load-dynamic` feature dlopens libonnxruntime at runtime.
   ORT_DYLIB_PATH = "${pkgs.onnxruntime}/lib/libonnxruntime.so";
+
+  # Point espeak-rs at the full nixpkgs espeak-ng data dir. The crate looks
+  # for `<this>/espeak-ng-data/` and falls back to NULL (= no data path) if
+  # the directory is missing — see comment next to `espeak-ng` in buildInputs.
+  PIPER_ESPEAKNG_DATA_DIRECTORY = "${pkgs.espeak-ng}/share";
 
   shellHook = ''
     export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"

--- a/shell.nix
+++ b/shell.nix
@@ -34,6 +34,17 @@ pkgs.mkShell {
 
     # ── Build tools ────────────────────────────────────────────────────────
     pkg-config
+    cmake
+    clang
+    llvmPackages.libclang
+
+    # ── Piper TTS native runtime ───────────────────────────────────────────
+    # piper-rs links libonnxruntime via `ort` with the `load-dynamic` feature
+    # (set ORT_DYLIB_PATH below). espeak-ng is *not* listed: espeak-rs-sys
+    # vendors the espeak-ng source under its own `espeak-ng/` directory and
+    # builds it via cmake — both the C library and the phoneme data ship
+    # inside the dependency.
+    onnxruntime
 
     # ── Tauri 2 Linux system dependencies ─────────────────────────────────
     # WebKit with ABI 4.1 (required by Tauri 2; 4.0 was removed)
@@ -141,8 +152,24 @@ pkgs.mkShell {
   OPENSSL_DIR = "${pkgs.openssl.dev}";
   OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
 
+  # bindgen (used by sonic-rs-sys, espeak-rs-sys, ort-sys) needs libclang.
+  LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
+  # `ort` with the `load-dynamic` feature dlopens libonnxruntime at runtime.
+  ORT_DYLIB_PATH = "${pkgs.onnxruntime}/lib/libonnxruntime.so";
+
   shellHook = ''
     export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
+
+    # bindgen needs the C system include paths from stdenv.cc — without these,
+    # `#include <stdio.h>` fails inside the espeak-rs-sys / sonic-rs-sys build
+    # scripts because clang has no implicit C system headers under nix.
+    if [ -f "${pkgs.stdenv.cc}/nix-support/libcxx-cxxflags" ]; then
+      _cxxflags="$(< ${pkgs.stdenv.cc}/nix-support/libcxx-cxxflags)"
+    else
+      _cxxflags=""
+    fi
+    export BINDGEN_EXTRA_CLANG_ARGS="$(< ${pkgs.stdenv.cc}/nix-support/libc-crt1-cflags) $(< ${pkgs.stdenv.cc}/nix-support/libc-cflags) $(< ${pkgs.stdenv.cc}/nix-support/cc-cflags) $_cxxflags"
 
     # Needed by glib-networking (TLS for WebKit)
     export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -553,6 +553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,8 +1557,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1562,9 +1570,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1892,6 +1902,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2398,6 +2424,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3427,6 +3459,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,6 +3560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +3615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3640,6 +3756,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3668,7 +3825,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3763,6 +3920,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3794,6 +3952,7 @@ dependencies = [
  "chrono",
  "dirs",
  "filetime",
+ "futures-util",
  "hound",
  "libc",
  "ogg",
@@ -3804,6 +3963,7 @@ dependencies = [
  "parking_lot",
  "piper-rs",
  "regex",
+ "reqwest 0.12.28",
  "scraper",
  "serde",
  "serde_json",
@@ -3819,6 +3979,12 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4061,6 +4227,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4525,7 +4703,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4909,6 +5087,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4933,6 +5126,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -5487,6 +5690,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -5585,6 +5801,16 @@ name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -163,7 +163,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -269,6 +269,48 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
 
 [[package]]
 name = "bit-set"
@@ -363,6 +405,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 
 [[package]]
 name = "byteorder"
@@ -469,12 +517,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
- "byteorder",
+ "byteorder 1.5.0",
  "fnv",
  "uuid",
 ]
@@ -507,6 +564,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -625,6 +693,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -933,6 +1020,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1106,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "espeak-rs"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d648355e4824dd2b37fcc84af3cbc234f96ae4f7c515fea2df7094f98453edd0"
+dependencies = [
+ "espeak-rs-sys",
+ "ffi-support",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "espeak-rs-sys"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb333310ae915d57961a6bbc67f53ef7b313a9ee80d393d55c0f27f1b65c848"
+dependencies = [
+ "bindgen 0.69.5",
+ "cmake",
+ "glob",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1185,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ffi-support"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27838c6815cfe9de2d3aeb145ffd19e565f577414b33f3bdbf42fe040e9e0ff6"
+dependencies = [
+ "lazy_static",
+ "log",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1235,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1265,7 +1402,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "byteorder",
+ "byteorder 1.5.0",
 ]
 
 [[package]]
@@ -1383,7 +1520,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -1648,6 +1785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,7 +1947,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
- "byteorder",
+ "byteorder 1.5.0",
  "png 0.17.16",
 ]
 
@@ -2002,6 +2148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2287,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,7 +2324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2178,6 +2345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2365,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.4",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2279,6 +2462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2491,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2352,6 +2551,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2609,16 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -2403,10 +2627,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2569,7 +2811,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
 dependencies = [
- "byteorder",
+ "byteorder 1.5.0",
 ]
 
 [[package]]
@@ -2613,6 +2855,32 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+dependencies = [
+ "half",
+ "libloading 0.8.9",
+ "ndarray",
+ "ort-sys",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+dependencies = [
+ "flate2",
+ "pkg-config",
+ "sha2",
+ "tar",
+ "ureq",
 ]
 
 [[package]]
@@ -2684,6 +2952,12 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -2917,6 +3191,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "piper-rs"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ae201fce47228d58b8ff1afa9a70015da6ead273da796c32808900a36988e2"
+dependencies = [
+ "espeak-rs",
+ "flume",
+ "ndarray",
+ "once_cell",
+ "ort",
+ "rayon",
+ "riff-wave",
+ "serde",
+ "serde_json",
+ "sonic-rs-sys",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,8 +3269,23 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3228,6 +3535,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3673,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "riff-wave"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a749a2a6b5d4e3659a095accc05fdb5b2439fc409c4a00d049a2e72e8352df1"
+dependencies = [
+ "byteorder 0.5.3",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3356,6 +3718,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3363,8 +3738,43 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3379,7 +3789,8 @@ version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "arboard",
- "byteorder",
+ "async-trait",
+ "byteorder 1.5.0",
  "chrono",
  "dirs",
  "filetime",
@@ -3388,7 +3799,10 @@ dependencies = [
  "ogg",
  "once_cell",
  "opus",
+ "ort",
+ "ort-sys",
  "parking_lot",
+ "piper-rs",
  "regex",
  "scraper",
  "serde",
@@ -3539,7 +3953,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -3804,6 +4218,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder 1.5.0",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,6 +4248,16 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sonic-rs-sys"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9580f267e06365724088d57fb956ee0016b227796fb947fc4b1a6cee74a60c6"
+dependencies = [
+ "bindgen 0.59.2",
+ "cc",
 ]
 
 [[package]]
@@ -3849,6 +4284,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -3911,6 +4355,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4025,6 +4475,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4327,7 +4788,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4697,7 +5158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
  "memchr",
- "nom",
+ "nom 8.0.0",
  "petgraph",
 ]
 
@@ -4794,6 +5255,28 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -5035,7 +5518,7 @@ checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
  "wayland-sys",
 ]
@@ -5047,7 +5530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.1",
- "rustix",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5164,6 +5647,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5204,6 +5705,18 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
 
 [[package]]
 name = "winapi"
@@ -5397,6 +5910,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5770,7 +6292,7 @@ dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix",
+ "rustix 1.1.4",
  "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
@@ -5857,7 +6379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -5866,6 +6388,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "yoke"
@@ -5912,7 +6444,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
@@ -5991,6 +6523,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,23 @@ ogg = "0.9"
 hound = "3.5"
 byteorder = "1.5"
 
+# ── Piper TTS (native engine) ────────────────────────────────────────────────
+# `piper-rs` runs Piper's VITS ONNX models in-process. We pin both `ort` and
+# `ort-sys` to `=2.0.0-rc.9` because piper-rs 0.1.9's source uses ort APIs that
+# were broken between rc.9 and rc.12, and `ort 2.0.0-rc.9` requires
+# `ort-sys = 2.0.0-rc.9` (later ort-sys releases dropped the `load-dynamic`
+# feature). See tmp/piper_rs_spike/findings.md for the reasoning.
+#
+# `ort` is configured with `default-features = false` + `load-dynamic` so
+# onnxruntime is dlopened from the path in `ORT_DYLIB_PATH` (set by shell.nix
+# to ${pkgs.onnxruntime}/lib/libonnxruntime.so) — avoids the default
+# `download-binaries` feature which fetches a prebuilt blob at build time and
+# does not work inside the nix sandbox.
+piper-rs = "0.1.9"
+ort = { version = "=2.0.0-rc.9", default-features = false, features = ["load-dynamic"] }
+ort-sys = "=2.0.0-rc.9"
+async-trait = "0.1"
+
 [dev-dependencies]
 tempfile = "3"
 similar = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -82,6 +82,12 @@ ort = { version = "=2.0.0-rc.9", default-features = false, features = ["load-dyn
 ort-sys = "=2.0.0-rc.9"
 async-trait = "0.1"
 
+# On-demand Piper voice download (Phase 4 of #42). `rustls-tls` keeps us off
+# the system OpenSSL ABI; `stream` exposes `bytes_stream()` for the progress
+# loop. `default-features = false` suppresses ureq + native-tls.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+futures-util = "0.3"
+
 [dev-dependencies]
 tempfile = "3"
 similar = "2"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -198,10 +198,19 @@ async fn synthesize_audio(
         Some(char_mapping_to_entries(mapping))
     };
 
+    // Voice id is engine-specific: Piper uses `piper_voice` (e.g. "ruslan"),
+    // Silero uses `speaker` (e.g. "xenia"). Keeping them in two distinct
+    // config fields means flipping engines preserves each side's choice.
+    let voice = if config.engine == "silero" {
+        config.speaker.clone()
+    } else {
+        config.piper_voice.clone()
+    };
+
     let output = tts
         .synthesize(
             normalized,
-            config.speaker.clone(),
+            voice,
             config.sample_rate,
             out_wav,
             tts_char_mapping,
@@ -756,11 +765,23 @@ pub async fn get_config(state: State<'_, AppState>) -> CmdResult<UIConfig> {
     state.storage.load_config().map_err(CommandError::from)
 }
 
-/// Merge a partial config patch into the current configuration and persist.
+/// Merge a partial config patch into the current configuration, swap the
+/// active TTS engine if needed, and persist. The engine swap runs *before*
+/// the config is saved — if the user picked a Silero stack we cannot spawn,
+/// the call returns an error and the previous config stays on disk.
 #[tauri::command]
 pub async fn update_config(state: State<'_, AppState>, patch: UIConfigPatch) -> CmdResult<()> {
     let mut config = state.storage.load_config().unwrap_or_default();
     apply_config_patch(&mut config, patch);
+
+    state
+        .engine_switcher
+        .apply_config(&config.engine, &config.piper_voice)
+        .await
+        .map_err(|e| CommandError::ConfigError {
+            message: format!("не удалось переключить движок: {e}"),
+        })?;
+
     state
         .storage
         .save_config(&config)
@@ -947,6 +968,12 @@ fn apply_config_patch(config: &mut UIConfig, patch: UIConfigPatch) {
     }
     if let Some(v) = patch.preview_dialog_enabled {
         config.preview_dialog_enabled = v;
+    }
+    if let Some(v) = patch.engine {
+        config.engine = v;
+    }
+    if let Some(v) = patch.piper_voice {
+        config.piper_voice = v;
     }
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,6 +20,7 @@ use crate::storage::schema::{
     EntryId, EntryStatus, TextEntry, UIConfig, UIConfigPatch, WordTimestamp,
 };
 use crate::storage::service::{StorageError, StorageService};
+use crate::tts::piper::download::download_voice;
 use crate::tts::{
     availability, AvailableEngines, CharMappingEntry, SynthesizeOutput, TtsEngine, TtsError,
 };
@@ -98,10 +99,13 @@ fn char_mapping_to_entries(mapping: &CharMapping) -> Vec<CharMappingEntry> {
 // ── Background synthesis ───────────────────────────────────────────────────────
 
 /// Public alias used by the tray module to avoid duplicating the synthesis logic.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_synthesis_pub<R: Runtime + 'static>(
     app: AppHandle<R>,
     storage: Arc<StorageService>,
     tts: Arc<dyn TtsEngine>,
+    piper_voices_dir: PathBuf,
+    emitter: crate::tts::supervisor::Emitter,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<parking_lot::Mutex<crate::pipeline::TTSPipeline>>,
     entry_id: EntryId,
@@ -111,6 +115,8 @@ pub fn spawn_synthesis_pub<R: Runtime + 'static>(
         app,
         storage,
         tts,
+        piper_voices_dir,
+        emitter,
         player,
         pipeline,
         entry_id,
@@ -181,9 +187,17 @@ fn mark_processing<R: Runtime>(
 /// call `tts.synthesize`. Returns the synthesize output along with the
 /// resolved WAV path and filename so [`finalize_audio_files`] can transcode
 /// to Opus without rebuilding them.
+///
+/// When the engine returns `voice_not_installed` and the active engine is
+/// Piper, the function auto-fetches the voice files via
+/// [`crate::tts::piper::download::download_voice`] and retries once. The
+/// retry runs only on Piper because Silero is bundled — its Python venv
+/// already includes the model.
 async fn synthesize_audio(
     tts: &dyn TtsEngine,
     storage: &StorageService,
+    piper_voices_dir: &std::path::Path,
+    emitter: &crate::tts::supervisor::Emitter,
     entry_id: &EntryId,
     normalized: String,
     mapping: &CharMapping,
@@ -209,16 +223,37 @@ async fn synthesize_audio(
         config.piper_voice.clone()
     };
 
-    let output = tts
+    let attempt = tts
         .synthesize(
-            normalized,
-            voice,
+            normalized.clone(),
+            voice.clone(),
             config.sample_rate,
-            out_wav,
-            tts_char_mapping,
+            out_wav.clone(),
+            tts_char_mapping.clone(),
         )
-        .await
-        .map_err(|e| SynthesisError::TtsFailed(e.to_string()))?;
+        .await;
+
+    let output = match attempt {
+        Ok(o) => o,
+        Err(TtsError::Ttsd { code, message })
+            if code == "voice_not_installed" && config.engine == "piper" =>
+        {
+            info!("voice \"{voice}\" not installed; auto-downloading then retrying ({message})");
+            crate::tts::piper::download::download_voice(piper_voices_dir, &voice, emitter)
+                .await
+                .map_err(|e| SynthesisError::TtsFailed(e.to_string()))?;
+            tts.synthesize(
+                normalized,
+                voice,
+                config.sample_rate,
+                out_wav,
+                tts_char_mapping,
+            )
+            .await
+            .map_err(|e| SynthesisError::TtsFailed(e.to_string()))?
+        }
+        Err(e) => return Err(SynthesisError::TtsFailed(e.to_string())),
+    };
 
     Ok((output, out_wav_path, wav_filename))
 }
@@ -318,10 +353,13 @@ fn autoplay<R: Runtime>(
 }
 
 /// Run the full synthesis pipeline for `entry_id` in a background task.
+#[allow(clippy::too_many_arguments)]
 fn spawn_synthesis<R: Runtime + 'static>(
     app: AppHandle<R>,
     storage: Arc<StorageService>,
     tts: Arc<dyn TtsEngine>,
+    piper_voices_dir: PathBuf,
+    emitter: crate::tts::supervisor::Emitter,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<Mutex<TTSPipeline>>,
     entry_id: EntryId,
@@ -337,8 +375,16 @@ fn spawn_synthesis<R: Runtime + 'static>(
             let (normalized, mapping) =
                 run_normalization(Arc::clone(&pipeline), entry.original_text.clone()).await?;
             mark_processing(&storage, &app, &entry_id, &normalized);
-            let (output, out_wav_path, wav_filename) =
-                synthesize_audio(tts.as_ref(), &storage, &entry_id, normalized, &mapping).await?;
+            let (output, out_wav_path, wav_filename) = synthesize_audio(
+                tts.as_ref(),
+                &storage,
+                &piper_voices_dir,
+                &emitter,
+                &entry_id,
+                normalized,
+                &mapping,
+            )
+            .await?;
             let (ts_filename, audio_filename) =
                 finalize_audio_files(&storage, &entry_id, &output, out_wav_path, &wav_filename)
                     .await;
@@ -412,6 +458,8 @@ fn ingest_text(
         app,
         Arc::clone(&state.storage),
         Arc::clone(&state.tts),
+        state.piper_voices_dir.clone(),
+        Arc::clone(&state.emitter),
         Arc::clone(&state.player),
         Arc::clone(&state.pipeline),
         entry_id,
@@ -598,6 +646,8 @@ pub async fn regenerate_entry(
         app,
         Arc::clone(&state.storage),
         Arc::clone(&state.tts),
+        state.piper_voices_dir.clone(),
+        Arc::clone(&state.emitter),
         Arc::clone(&state.player),
         Arc::clone(&state.pipeline),
         uuid,
@@ -765,6 +815,20 @@ pub async fn set_volume(state: State<'_, AppState>, volume: f32) -> CmdResult<()
 #[tauri::command]
 pub async fn get_config(state: State<'_, AppState>) -> CmdResult<UIConfig> {
     state.storage.load_config().map_err(CommandError::from)
+}
+
+/// Download a Piper voice on user demand. Idempotent — already-present
+/// files are skipped. Progress is delivered via the
+/// `voice_download_started` / `voice_download_progress` /
+/// `voice_download_finished` events; the `Result` here only reports the
+/// final outcome so the frontend can show one final notification.
+#[tauri::command]
+pub async fn download_piper_voice(state: State<'_, AppState>, voice_id: String) -> CmdResult<()> {
+    let voices_dir = state.piper_voices_dir.clone();
+    let emitter = Arc::clone(&state.emitter);
+    download_voice(&voices_dir, &voice_id, &emitter)
+        .await
+        .map_err(CommandError::from)
 }
 
 /// Probe which TTS engines can be selected on the running system.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,7 +20,7 @@ use crate::storage::schema::{
     EntryId, EntryStatus, TextEntry, UIConfig, UIConfigPatch, WordTimestamp,
 };
 use crate::storage::service::{StorageError, StorageService};
-use crate::tts::{CharMappingEntry, SynthesizeOutput, TtsError, TtsSupervisor};
+use crate::tts::{CharMappingEntry, SynthesizeOutput, TtsEngine, TtsError};
 
 // ── Error type ─────────────────────────────────────────────────────────────────
 
@@ -99,7 +99,7 @@ fn char_mapping_to_entries(mapping: &CharMapping) -> Vec<CharMappingEntry> {
 pub fn spawn_synthesis_pub<R: Runtime + 'static>(
     app: AppHandle<R>,
     storage: Arc<StorageService>,
-    tts: Arc<crate::tts::TtsSupervisor>,
+    tts: Arc<dyn TtsEngine>,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<parking_lot::Mutex<crate::pipeline::TTSPipeline>>,
     entry_id: EntryId,
@@ -180,7 +180,7 @@ fn mark_processing<R: Runtime>(
 /// resolved WAV path and filename so [`finalize_audio_files`] can transcode
 /// to Opus without rebuilding them.
 async fn synthesize_audio(
-    tts: &TtsSupervisor,
+    tts: &dyn TtsEngine,
     storage: &StorageService,
     entry_id: &EntryId,
     normalized: String,
@@ -310,7 +310,7 @@ fn autoplay<R: Runtime>(
 fn spawn_synthesis<R: Runtime + 'static>(
     app: AppHandle<R>,
     storage: Arc<StorageService>,
-    tts: Arc<TtsSupervisor>,
+    tts: Arc<dyn TtsEngine>,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<Mutex<TTSPipeline>>,
     entry_id: EntryId,
@@ -327,7 +327,7 @@ fn spawn_synthesis<R: Runtime + 'static>(
                 run_normalization(Arc::clone(&pipeline), entry.original_text.clone()).await?;
             mark_processing(&storage, &app, &entry_id, &normalized);
             let (output, out_wav_path, wav_filename) =
-                synthesize_audio(&tts, &storage, &entry_id, normalized, &mapping).await?;
+                synthesize_audio(tts.as_ref(), &storage, &entry_id, normalized, &mapping).await?;
             let (ts_filename, audio_filename) =
                 finalize_audio_files(&storage, &entry_id, &output, out_wav_path, &wav_filename)
                     .await;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,7 +20,9 @@ use crate::storage::schema::{
     EntryId, EntryStatus, TextEntry, UIConfig, UIConfigPatch, WordTimestamp,
 };
 use crate::storage::service::{StorageError, StorageService};
-use crate::tts::{CharMappingEntry, SynthesizeOutput, TtsEngine, TtsError};
+use crate::tts::{
+    availability, AvailableEngines, CharMappingEntry, SynthesizeOutput, TtsEngine, TtsError,
+};
 
 // ── Error type ─────────────────────────────────────────────────────────────────
 
@@ -763,6 +765,22 @@ pub async fn set_volume(state: State<'_, AppState>, volume: f32) -> CmdResult<()
 #[tauri::command]
 pub async fn get_config(state: State<'_, AppState>) -> CmdResult<UIConfig> {
     state.storage.load_config().map_err(CommandError::from)
+}
+
+/// Probe which TTS engines can be selected on the running system.
+///
+/// Piper is in-process and always available. Silero requires the `ttsd/`
+/// Python package and the `uv` toolchain — see [`tts::availability`].
+/// Cheap (filesystem stat + one `uv --version` exec); safe to call on
+/// every Settings dialog open.
+#[tauri::command]
+pub async fn get_available_engines(state: State<'_, AppState>) -> CmdResult<AvailableEngines> {
+    let ttsd_dir = state.ttsd_dir.clone();
+    tokio::task::spawn_blocking(move || availability::probe(&ttsd_dir))
+        .await
+        .map_err(|e| CommandError::Internal {
+            message: format!("availability probe panicked: {e}"),
+        })
 }
 
 /// Merge a partial config patch into the current configuration, swap the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -186,10 +186,19 @@ fn resolve_ttsd_dir<R: Runtime>(app: &AppHandle<R>) -> std::path::PathBuf {
 /// — see `tts::piper::catalog`. Phase 4 of #42 adds on-demand download;
 /// for now, if the default voice isn't on disk, warmup emits `model_error`
 /// and the first synthesize returns `voice_not_installed`.
+/// Returns the active engine layer plus the runtime paths and emitter the
+/// rest of the app needs (Phase 4 download command, Phase 3 probe).
+type EngineWiring = (
+    Arc<tts::EngineSwitcher>,
+    std::path::PathBuf, // ttsd_dir
+    std::path::PathBuf, // piper_voices_dir
+    tts::supervisor::Emitter,
+);
+
 fn build_engine<R: Runtime>(
     app: &AppHandle<R>,
     storage: &StorageService,
-) -> Result<(Arc<tts::EngineSwitcher>, std::path::PathBuf), SetupError> {
+) -> Result<EngineWiring, SetupError> {
     let voices_dir = dirs::data_local_dir()
         .ok_or("dirs::data_local_dir() returned None")?
         .join("ruvox")
@@ -229,11 +238,11 @@ fn build_engine<R: Runtime>(
         initial_engine,
         initial_kind,
         initial_voice,
-        voices_dir,
+        voices_dir.clone(),
         ttsd_dir.clone(),
-        emitter,
+        Arc::clone(&emitter),
     ));
-    Ok((switcher, ttsd_dir))
+    Ok((switcher, ttsd_dir, voices_dir, emitter))
 }
 
 fn build_piper_initial(
@@ -268,9 +277,12 @@ fn try_build_silero(
 /// The tray emits commands for "read clipboard now" / "queue clipboard"; this
 /// loop reads the system clipboard on a blocking thread, creates a history
 /// entry, and kicks off background synthesis.
+#[allow(clippy::too_many_arguments)]
 fn spawn_tray_handler<R: Runtime + 'static>(
     storage: Arc<StorageService>,
     tts: Arc<dyn tts::TtsEngine>,
+    piper_voices_dir: std::path::PathBuf,
+    emitter: tts::supervisor::Emitter,
     player: Arc<Player<R>>,
     pipeline: Arc<Mutex<TTSPipeline>>,
     app: AppHandle<R>,
@@ -317,6 +329,8 @@ fn spawn_tray_handler<R: Runtime + 'static>(
                 app.clone(),
                 Arc::clone(&storage),
                 Arc::clone(&tts),
+                piper_voices_dir.clone(),
+                Arc::clone(&emitter),
                 Arc::clone(&player),
                 Arc::clone(&pipeline),
                 entry_id,
@@ -344,7 +358,8 @@ pub fn run() {
             let storage = Arc::new(StorageService::new().expect("failed to open storage"));
             spawn_audio_migration_and_cleanup(Arc::clone(&storage));
 
-            let (engine_switcher, ttsd_dir) = build_engine(app.handle(), &storage)?;
+            let (engine_switcher, ttsd_dir, piper_voices_dir, emitter) =
+                build_engine(app.handle(), &storage)?;
             let tts: Arc<dyn tts::TtsEngine> = engine_switcher.clone();
             // Warm up the model in background. The engine owns the
             // model_loading → model_loaded/model_error emit sequence so the
@@ -360,6 +375,8 @@ pub fn run() {
             let tray_tx = spawn_tray_handler(
                 Arc::clone(&storage),
                 Arc::clone(&tts),
+                piper_voices_dir.clone(),
+                Arc::clone(&emitter),
                 Arc::clone(&player),
                 Arc::clone(&pipeline),
                 app.handle().clone(),
@@ -370,6 +387,8 @@ pub fn run() {
                 tts,
                 engine_switcher,
                 ttsd_dir,
+                piper_voices_dir,
+                emitter,
                 player,
                 pipeline,
                 tray_cmd_tx: Some(tray_tx),
@@ -398,6 +417,7 @@ pub fn run() {
             get_config,
             update_config,
             get_available_engines,
+            download_piper_voice,
             get_timestamps,
             clear_cache,
             get_cache_stats,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,17 +143,50 @@ fn spawn_audio_migration_and_cleanup(storage: Arc<StorageService>) {
     });
 }
 
-/// Build the TTS engine for the running app.
+/// Resolve the on-disk `ttsd/` directory used by Silero.
 ///
-/// Today we hardcode the Piper engine (issue #42, Phase 1). Once issue #43
-/// lands a `withSilero` flake flag and the availability probe (issue #42
-/// Phase 3), this function will branch on the user's config and the probe.
+/// In production the bundle ships ttsd next to the binary (resource_dir/ttsd).
+/// In `cargo tauri dev` cwd is `src-tauri/`, so the project ttsd lives at
+/// `../ttsd`; fall back to `./ttsd` for ad-hoc runs from the repo root.
+/// The path is consumed by [`tts::EngineSwitcher::apply_config`] only when
+/// the user actually picks Silero — the directory is not required to exist
+/// at startup.
+fn resolve_ttsd_dir<R: Runtime>(app: &AppHandle<R>) -> std::path::PathBuf {
+    let res_dir = app
+        .path()
+        .resource_dir()
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+        .join("ttsd");
+    if res_dir.exists() {
+        res_dir
+    } else if std::path::Path::new("../ttsd/pyproject.toml").exists() {
+        std::path::PathBuf::from("../ttsd")
+    } else {
+        std::path::PathBuf::from("ttsd")
+    }
+}
+
+/// Build the TTS engine layer for the running app.
 ///
-/// Voice models live at `<data_local_dir>/ruvox/voices/piper/<voice>/...`
+/// Returns the [`tts::EngineSwitcher`] that owns the active engine. The
+/// switcher impls [`tts::TtsEngine`], so callers can hold either an
+/// `Arc<EngineSwitcher>` (for swap/`apply_config`) or `Arc<dyn TtsEngine>`
+/// (for synthesis) — both pointing at the same allocation.
+///
+/// The initial engine is chosen from the persisted config:
+/// - `engine = "piper"` (default) → in-process [`tts::PiperEngine`].
+/// - `engine = "silero"` → [`tts::TtsSupervisor`] over `uv run python -m ttsd`.
+///   Failure to spawn (no `uv`, missing ttsd dir) silently falls back to
+///   Piper; Phase 3 of #42 will probe up-front instead.
+///
+/// Voice models live at `<data_local_dir>/ruvox/voices/piper/<voice>/…`
 /// — see `tts::piper::catalog`. Phase 4 of #42 adds on-demand download;
-/// for now, if the default voice isn't on disk, warmup logs a `model_error`
+/// for now, if the default voice isn't on disk, warmup emits `model_error`
 /// and the first synthesize returns `voice_not_installed`.
-fn build_engine<R: Runtime>(app: &AppHandle<R>) -> Result<Arc<dyn tts::TtsEngine>, SetupError> {
+fn build_engine<R: Runtime>(
+    app: &AppHandle<R>,
+    storage: &StorageService,
+) -> Result<Arc<tts::EngineSwitcher>, SetupError> {
     let voices_dir = dirs::data_local_dir()
         .ok_or("dirs::data_local_dir() returned None")?
         .join("ruvox")
@@ -165,11 +198,61 @@ fn build_engine<R: Runtime>(app: &AppHandle<R>) -> Result<Arc<dyn tts::TtsEngine
         let _ = app_handle_for_emitter.emit(event_name, payload);
     });
 
-    Ok(Arc::new(tts::PiperEngine::new(
+    let config = storage.load_config().unwrap_or_default();
+    let ttsd_dir = resolve_ttsd_dir(app);
+
+    let (initial_engine, initial_kind, initial_voice) = match config.engine.as_str() {
+        "silero" => match try_build_silero(&ttsd_dir, Arc::clone(&emitter)) {
+            Ok(sup) => {
+                let engine: Arc<dyn tts::TtsEngine> = sup;
+                (engine, tts::EngineKind::Silero, None)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "config requested Silero but spawn failed ({e}); falling back to Piper"
+                );
+                let voice = config.piper_voice.clone();
+                let engine: Arc<dyn tts::TtsEngine> = Arc::new(tts::PiperEngine::new(
+                    voices_dir.clone(),
+                    voice.clone(),
+                    Arc::clone(&emitter),
+                ));
+                (engine, tts::EngineKind::Piper, Some(voice))
+            }
+        },
+        _ => {
+            let voice = config.piper_voice.clone();
+            let engine: Arc<dyn tts::TtsEngine> = Arc::new(tts::PiperEngine::new(
+                voices_dir.clone(),
+                voice.clone(),
+                Arc::clone(&emitter),
+            ));
+            (engine, tts::EngineKind::Piper, Some(voice))
+        }
+    };
+
+    Ok(Arc::new(tts::EngineSwitcher::new(
+        initial_engine,
+        initial_kind,
+        initial_voice,
         voices_dir,
-        tts::piper::catalog::DEFAULT_VOICE.to_string(),
+        ttsd_dir,
         emitter,
     )))
+}
+
+fn try_build_silero(
+    ttsd_dir: &std::path::Path,
+    emitter: tts::supervisor::Emitter,
+) -> Result<Arc<tts::TtsSupervisor>, tts::TtsError> {
+    let ttsd_dir = ttsd_dir.to_path_buf();
+    let factory: tts::supervisor::CommandFactory = Arc::new(move || {
+        let mut cmd = tokio::process::Command::new("uv");
+        cmd.args(["run", "python", "-m", "ttsd"])
+            .current_dir(&ttsd_dir);
+        cmd
+    });
+    Ok(Arc::new(tts::TtsSupervisor::spawn(factory, emitter)?))
 }
 
 /// Spawn the tray-command handler loop and return the channel sender.
@@ -253,7 +336,8 @@ pub fn run() {
             let storage = Arc::new(StorageService::new().expect("failed to open storage"));
             spawn_audio_migration_and_cleanup(Arc::clone(&storage));
 
-            let tts: Arc<dyn tts::TtsEngine> = build_engine(app.handle())?;
+            let engine_switcher = build_engine(app.handle(), &storage)?;
+            let tts: Arc<dyn tts::TtsEngine> = engine_switcher.clone();
             // Warm up the model in background. The engine owns the
             // model_loading → model_loaded/model_error emit sequence so the
             // initial warmup and post-respawn warmup share one code path.
@@ -276,6 +360,7 @@ pub fn run() {
             app.manage(AppState {
                 storage,
                 tts,
+                engine_switcher,
                 player,
                 pipeline,
                 tray_cmd_tx: Some(tray_tx),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,16 +168,19 @@ fn resolve_ttsd_dir<R: Runtime>(app: &AppHandle<R>) -> std::path::PathBuf {
 
 /// Build the TTS engine layer for the running app.
 ///
-/// Returns the [`tts::EngineSwitcher`] that owns the active engine. The
-/// switcher impls [`tts::TtsEngine`], so callers can hold either an
-/// `Arc<EngineSwitcher>` (for swap/`apply_config`) or `Arc<dyn TtsEngine>`
-/// (for synthesis) — both pointing at the same allocation.
+/// Returns the [`tts::EngineSwitcher`] (which owns the active engine) and
+/// the resolved `ttsd/` directory so the rest of the app can re-probe
+/// availability later via `get_available_engines`.
 ///
-/// The initial engine is chosen from the persisted config:
+/// The initial engine is chosen from the persisted config and the Silero
+/// availability probe (Phase 3 of #42):
 /// - `engine = "piper"` (default) → in-process [`tts::PiperEngine`].
-/// - `engine = "silero"` → [`tts::TtsSupervisor`] over `uv run python -m ttsd`.
-///   Failure to spawn (no `uv`, missing ttsd dir) silently falls back to
-///   Piper; Phase 3 of #42 will probe up-front instead.
+/// - `engine = "silero"` *and* probe says Silero is available →
+///   [`tts::TtsSupervisor`] over `uv run python -m ttsd`. Spawn failure
+///   (race between probe and spawn) silently falls back to Piper.
+/// - `engine = "silero"` but probe says unavailable → silent migration to
+///   Piper; the user's `engine` value on disk is left untouched so they
+///   can roll back by installing the Silero stack.
 ///
 /// Voice models live at `<data_local_dir>/ruvox/voices/piper/<voice>/…`
 /// — see `tts::piper::catalog`. Phase 4 of #42 adds on-demand download;
@@ -186,7 +189,7 @@ fn resolve_ttsd_dir<R: Runtime>(app: &AppHandle<R>) -> std::path::PathBuf {
 fn build_engine<R: Runtime>(
     app: &AppHandle<R>,
     storage: &StorageService,
-) -> Result<Arc<tts::EngineSwitcher>, SetupError> {
+) -> Result<(Arc<tts::EngineSwitcher>, std::path::PathBuf), SetupError> {
     let voices_dir = dirs::data_local_dir()
         .ok_or("dirs::data_local_dir() returned None")?
         .join("ruvox")
@@ -201,44 +204,49 @@ fn build_engine<R: Runtime>(
     let config = storage.load_config().unwrap_or_default();
     let ttsd_dir = resolve_ttsd_dir(app);
 
-    let (initial_engine, initial_kind, initial_voice) = match config.engine.as_str() {
-        "silero" => match try_build_silero(&ttsd_dir, Arc::clone(&emitter)) {
+    let want_silero = config.engine == "silero";
+    let silero_available = want_silero && tts::availability::probe(&ttsd_dir).silero.available;
+
+    let (initial_engine, initial_kind, initial_voice) = if silero_available {
+        match try_build_silero(&ttsd_dir, Arc::clone(&emitter)) {
             Ok(sup) => {
                 let engine: Arc<dyn tts::TtsEngine> = sup;
                 (engine, tts::EngineKind::Silero, None)
             }
             Err(e) => {
-                tracing::warn!(
-                    "config requested Silero but spawn failed ({e}); falling back to Piper"
-                );
-                let voice = config.piper_voice.clone();
-                let engine: Arc<dyn tts::TtsEngine> = Arc::new(tts::PiperEngine::new(
-                    voices_dir.clone(),
-                    voice.clone(),
-                    Arc::clone(&emitter),
-                ));
-                (engine, tts::EngineKind::Piper, Some(voice))
+                tracing::warn!("Silero probe passed but spawn failed ({e}); falling back to Piper");
+                build_piper_initial(&voices_dir, &config.piper_voice, &emitter)
             }
-        },
-        _ => {
-            let voice = config.piper_voice.clone();
-            let engine: Arc<dyn tts::TtsEngine> = Arc::new(tts::PiperEngine::new(
-                voices_dir.clone(),
-                voice.clone(),
-                Arc::clone(&emitter),
-            ));
-            (engine, tts::EngineKind::Piper, Some(voice))
         }
+    } else {
+        if want_silero {
+            tracing::info!("Silero requested in config but unavailable; serving Piper this run");
+        }
+        build_piper_initial(&voices_dir, &config.piper_voice, &emitter)
     };
 
-    Ok(Arc::new(tts::EngineSwitcher::new(
+    let switcher = Arc::new(tts::EngineSwitcher::new(
         initial_engine,
         initial_kind,
         initial_voice,
         voices_dir,
-        ttsd_dir,
+        ttsd_dir.clone(),
         emitter,
-    )))
+    ));
+    Ok((switcher, ttsd_dir))
+}
+
+fn build_piper_initial(
+    voices_dir: &std::path::Path,
+    voice: &str,
+    emitter: &tts::supervisor::Emitter,
+) -> (Arc<dyn tts::TtsEngine>, tts::EngineKind, Option<String>) {
+    let engine: Arc<dyn tts::TtsEngine> = Arc::new(tts::PiperEngine::new(
+        voices_dir.to_path_buf(),
+        voice.to_string(),
+        Arc::clone(emitter),
+    ));
+    (engine, tts::EngineKind::Piper, Some(voice.to_string()))
 }
 
 fn try_build_silero(
@@ -336,7 +344,7 @@ pub fn run() {
             let storage = Arc::new(StorageService::new().expect("failed to open storage"));
             spawn_audio_migration_and_cleanup(Arc::clone(&storage));
 
-            let engine_switcher = build_engine(app.handle(), &storage)?;
+            let (engine_switcher, ttsd_dir) = build_engine(app.handle(), &storage)?;
             let tts: Arc<dyn tts::TtsEngine> = engine_switcher.clone();
             // Warm up the model in background. The engine owns the
             // model_loading → model_loaded/model_error emit sequence so the
@@ -361,6 +369,7 @@ pub fn run() {
                 storage,
                 tts,
                 engine_switcher,
+                ttsd_dir,
                 player,
                 pipeline,
                 tray_cmd_tx: Some(tray_tx),
@@ -388,6 +397,7 @@ pub fn run() {
             set_volume,
             get_config,
             update_config,
+            get_available_engines,
             get_timestamps,
             clear_cache,
             get_cache_stats,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,52 +143,33 @@ fn spawn_audio_migration_and_cleanup(storage: Arc<StorageService>) {
     });
 }
 
-/// Resolve `ttsd` directory, build the supervisor's command factory + emitter,
-/// and spawn the subprocess.
+/// Build the TTS engine for the running app.
 ///
-/// `tokio::process::Command::spawn` requires an active tokio runtime context,
-/// so the spawn is driven from `block_on` — the inner future returns instantly.
-fn build_ttsd_supervisor<R: Runtime>(
-    app: &AppHandle<R>,
-) -> Result<Arc<tts::TtsSupervisor>, SetupError> {
-    // In production: bundled next to the binary (resource_dir/ttsd).
-    // In `cargo tauri dev`: cwd is src-tauri/, so the project ttsd lives
-    // at ../ttsd; fall back to ./ttsd for ad-hoc runs from the repo root.
-    let ttsd_dir = {
-        let res_dir = app
-            .path()
-            .resource_dir()
-            .unwrap_or_else(|_| std::path::PathBuf::from("."))
-            .join("ttsd");
-        if res_dir.exists() {
-            res_dir
-        } else if std::path::Path::new("../ttsd/pyproject.toml").exists() {
-            std::path::PathBuf::from("../ttsd")
-        } else {
-            std::path::PathBuf::from("ttsd")
-        }
-    };
+/// Today we hardcode the Piper engine (issue #42, Phase 1). Once issue #43
+/// lands a `withSilero` flake flag and the availability probe (issue #42
+/// Phase 3), this function will branch on the user's config and the probe.
+///
+/// Voice models live at `<data_local_dir>/ruvox/voices/piper/<voice>/...`
+/// — see `tts::piper::catalog`. Phase 4 of #42 adds on-demand download;
+/// for now, if the default voice isn't on disk, warmup logs a `model_error`
+/// and the first synthesize returns `voice_not_installed`.
+fn build_engine<R: Runtime>(app: &AppHandle<R>) -> Result<Arc<dyn tts::TtsEngine>, SetupError> {
+    let voices_dir = dirs::data_local_dir()
+        .ok_or("dirs::data_local_dir() returned None")?
+        .join("ruvox")
+        .join("voices")
+        .join("piper");
 
-    // Cloning the path captured by value keeps the closure `Fn` (not
-    // `FnOnce`) — required for the `Arc<dyn Fn(...)>` shape.
-    let ttsd_dir_for_factory = ttsd_dir;
-    let factory: tts::supervisor::CommandFactory = Arc::new(move || {
-        let mut cmd = tokio::process::Command::new("uv");
-        cmd.args(["run", "python", "-m", "ttsd"])
-            .current_dir(&ttsd_dir_for_factory);
-        cmd
-    });
-
-    // Emitter for ttsd_restarting / tts_fatal (and the model_* lifecycle
-    // re-emitted from supervisor.spawn_warmup).
     let app_handle_for_emitter = app.clone();
     let emitter: tts::supervisor::Emitter = Arc::new(move |event_name, payload| {
         let _ = app_handle_for_emitter.emit(event_name, payload);
     });
 
-    let supervisor =
-        tauri::async_runtime::block_on(async move { tts::TtsSupervisor::spawn(factory, emitter) })?;
-    Ok(Arc::new(supervisor))
+    Ok(Arc::new(tts::PiperEngine::new(
+        voices_dir,
+        tts::piper::catalog::DEFAULT_VOICE.to_string(),
+        emitter,
+    )))
 }
 
 /// Spawn the tray-command handler loop and return the channel sender.
@@ -198,7 +179,7 @@ fn build_ttsd_supervisor<R: Runtime>(
 /// entry, and kicks off background synthesis.
 fn spawn_tray_handler<R: Runtime + 'static>(
     storage: Arc<StorageService>,
-    tts: Arc<tts::TtsSupervisor>,
+    tts: Arc<dyn tts::TtsEngine>,
     player: Arc<Player<R>>,
     pipeline: Arc<Mutex<TTSPipeline>>,
     app: AppHandle<R>,
@@ -272,8 +253,8 @@ pub fn run() {
             let storage = Arc::new(StorageService::new().expect("failed to open storage"));
             spawn_audio_migration_and_cleanup(Arc::clone(&storage));
 
-            let tts = build_ttsd_supervisor(app.handle())?;
-            // Warm up Silero model in background. The supervisor owns the
+            let tts: Arc<dyn tts::TtsEngine> = build_engine(app.handle())?;
+            // Warm up the model in background. The engine owns the
             // model_loading → model_loaded/model_error emit sequence so the
             // initial warmup and post-respawn warmup share one code path.
             {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7,7 +7,7 @@ use crate::pipeline::TTSPipeline;
 use crate::player::Player;
 use crate::storage::service::StorageService;
 use crate::tray::TrayCmd;
-use crate::tts::TtsEngine;
+use crate::tts::{EngineSwitcher, TtsEngine};
 
 /// Application-wide state held in `tauri::State<AppState>`.
 ///
@@ -16,10 +16,13 @@ use crate::tts::TtsEngine;
 /// `tauri::generate_handler!`.
 pub struct AppState {
     pub storage: Arc<StorageService>,
-    /// TTS engine. Today this is always [`crate::tts::PiperEngine`]; #43 will
-    /// pick between Piper and Silero at startup based on the user's config
-    /// and an availability probe.
+    /// TTS engine — actually an [`EngineSwitcher`], exposed as a trait object
+    /// so the synthesis pipeline stays engine-agnostic. Use `engine_switcher`
+    /// when the caller needs to swap the underlying engine.
     pub tts: Arc<dyn TtsEngine>,
+    /// Typed handle to the same switcher held in `tts`. Used by
+    /// `update_config` to apply engine / voice changes at runtime.
+    pub engine_switcher: Arc<EngineSwitcher>,
     pub player: Arc<Player<tauri::Wry>>,
     pub pipeline: Arc<Mutex<TTSPipeline>>,
     /// Sender for tray menu commands (read_now / read_later).

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7,7 +7,7 @@ use crate::pipeline::TTSPipeline;
 use crate::player::Player;
 use crate::storage::service::StorageService;
 use crate::tray::TrayCmd;
-use crate::tts::TtsSupervisor;
+use crate::tts::TtsEngine;
 
 /// Application-wide state held in `tauri::State<AppState>`.
 ///
@@ -16,7 +16,10 @@ use crate::tts::TtsSupervisor;
 /// `tauri::generate_handler!`.
 pub struct AppState {
     pub storage: Arc<StorageService>,
-    pub tts: Arc<TtsSupervisor>,
+    /// TTS engine. Today this is always [`crate::tts::PiperEngine`]; #43 will
+    /// pick between Piper and Silero at startup based on the user's config
+    /// and an availability probe.
+    pub tts: Arc<dyn TtsEngine>,
     pub player: Arc<Player<tauri::Wry>>,
     pub pipeline: Arc<Mutex<TTSPipeline>>,
     /// Sender for tray menu commands (read_now / read_later).

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,6 +8,7 @@ use crate::pipeline::TTSPipeline;
 use crate::player::Player;
 use crate::storage::service::StorageService;
 use crate::tray::TrayCmd;
+use crate::tts::supervisor::Emitter;
 use crate::tts::{EngineSwitcher, TtsEngine};
 
 /// Application-wide state held in `tauri::State<AppState>`.
@@ -28,6 +29,13 @@ pub struct AppState {
     /// Consumed by `get_available_engines` to probe Silero's environment
     /// without re-discovering the path on every call.
     pub ttsd_dir: PathBuf,
+    /// Root directory for Piper voice files (one subdir per voice id).
+    /// Used by `download_piper_voice` and the auto-download fallback in
+    /// `synthesize_audio` so they don't need to re-derive the path.
+    pub piper_voices_dir: PathBuf,
+    /// Frontend emitter shared with the engine layer. Held here so the
+    /// download path can reuse it without rebuilding the closure.
+    pub emitter: Emitter,
     pub player: Arc<Player<tauri::Wry>>,
     pub pipeline: Arc<Mutex<TTSPipeline>>,
     /// Sender for tray menu commands (read_now / read_later).

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -23,6 +24,10 @@ pub struct AppState {
     /// Typed handle to the same switcher held in `tts`. Used by
     /// `update_config` to apply engine / voice changes at runtime.
     pub engine_switcher: Arc<EngineSwitcher>,
+    /// Resolved on-disk location of the optional `ttsd/` Python package.
+    /// Consumed by `get_available_engines` to probe Silero's environment
+    /// without re-discovering the path on every call.
+    pub ttsd_dir: PathBuf,
     pub player: Arc<Player<tauri::Wry>>,
     pub pipeline: Arc<Mutex<TTSPipeline>>,
     /// Sender for tray menu commands (read_now / read_later).

--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -103,6 +103,12 @@ pub struct UIConfig {
     /// Show preview dialog before synthesis.
     #[serde(default = "UIConfig::default_true")]
     pub preview_dialog_enabled: bool,
+    /// Active TTS engine: `"piper"` (default) | `"silero"`.
+    #[serde(default = "UIConfig::default_engine")]
+    pub engine: String,
+    /// Active Piper voice id (`"ruslan"` by default — see `tts::piper::catalog`).
+    #[serde(default = "UIConfig::default_piper_voice")]
+    pub piper_voice: String,
 }
 
 impl UIConfig {
@@ -111,6 +117,12 @@ impl UIConfig {
     }
     fn default_sample_rate() -> u32 {
         48000
+    }
+    fn default_engine() -> String {
+        "piper".to_string()
+    }
+    fn default_piper_voice() -> String {
+        "ruslan".to_string()
     }
     fn default_speech_rate() -> f64 {
         1.0
@@ -163,6 +175,8 @@ impl Default for UIConfig {
             player_hotkeys: Self::default_player_hotkeys(),
             window_geometry: None,
             preview_dialog_enabled: true,
+            engine: Self::default_engine(),
+            piper_voice: Self::default_piper_voice(),
         }
     }
 }
@@ -184,6 +198,8 @@ pub struct UIConfigPatch {
     pub player_hotkeys: Option<std::collections::HashMap<String, String>>,
     pub window_geometry: Option<Option<[i32; 4]>>,
     pub preview_dialog_enabled: Option<bool>,
+    pub engine: Option<String>,
+    pub piper_voice: Option<String>,
 }
 
 #[cfg(test)]
@@ -257,6 +273,18 @@ mod tests {
         assert!(c.notify_on_error);
         assert_eq!(c.max_cache_size_mb, 500);
         assert!(!c.speaker.is_empty());
+        assert_eq!(c.engine, "piper");
+        assert_eq!(c.piper_voice, "ruslan");
+    }
+
+    #[test]
+    fn config_missing_engine_keys_defaults_to_piper() {
+        // Existing pre-#42 configs have no engine/piper_voice — must parse and
+        // silently switch the user to Piper (the new primary engine).
+        let json = r#"{"speaker":"xenia","sample_rate":48000,"speech_rate":1.0}"#;
+        let c: UIConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(c.engine, "piper");
+        assert_eq!(c.piper_voice, "ruslan");
     }
 
     #[test]

--- a/src-tauri/src/tts/availability.rs
+++ b/src-tauri/src/tts/availability.rs
@@ -1,0 +1,116 @@
+//! Lightweight probe for which TTS engines can be selected on the running
+//! system. Phase 3 of #42.
+//!
+//! Piper is in-process and always available — its model files may be
+//! missing, but engine itself loads, and a missing voice surfaces from
+//! synthesis as `voice_not_installed` (Phase 4 will offer to download it).
+//! Silero requires the `ttsd/` Python package, the `uv` toolchain to drive
+//! its venv, and (transitively) the torch + Silero model. The probe is
+//! cheap on purpose: it only checks the directory + `uv --version` so app
+//! startup does not pay for a torch import. Failure to actually load the
+//! model still surfaces from `model_error` later.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::Serialize;
+
+/// Per-engine availability: whether the user can pick the engine in the
+/// Settings selector, and a Russian-language reason to surface when not.
+#[derive(Debug, Clone, Serialize)]
+pub struct EngineAvailability {
+    pub available: bool,
+    /// `Some` only when `available == false`.
+    pub reason: Option<String>,
+}
+
+/// Output of [`probe`]. Field names match the `AvailabilityMap` shape on
+/// the frontend.
+#[derive(Debug, Clone, Serialize)]
+pub struct AvailableEngines {
+    pub piper: EngineAvailability,
+    pub silero: EngineAvailability,
+}
+
+/// Probe the running environment for engine availability. `ttsd_dir` is
+/// the path resolved by `lib.rs::resolve_ttsd_dir` — the location at which
+/// the `ttsd/` Python package would live if shipped.
+pub fn probe(ttsd_dir: &Path) -> AvailableEngines {
+    AvailableEngines {
+        piper: EngineAvailability {
+            available: true,
+            reason: None,
+        },
+        silero: probe_silero(ttsd_dir),
+    }
+}
+
+fn probe_silero(ttsd_dir: &Path) -> EngineAvailability {
+    let pyproject = ttsd_dir.join("pyproject.toml");
+    if !pyproject.exists() {
+        return EngineAvailability {
+            available: false,
+            reason: Some(format!(
+                "ttsd не найден по пути {}. Соберите окружение с включённым Silero-флагом.",
+                ttsd_dir.display()
+            )),
+        };
+    }
+    match check_uv() {
+        Ok(()) => EngineAvailability {
+            available: true,
+            reason: None,
+        },
+        Err(msg) => EngineAvailability {
+            available: false,
+            reason: Some(msg),
+        },
+    }
+}
+
+fn check_uv() -> Result<(), String> {
+    let out = Command::new("uv").arg("--version").output();
+    match out {
+        Ok(o) if o.status.success() => Ok(()),
+        Ok(o) => Err(format!(
+            "uv найден, но `uv --version` вернул {}",
+            o.status
+        )),
+        Err(_) => Err("`uv` не найден в PATH. Установите его или используйте nix-shell с включённым Silero-флагом.".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn piper_is_always_available() {
+        let res = probe(&std::env::temp_dir());
+        assert!(res.piper.available);
+        assert!(res.piper.reason.is_none());
+    }
+
+    #[test]
+    fn silero_unavailable_when_ttsd_dir_missing_pyproject() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let probe_result = probe(dir.path());
+        assert!(!probe_result.silero.available);
+        let reason = probe_result.silero.reason.expect("reason set");
+        assert!(reason.contains("ttsd"));
+    }
+
+    #[test]
+    fn silero_reason_is_in_russian() {
+        // Smoke: every reason we surface to the user must be Cyrillic. Lets
+        // future probes (e.g. torch sniff) break loudly if someone ships an
+        // English string by accident.
+        let dir = tempfile::TempDir::new().unwrap();
+        let r = probe(dir.path()).silero;
+        let reason = r.reason.unwrap();
+        assert!(
+            reason.chars().any(|c| matches!(c, 'А'..='я' | 'ё' | 'Ё')),
+            "reason should be Russian: {reason}"
+        );
+    }
+}

--- a/src-tauri/src/tts/engine.rs
+++ b/src-tauri/src/tts/engine.rs
@@ -1,0 +1,79 @@
+//! Engine-agnostic interface for the TTS layer.
+//!
+//! Two concrete impls exist:
+//! - [`crate::tts::supervisor::TtsSupervisor`] — Silero, runs as a Python
+//!   `ttsd` sidecar that can die and respawn.
+//! - [`crate::tts::piper::PiperEngine`] — Piper, runs in-process via the
+//!   `piper-rs` ONNX wrapper.
+//!
+//! [`crate::state::AppState::tts`] holds a `Arc<dyn TtsEngine>` so the rest of
+//! the codebase (commands, synthesis worker, tray) is engine-agnostic.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::{CharMappingEntry, SynthesizeOutput, TtsError};
+
+/// Identifies which engine implementation is currently active. Used for
+/// logging, telemetry, and (future) UI events that need to differentiate
+/// between Silero and Piper lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EngineKind {
+    Silero,
+    Piper,
+}
+
+impl EngineKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EngineKind::Silero => "silero",
+            EngineKind::Piper => "piper",
+        }
+    }
+}
+
+/// Engine-agnostic TTS interface.
+///
+/// All methods are async and return [`TtsError`]. Implementations must be
+/// `Send + Sync` so the engine can be shared via `Arc<dyn TtsEngine>` across
+/// the Tokio runtime.
+#[async_trait]
+pub trait TtsEngine: Send + Sync {
+    /// Identifies the concrete engine. Cheap; called for logs/events only.
+    fn kind(&self) -> EngineKind;
+
+    /// Load the model. Idempotent — calling it twice should be a no-op.
+    /// Implementations should emit `model_loading` → `model_loaded` /
+    /// `model_error` events themselves if they want UI feedback.
+    async fn warmup(&self) -> Result<(), TtsError>;
+
+    /// Run the warmup in the background, mirroring the
+    /// `model_loading` → `model_loaded` / `model_error` lifecycle that the
+    /// frontend expects on startup. Returns immediately; the warmup runs in
+    /// a detached task.
+    async fn spawn_initial_warmup(&self);
+
+    /// Synthesize `text` and write the WAV file to `out_wav`.
+    ///
+    /// `voice` is the engine-specific voice id (`xenia` for Silero,
+    /// `ruslan` for Piper, etc.). `char_mapping` is the optional pipeline
+    /// bridge for mapping normalized text positions back to original-text
+    /// offsets in the returned word timestamps.
+    async fn synthesize(
+        &self,
+        text: String,
+        voice: String,
+        sample_rate: u32,
+        out_wav: String,
+        char_mapping: Option<Vec<CharMappingEntry>>,
+    ) -> Result<SynthesizeOutput, TtsError>;
+
+    /// Graceful shutdown. After this call the engine should release model
+    /// memory / subprocess handles and refuse subsequent requests.
+    async fn shutdown(&self) -> Result<(), TtsError>;
+}
+
+/// Convenience alias for a shared dynamic-dispatch engine handle.
+pub type SharedEngine = Arc<dyn TtsEngine>;

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -12,10 +12,12 @@
 pub mod engine;
 pub mod piper;
 pub mod supervisor;
+pub mod switcher;
 
 pub use engine::{EngineKind, SharedEngine, TtsEngine};
 pub use piper::PiperEngine;
 pub use supervisor::TtsSupervisor;
+pub use switcher::EngineSwitcher;
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -9,7 +9,12 @@
 //! driver task exits when the subprocess dies and subsequent calls return
 //! [`TtsError::Died`]. Crash recovery is layered on top in [`supervisor`].
 
+pub mod engine;
+pub mod piper;
 pub mod supervisor;
+
+pub use engine::{EngineKind, SharedEngine, TtsEngine};
+pub use piper::PiperEngine;
 pub use supervisor::TtsSupervisor;
 
 use std::sync::Arc;

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -9,11 +9,13 @@
 //! driver task exits when the subprocess dies and subsequent calls return
 //! [`TtsError::Died`]. Crash recovery is layered on top in [`supervisor`].
 
+pub mod availability;
 pub mod engine;
 pub mod piper;
 pub mod supervisor;
 pub mod switcher;
 
+pub use availability::{AvailableEngines, EngineAvailability};
 pub use engine::{EngineKind, SharedEngine, TtsEngine};
 pub use piper::PiperEngine;
 pub use supervisor::TtsSupervisor;

--- a/src-tauri/src/tts/piper/catalog.rs
+++ b/src-tauri/src/tts/piper/catalog.rs
@@ -1,0 +1,100 @@
+//! Hand-curated catalogue of supported Piper voices.
+//!
+//! Source of truth for the engine. The frontend keeps a parallel TS mirror
+//! (`src/lib/piperVoices.ts`) — the catalogue is small (4 ru_RU voices today)
+//! and changes rarely, so a hand-mirrored copy is preferred over a build-time
+//! codegen step.
+//!
+//! Model files live at `<data_local_dir>/ruvox/voices/piper/<id>/<file>`,
+//! downloaded on demand from `huggingface.co/rhasspy/piper-voices`.
+
+/// Recommended default voice for fresh installs.
+pub const DEFAULT_VOICE: &str = "ruslan";
+
+/// One Piper voice entry.
+pub struct Voice {
+    /// Stable voice identifier (also the directory + file basename).
+    pub id: &'static str,
+    /// Russian human-readable label for the settings UI.
+    pub label: &'static str,
+    /// Marked with a "Рекомендуется" badge in the settings UI.
+    pub recommended: bool,
+    /// Quality tier as published by rhasspy. We currently use "medium" for
+    /// all four ru_RU voices (low: ~20 MB, medium: ~60 MB, high: ~120 MB).
+    pub quality: &'static str,
+    /// HF URL of the `.onnx` file.
+    pub model_url: &'static str,
+    /// HF URL of the `.onnx.json` config file.
+    pub config_url: &'static str,
+}
+
+/// All voices known to the app.
+pub const VOICES: &[Voice] = &[
+    Voice {
+        id: "denis",
+        label: "Денис (мужской)",
+        recommended: false,
+        quality: "medium",
+        model_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx",
+        config_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx.json",
+    },
+    Voice {
+        id: "dmitri",
+        label: "Дмитрий (мужской)",
+        recommended: false,
+        quality: "medium",
+        model_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx",
+        config_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx.json",
+    },
+    Voice {
+        id: "irina",
+        label: "Ирина (женский)",
+        recommended: false,
+        quality: "medium",
+        model_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx",
+        config_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx.json",
+    },
+    Voice {
+        id: "ruslan",
+        label: "Руслан (мужской)",
+        recommended: true,
+        quality: "medium",
+        model_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx",
+        config_url:
+            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx.json",
+    },
+];
+
+/// Look up a voice by id. Returns `None` for unknown ids.
+pub fn lookup(id: &str) -> Option<&'static Voice> {
+    VOICES.iter().find(|v| v.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exactly_one_voice_is_recommended() {
+        let n = VOICES.iter().filter(|v| v.recommended).count();
+        assert_eq!(n, 1, "expected exactly one recommended voice");
+    }
+
+    #[test]
+    fn default_voice_is_recommended_one() {
+        let v = lookup(DEFAULT_VOICE).expect("default voice present in catalog");
+        assert!(v.recommended);
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown() {
+        assert!(lookup("does-not-exist").is_none());
+    }
+}

--- a/src-tauri/src/tts/piper/download.rs
+++ b/src-tauri/src/tts/piper/download.rs
@@ -1,0 +1,246 @@
+//! On-demand download of Piper voice files (Phase 4 of #42).
+//!
+//! Each voice ships as two files in `<voices_dir>/<voice_id>/`:
+//! - `ru_RU-<voice_id>-medium.onnx.json` — voice config (~4 KB)
+//! - `ru_RU-<voice_id>-medium.onnx`      — VITS weights (~60 MB)
+//!
+//! The download is split into two requests because Piper's loader needs the
+//! `.onnx.json` first (it carries the sample rate and phoneme map). Each
+//! file is staged in `<dest>.partial` and atomically renamed into place
+//! once fully written, so a crashed download cannot leave a half-baked
+//! `.onnx` lying around for the loader to choke on next launch.
+//!
+//! Progress is reported through the supervisor's `Emitter` callback so the
+//! engine layer stays free of `tauri::AppHandle`. Three event names:
+//! - `voice_download_started`  — `{ engine, voice }`
+//! - `voice_download_progress` — `{ engine, voice, file_kind, file_idx,
+//!                                  total_files, downloaded_bytes,
+//!                                  total_bytes }`
+//! - `voice_download_finished` — `{ engine, voice }`
+//!
+//! Failures emit a `voice_download_finished` with `{ ok: false, message }`
+//! so the frontend notification has a single terminal event to listen for.
+
+use std::path::Path;
+
+use futures_util::StreamExt;
+use serde_json::json;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+use super::catalog;
+use crate::tts::supervisor::Emitter;
+use crate::tts::TtsError;
+
+/// Throttle progress events to ~1 per 256 KB so the IPC bridge does not
+/// drown the renderer.
+const PROGRESS_EMIT_BYTES: u64 = 256 * 1024;
+
+/// Download both files for `voice_id` into `voices_dir`. Idempotent: skips
+/// any file already present on disk. Atomic per-file (write to `.partial`,
+/// then rename). Cancellation is not supported in this revision — callers
+/// drop the future to abort, leaving any `.partial` files for the next run
+/// to overwrite.
+pub async fn download_voice(
+    voices_dir: &Path,
+    voice_id: &str,
+    emitter: &Emitter,
+) -> Result<(), TtsError> {
+    let voice = catalog::lookup(voice_id).ok_or_else(|| TtsError::Ttsd {
+        code: "voice_unknown".to_string(),
+        message: format!("неизвестный голос Piper: \"{voice_id}\""),
+    })?;
+
+    let dest_dir = voices_dir.join(voice_id);
+    fs::create_dir_all(&dest_dir).await.map_err(TtsError::Ipc)?;
+
+    let json_filename = format!("ru_RU-{voice_id}-medium.onnx.json");
+    let onnx_filename = format!("ru_RU-{voice_id}-medium.onnx");
+    let json_path = dest_dir.join(&json_filename);
+    let onnx_path = dest_dir.join(&onnx_filename);
+
+    (emitter)(
+        "voice_download_started",
+        json!({ "engine": "piper", "voice": voice_id }),
+    );
+
+    let result = async {
+        // Config first — Piper's loader reads it before the model.
+        if !json_path.exists() {
+            download_one(
+                voice.config_url,
+                &json_path,
+                voice_id,
+                "json",
+                0,
+                2,
+                emitter,
+            )
+            .await?;
+        } else {
+            emit_skip(emitter, voice_id, "json", 0, 2);
+        }
+        if !onnx_path.exists() {
+            download_one(voice.model_url, &onnx_path, voice_id, "onnx", 1, 2, emitter).await?;
+        } else {
+            emit_skip(emitter, voice_id, "onnx", 1, 2);
+        }
+        Ok::<_, TtsError>(())
+    }
+    .await;
+
+    match &result {
+        Ok(()) => {
+            (emitter)(
+                "voice_download_finished",
+                json!({ "engine": "piper", "voice": voice_id, "ok": true }),
+            );
+        }
+        Err(e) => {
+            (emitter)(
+                "voice_download_finished",
+                json!({
+                    "engine": "piper",
+                    "voice": voice_id,
+                    "ok": false,
+                    "message": e.to_string(),
+                }),
+            );
+        }
+    }
+    result
+}
+
+fn emit_skip(emitter: &Emitter, voice_id: &str, kind: &str, idx: u32, total: u32) {
+    (emitter)(
+        "voice_download_progress",
+        json!({
+            "engine": "piper",
+            "voice": voice_id,
+            "file_kind": kind,
+            "file_idx": idx,
+            "total_files": total,
+            "downloaded_bytes": 0u64,
+            "total_bytes": 0u64,
+            "skipped": true,
+        }),
+    );
+}
+
+async fn download_one(
+    url: &str,
+    dest: &Path,
+    voice_id: &str,
+    file_kind: &str,
+    file_idx: u32,
+    total_files: u32,
+    emitter: &Emitter,
+) -> Result<(), TtsError> {
+    let resp = reqwest::get(url).await.map_err(|e| TtsError::Ttsd {
+        code: "voice_download_failed".to_string(),
+        message: format!("HTTP GET {url} failed: {e}"),
+    })?;
+    if !resp.status().is_success() {
+        return Err(TtsError::Ttsd {
+            code: "voice_download_failed".to_string(),
+            message: format!("HTTP {} for {url}", resp.status()),
+        });
+    }
+    let total_bytes = resp.content_length();
+
+    let tmp = dest.with_extension("partial");
+    let mut file = fs::File::create(&tmp).await.map_err(TtsError::Ipc)?;
+    let mut downloaded: u64 = 0;
+    let mut last_emit: u64 = 0;
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| TtsError::Ttsd {
+            code: "voice_download_failed".to_string(),
+            message: format!("chunk read failed: {e}"),
+        })?;
+        file.write_all(&chunk).await.map_err(TtsError::Ipc)?;
+        downloaded += chunk.len() as u64;
+        if downloaded - last_emit >= PROGRESS_EMIT_BYTES {
+            (emitter)(
+                "voice_download_progress",
+                json!({
+                    "engine": "piper",
+                    "voice": voice_id,
+                    "file_kind": file_kind,
+                    "file_idx": file_idx,
+                    "total_files": total_files,
+                    "downloaded_bytes": downloaded,
+                    "total_bytes": total_bytes,
+                }),
+            );
+            last_emit = downloaded;
+        }
+    }
+    file.flush().await.map_err(TtsError::Ipc)?;
+    drop(file);
+    fs::rename(&tmp, dest).await.map_err(TtsError::Ipc)?;
+
+    // Final 100% tick — `bytes_stream` rarely lands exactly on the
+    // throttle boundary, so this guarantees the UI's progress bar fills.
+    (emitter)(
+        "voice_download_progress",
+        json!({
+            "engine": "piper",
+            "voice": voice_id,
+            "file_kind": file_kind,
+            "file_idx": file_idx,
+            "total_files": total_files,
+            "downloaded_bytes": downloaded,
+            "total_bytes": total_bytes,
+        }),
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tts::supervisor::test_helpers::recording_emitter;
+
+    #[tokio::test]
+    async fn download_voice_rejects_unknown_voice_id() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (emitter, _) = recording_emitter();
+        let err = download_voice(dir.path(), "does-not-exist", &emitter)
+            .await
+            .unwrap_err();
+        match err {
+            TtsError::Ttsd { code, .. } => assert_eq!(code, "voice_unknown"),
+            other => panic!("expected voice_unknown, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_voice_skips_files_already_on_disk() {
+        // Pre-populate both files; the function must not touch the network
+        // and must emit a `skipped: true` progress event for each file.
+        let dir = tempfile::TempDir::new().unwrap();
+        let voice = "ruslan";
+        let voice_dir = dir.path().join(voice);
+        fs::create_dir_all(&voice_dir).await.unwrap();
+        fs::write(voice_dir.join("ru_RU-ruslan-medium.onnx"), b"x")
+            .await
+            .unwrap();
+        fs::write(voice_dir.join("ru_RU-ruslan-medium.onnx.json"), b"{}")
+            .await
+            .unwrap();
+
+        let (emitter, log) = recording_emitter();
+        download_voice(dir.path(), voice, &emitter).await.unwrap();
+
+        let log = log.lock().unwrap();
+        let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"voice_download_started"));
+        assert!(names.contains(&"voice_download_finished"));
+        let skipped = log
+            .iter()
+            .filter(|(n, p)| n == "voice_download_progress" && p["skipped"] == true)
+            .count();
+        assert_eq!(skipped, 2, "expected 2 skipped progress events");
+    }
+}

--- a/src-tauri/src/tts/piper/engine.rs
+++ b/src-tauri/src/tts/piper/engine.rs
@@ -29,9 +29,16 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use piper_rs::synth::PiperSpeechSynthesizer;
+use piper_rs::PiperSynthesisConfig;
 use serde_json::json;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
+
+/// VITS `length_scale` applied at synthesis time. The Piper voice configs
+/// ship `length_scale: 1.0` which sounds slow on Russian voices; 0.8 cuts
+/// audio length by ~20% while keeping the natural prosody (we change the
+/// model's own duration prediction, not a post-process resample).
+const PIPER_LENGTH_SCALE: f32 = 0.8;
 
 use super::timestamps::estimate_timestamps_single_chunk;
 use crate::tts::engine::{EngineKind, TtsEngine};
@@ -305,6 +312,26 @@ fn load_voice_blocking(config_path: &Path) -> Result<(PiperSpeechSynthesizer, u3
         code: "piper_load_failed".to_string(),
         message: format!("piper-rs from_config_path failed: {e}"),
     })?;
+    // Pull the voice's noise scales from the JSON we just parsed so we keep
+    // the per-voice tuning when overriding `length_scale`.
+    let inference = cfg.get("inference");
+    let noise_scale = inference
+        .and_then(|v| v.get("noise_scale"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.667) as f32;
+    let noise_w = inference
+        .and_then(|v| v.get("noise_w"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.8) as f32;
+    let synth_config = PiperSynthesisConfig {
+        speaker: None,
+        noise_scale,
+        length_scale: PIPER_LENGTH_SCALE,
+        noise_w,
+    };
+    if let Err(e) = model.set_fallback_synthesis_config(&synth_config) {
+        warn!(target: "tts::piper", "failed to apply length_scale={PIPER_LENGTH_SCALE}: {e}");
+    }
     let synth = PiperSpeechSynthesizer::new(model).map_err(|e| TtsError::Ttsd {
         code: "piper_load_failed".to_string(),
         message: format!("PiperSpeechSynthesizer::new failed: {e}"),

--- a/src-tauri/src/tts/piper/engine.rs
+++ b/src-tauri/src/tts/piper/engine.rs
@@ -1,0 +1,337 @@
+//! `piper-rs`-backed [`TtsEngine`] implementation.
+//!
+//! Loads a `.onnx` voice + `.onnx.json` config from
+//! `<voices_dir>/<voice_id>/`. Inference runs in `spawn_blocking` because
+//! piper-rs's synthesis is synchronous CPU work.
+//!
+//! ## Why we hold a [`PiperSpeechSynthesizer`] and parse the JSON manually
+//!
+//! piper-rs 0.1.9 does not publicly export the `PiperModel` trait — only
+//! [`PiperSpeechSynthesizer`] (via `piper_rs::synth`) and a handful of
+//! Result/Error types. That means we cannot:
+//!   * name `Arc<dyn PiperModel + Send + Sync>` in our struct fields,
+//!   * call `audio_output_info()` (a `PiperModel` trait method) from outside.
+//!
+//! Workarounds: store the public `PiperSpeechSynthesizer` and read the audio
+//! sample rate ourselves from the `.onnx.json` config file. Synthesis goes
+//! through `synthesize_parallel`, which yields `AudioSamples` chunks whose
+//! `into_vec()` inherent method is public even though `AudioSamples` itself
+//! isn't a nameable type.
+//!
+//! ## Failure mapping
+//! - voice files missing → `TtsError::Ttsd { code: "voice_not_installed", … }`
+//! - config JSON parse / load failure → `TtsError::Ttsd { code: "piper_load_failed", … }`
+//! - phonemizer / ONNX inference failure → `TtsError::Ttsd { code: "piper_*_failed", … }`
+//! - WAV write failure → `TtsError::Ipc(io::Error)`
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use piper_rs::synth::PiperSpeechSynthesizer;
+use serde_json::json;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+use super::timestamps::estimate_timestamps_single_chunk;
+use crate::tts::engine::{EngineKind, TtsEngine};
+use crate::tts::supervisor::Emitter;
+use crate::tts::{CharMappingEntry, SynthesizeOutput, TtsError};
+
+type LoadedSlot = Arc<RwLock<Option<LoadedVoice>>>;
+
+/// In-process Piper engine.
+pub struct PiperEngine {
+    voices_dir: PathBuf,
+    /// Currently loaded voice — behind `Arc<RwLock<...>>` so the detached
+    /// `spawn_initial_warmup` task can install the loaded voice without
+    /// holding a borrow of `&self`.
+    loaded: LoadedSlot,
+    /// Default voice id, used by `warmup` and as a fallback.
+    default_voice: String,
+    /// Frontend event emitter.
+    emitter: Emitter,
+}
+
+struct LoadedVoice {
+    id: String,
+    synth: Arc<PiperSpeechSynthesizer>,
+    sample_rate: u32,
+}
+
+/// Lightweight handle returned from `ensure_loaded` — keeps the synthesizer
+/// alive while a synthesize call runs without holding the engine's RwLock.
+struct LoadedHandle {
+    synth: Arc<PiperSpeechSynthesizer>,
+    sample_rate: u32,
+}
+
+impl PiperEngine {
+    /// Build a new engine. No I/O — the model is loaded lazily on first
+    /// `warmup` / `synthesize`.
+    pub fn new(voices_dir: PathBuf, default_voice: String, emitter: Emitter) -> Self {
+        Self {
+            voices_dir,
+            loaded: Arc::new(RwLock::new(None)),
+            default_voice,
+            emitter,
+        }
+    }
+
+    /// Resolve `<voices_dir>/<voice_id>/ru_RU-<voice_id>-medium.onnx.json`.
+    /// Matches the rhasspy file naming convention.
+    fn config_path_for(voices_dir: &Path, voice_id: &str) -> PathBuf {
+        voices_dir
+            .join(voice_id)
+            .join(format!("ru_RU-{voice_id}-medium.onnx.json"))
+    }
+
+    /// Load (or reload, if voice changed) the Piper model.
+    async fn ensure_loaded(&self, voice_id: &str) -> Result<LoadedHandle, TtsError> {
+        // Fast path — voice already loaded.
+        {
+            let guard = self.loaded.read().await;
+            if let Some(loaded) = guard.as_ref() {
+                if loaded.id == voice_id {
+                    return Ok(LoadedHandle {
+                        synth: Arc::clone(&loaded.synth),
+                        sample_rate: loaded.sample_rate,
+                    });
+                }
+            }
+        }
+
+        let config_path = Self::config_path_for(&self.voices_dir, voice_id);
+        if !config_path.exists() {
+            return Err(TtsError::Ttsd {
+                code: "voice_not_installed".to_string(),
+                message: format!(
+                    "Piper voice \"{voice_id}\" не установлен ({}). \
+                     Загрузка по требованию будет добавлена в Phase 4.",
+                    config_path.display()
+                ),
+            });
+        }
+
+        let voice_id_owned = voice_id.to_string();
+        let cfg = config_path.clone();
+        let (synth, sample_rate) = tokio::task::spawn_blocking(move || load_voice_blocking(&cfg))
+            .await
+            .map_err(|e| TtsError::Ttsd {
+                code: "piper_load_panic".to_string(),
+                message: format!("piper-rs load task panicked: {e}"),
+            })??;
+
+        let synth = Arc::new(synth);
+        let mut guard = self.loaded.write().await;
+        *guard = Some(LoadedVoice {
+            id: voice_id_owned,
+            synth: Arc::clone(&synth),
+            sample_rate,
+        });
+        info!(target: "tts::piper", "loaded voice \"{voice_id}\" (sr={sample_rate})");
+        Ok(LoadedHandle { synth, sample_rate })
+    }
+}
+
+#[async_trait]
+impl TtsEngine for PiperEngine {
+    fn kind(&self) -> EngineKind {
+        EngineKind::Piper
+    }
+
+    async fn warmup(&self) -> Result<(), TtsError> {
+        let _ = self.ensure_loaded(&self.default_voice).await?;
+        Ok(())
+    }
+
+    async fn spawn_initial_warmup(&self) {
+        let voices_dir = self.voices_dir.clone();
+        let voice_id = self.default_voice.clone();
+        let emitter = Arc::clone(&self.emitter);
+        let slot = Arc::clone(&self.loaded);
+
+        tokio::spawn(async move {
+            (emitter)("model_loading", json!({ "engine": "piper" }));
+
+            let config_path = PiperEngine::config_path_for(&voices_dir, &voice_id);
+            if !config_path.exists() {
+                let msg = format!(
+                    "Piper voice \"{voice_id}\" не установлен ({}). \
+                     Загрузка по требованию будет добавлена в Phase 4.",
+                    config_path.display()
+                );
+                warn!(target: "tts::piper", "warmup skipped: {msg}");
+                (emitter)("model_error", json!({ "engine": "piper", "message": msg }));
+                return;
+            }
+
+            let cfg = config_path.clone();
+            let load_result = tokio::task::spawn_blocking(move || load_voice_blocking(&cfg)).await;
+
+            match load_result {
+                Ok(Ok((synth, sample_rate))) => {
+                    let synth = Arc::new(synth);
+                    let mut guard = slot.write().await;
+                    *guard = Some(LoadedVoice {
+                        id: voice_id,
+                        synth,
+                        sample_rate,
+                    });
+                    info!(target: "tts::piper", "warmup complete (sr={sample_rate})");
+                    (emitter)("model_loaded", json!({ "engine": "piper" }));
+                }
+                Ok(Err(e)) => {
+                    warn!(target: "tts::piper", "warmup load failed: {e}");
+                    (emitter)(
+                        "model_error",
+                        json!({ "engine": "piper", "message": e.to_string() }),
+                    );
+                }
+                Err(e) => {
+                    warn!(target: "tts::piper", "warmup task panicked: {e}");
+                    (emitter)(
+                        "model_error",
+                        json!({ "engine": "piper", "message": e.to_string() }),
+                    );
+                }
+            }
+        });
+    }
+
+    async fn synthesize(
+        &self,
+        text: String,
+        voice: String,
+        _sample_rate: u32, // Piper output is fixed by the voice; mpv handles SR mismatch.
+        out_wav: String,
+        char_mapping: Option<Vec<CharMappingEntry>>,
+    ) -> Result<SynthesizeOutput, TtsError> {
+        let handle = self.ensure_loaded(&voice).await?;
+        let synth = Arc::clone(&handle.synth);
+        let sample_rate = handle.sample_rate;
+        let text_for_blocking = text.clone();
+
+        let samples: Vec<f32> =
+            tokio::task::spawn_blocking(move || -> Result<Vec<f32>, TtsError> {
+                let stream = synth
+                    .synthesize_parallel(text_for_blocking, None)
+                    .map_err(|e| TtsError::Ttsd {
+                        code: "piper_synthesis_failed".to_string(),
+                        message: format!("synthesize_parallel failed: {e}"),
+                    })?;
+
+                let mut samples: Vec<f32> = Vec::new();
+                for chunk_result in stream {
+                    let chunk = chunk_result.map_err(|e| TtsError::Ttsd {
+                        code: "piper_synthesis_failed".to_string(),
+                        message: format!("synthesis chunk failed: {e}"),
+                    })?;
+                    samples.append(&mut chunk.into_vec());
+                }
+                Ok(samples)
+            })
+            .await
+            .map_err(|e| TtsError::Ttsd {
+                code: "piper_synthesis_panic".to_string(),
+                message: format!("synthesis task panicked: {e}"),
+            })??;
+
+        let duration_sec = if sample_rate == 0 {
+            0.0
+        } else {
+            samples.len() as f64 / sample_rate as f64
+        };
+
+        let out_path = PathBuf::from(&out_wav);
+        if let Some(parent) = out_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(TtsError::Ipc)?;
+        }
+        let samples_for_write = samples;
+        let out_wav_for_write = out_wav.clone();
+        tokio::task::spawn_blocking(move || {
+            write_wav_i16(&out_wav_for_write, sample_rate, &samples_for_write)
+        })
+        .await
+        .map_err(|e| {
+            TtsError::Ipc(std::io::Error::other(format!(
+                "wav write task panicked: {e}"
+            )))
+        })??;
+
+        let timestamps =
+            estimate_timestamps_single_chunk(&text, duration_sec, char_mapping.as_deref());
+
+        Ok(SynthesizeOutput {
+            timestamps,
+            duration_sec,
+        })
+    }
+
+    async fn shutdown(&self) -> Result<(), TtsError> {
+        // In-process — drop the synthesizer so onnxruntime releases its
+        // session. The next `warmup` will reload.
+        let mut guard = self.loaded.write().await;
+        *guard = None;
+        Ok(())
+    }
+}
+
+/// Synchronous helper for the blocking thread: load the model, parse the
+/// config JSON to extract the sample rate, wrap in `PiperSpeechSynthesizer`.
+fn load_voice_blocking(config_path: &Path) -> Result<(PiperSpeechSynthesizer, u32), TtsError> {
+    // Sample rate comes from the config JSON because PiperModel::audio_output_info
+    // is not reachable from outside the crate (see module-level comment).
+    let cfg_text = std::fs::read_to_string(config_path).map_err(|e| TtsError::Ttsd {
+        code: "piper_load_failed".to_string(),
+        message: format!("failed to read piper config {}: {e}", config_path.display()),
+    })?;
+    let cfg: serde_json::Value = serde_json::from_str(&cfg_text).map_err(|e| TtsError::Ttsd {
+        code: "piper_load_failed".to_string(),
+        message: format!("failed to parse piper config: {e}"),
+    })?;
+    let sample_rate = cfg
+        .get("audio")
+        .and_then(|a| a.get("sample_rate"))
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| TtsError::Ttsd {
+            code: "piper_load_failed".to_string(),
+            message: "piper config is missing audio.sample_rate".to_string(),
+        })? as u32;
+
+    let model = piper_rs::from_config_path(config_path).map_err(|e| TtsError::Ttsd {
+        code: "piper_load_failed".to_string(),
+        message: format!("piper-rs from_config_path failed: {e}"),
+    })?;
+    let synth = PiperSpeechSynthesizer::new(model).map_err(|e| TtsError::Ttsd {
+        code: "piper_load_failed".to_string(),
+        message: format!("PiperSpeechSynthesizer::new failed: {e}"),
+    })?;
+    Ok((synth, sample_rate))
+}
+
+/// Write `samples` (f32 in -1.0..1.0) as a mono i16 PCM WAV at `sample_rate`.
+fn write_wav_i16(path: &str, sample_rate: u32, samples: &[f32]) -> Result<(), TtsError> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec).map_err(map_hound_err)?;
+    for s in samples {
+        let clipped = s.clamp(-1.0, 1.0);
+        let i = (clipped * 32767.0) as i16;
+        writer.write_sample(i).map_err(map_hound_err)?;
+    }
+    writer.finalize().map_err(map_hound_err)
+}
+
+fn map_hound_err(e: hound::Error) -> TtsError {
+    match e {
+        hound::Error::IoError(io) => TtsError::Ipc(io),
+        other => TtsError::Ipc(std::io::Error::other(other.to_string())),
+    }
+}

--- a/src-tauri/src/tts/piper/mod.rs
+++ b/src-tauri/src/tts/piper/mod.rs
@@ -4,6 +4,7 @@
 //! the design rationale (native runtime, no Python sidecar, voices on demand).
 
 pub mod catalog;
+pub mod download;
 pub mod engine;
 pub mod timestamps;
 

--- a/src-tauri/src/tts/piper/mod.rs
+++ b/src-tauri/src/tts/piper/mod.rs
@@ -1,0 +1,10 @@
+//! Piper TTS engine — in-process ONNX inference via the `piper-rs` crate.
+//!
+//! See `tmp/issue_42_piper_plan.md` and `tmp/piper_rs_spike/findings.md` for
+//! the design rationale (native runtime, no Python sidecar, voices on demand).
+
+pub mod catalog;
+pub mod engine;
+pub mod timestamps;
+
+pub use engine::PiperEngine;

--- a/src-tauri/src/tts/piper/timestamps.rs
+++ b/src-tauri/src/tts/piper/timestamps.rs
@@ -1,0 +1,157 @@
+//! Word-level timestamp estimation for Piper output.
+//!
+//! Piper does not natively emit per-word timing, so we follow the same
+//! strategy as `ttsd/ttsd/timestamps.py`: distribute the total audio duration
+//! proportionally by word character length.
+//!
+//! Single-chunk only — Piper synthesizes the whole text in one call. If a
+//! future revision chunks long inputs, extend this with a chunked variant.
+
+use regex::Regex;
+
+use crate::tts::{CharMappingEntry, WordTimestamp};
+
+/// Estimate per-word timestamps for `text` over a single audio chunk of length
+/// `total_duration_sec`. `char_mapping`, when present, maps normalized-text
+/// offsets back to original-text offsets (so the player highlights the right
+/// span in the user's input).
+pub fn estimate_timestamps_single_chunk(
+    text: &str,
+    total_duration_sec: f64,
+    char_mapping: Option<&[CharMappingEntry]>,
+) -> Vec<WordTimestamp> {
+    // `regex::Regex::new(r"\b\w+\b")` is Unicode-aware by default — `\w`
+    // matches Cyrillic and other letter scripts.
+    static_re().captures_iter(text);
+    let words: Vec<(&str, usize, usize)> = static_re()
+        .find_iter(text)
+        .map(|m| (m.as_str(), m.start(), m.end()))
+        .collect();
+
+    if words.is_empty() {
+        return Vec::new();
+    }
+    let total_chars: usize = words.iter().map(|(w, _, _)| w.chars().count()).sum();
+    if total_chars == 0 {
+        return Vec::new();
+    }
+
+    let mut current_time = 0.0;
+    let mut out = Vec::with_capacity(words.len());
+
+    for (word, norm_start, norm_end) in words {
+        let word_chars = word.chars().count();
+        let word_duration = (word_chars as f64 / total_chars as f64) * total_duration_sec;
+
+        let original_pos = match char_mapping {
+            Some(spans) => map_via_spans(spans, norm_start, norm_end),
+            None => (norm_start, norm_end),
+        };
+
+        out.push(WordTimestamp {
+            word: word.to_string(),
+            start: round3(current_time),
+            end: round3(current_time + word_duration),
+            original_pos,
+        });
+        current_time += word_duration;
+    }
+
+    out
+}
+
+fn round3(v: f64) -> f64 {
+    (v * 1000.0).round() / 1000.0
+}
+
+fn static_re() -> &'static Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b\w+\b").expect("valid word regex"))
+}
+
+/// Find the span(s) covering `[norm_start, norm_end)` and return the smallest
+/// interval in original-text coordinates that contains them. Mirrors the
+/// `_map_via_spans` helper in `ttsd/timestamps.py`.
+fn map_via_spans(spans: &[CharMappingEntry], norm_start: usize, norm_end: usize) -> (usize, usize) {
+    let mut best_start: Option<usize> = None;
+    let mut best_end: Option<usize> = None;
+
+    for span in spans {
+        if span.norm_end <= norm_start {
+            continue;
+        }
+        if span.norm_start >= norm_end {
+            break;
+        }
+        match best_start {
+            None => best_start = Some(span.orig_start),
+            Some(s) if span.orig_start < s => best_start = Some(span.orig_start),
+            _ => {}
+        }
+        match best_end {
+            None => best_end = Some(span.orig_end),
+            Some(e) if span.orig_end > e => best_end = Some(span.orig_end),
+            _ => {}
+        }
+    }
+
+    match (best_start, best_end) {
+        (Some(s), Some(e)) => (s, e),
+        _ => (norm_start, norm_end),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_text_returns_no_words() {
+        let ts = estimate_timestamps_single_chunk("", 1.0, None);
+        assert!(ts.is_empty());
+    }
+
+    #[test]
+    fn punctuation_only_returns_no_words() {
+        let ts = estimate_timestamps_single_chunk("..., !!", 1.0, None);
+        assert!(ts.is_empty());
+    }
+
+    #[test]
+    fn russian_words_split_by_whitespace() {
+        let ts = estimate_timestamps_single_chunk("привет мир", 2.0, None);
+        assert_eq!(ts.len(), 2);
+        assert_eq!(ts[0].word, "привет");
+        assert_eq!(ts[1].word, "мир");
+        // 6 chars + 3 chars = 9 total. привет = 6/9 * 2 = 1.333…
+        assert!((ts[0].end - ts[0].start - 1.333).abs() < 0.01);
+        assert!((ts[1].end - 2.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn timestamps_advance_monotonically() {
+        let ts = estimate_timestamps_single_chunk("один два три четыре", 4.0, None);
+        for i in 1..ts.len() {
+            assert!(ts[i].start >= ts[i - 1].end - 1e-6);
+        }
+    }
+
+    #[test]
+    fn char_mapping_maps_norm_to_orig() {
+        // "API" (3 bytes in original) was normalized to "эй пи ай" — 14 bytes
+        // in UTF-8. One span covers the whole normalized range and points at
+        // the original 3-byte word.
+        let spans = vec![CharMappingEntry {
+            norm_start: 0,
+            norm_end: 14,
+            orig_start: 0,
+            orig_end: 3,
+        }];
+        let ts = estimate_timestamps_single_chunk("эй пи ай", 1.0, Some(&spans));
+        assert_eq!(ts.len(), 3);
+        for w in &ts {
+            assert_eq!(w.original_pos, (0, 3));
+        }
+    }
+}

--- a/src-tauri/src/tts/piper/timestamps.rs
+++ b/src-tauri/src/tts/piper/timestamps.rs
@@ -15,6 +15,12 @@ use crate::tts::{CharMappingEntry, WordTimestamp};
 /// `total_duration_sec`. `char_mapping`, when present, maps normalized-text
 /// offsets back to original-text offsets (so the player highlights the right
 /// span in the user's input).
+///
+/// Word offsets are reported in **Unicode codepoint** units (not UTF-8 bytes),
+/// matching `CharMapping`/`CharMappingEntry` and the JS frontend (which indexes
+/// into UTF-16 strings — equivalent to codepoints for BMP characters like all
+/// Cyrillic). `regex::find_iter` returns byte spans, so we convert them in a
+/// single forward pass that amortizes the char-counting work.
 pub fn estimate_timestamps_single_chunk(
     text: &str,
     total_duration_sec: f64,
@@ -22,11 +28,18 @@ pub fn estimate_timestamps_single_chunk(
 ) -> Vec<WordTimestamp> {
     // `regex::Regex::new(r"\b\w+\b")` is Unicode-aware by default — `\w`
     // matches Cyrillic and other letter scripts.
-    static_re().captures_iter(text);
-    let words: Vec<(&str, usize, usize)> = static_re()
-        .find_iter(text)
-        .map(|m| (m.as_str(), m.start(), m.end()))
-        .collect();
+    let mut words: Vec<(&str, usize, usize)> = Vec::new();
+    let mut prev_byte = 0;
+    let mut chars_so_far = 0;
+    for m in static_re().find_iter(text) {
+        chars_so_far += text[prev_byte..m.start()].chars().count();
+        let char_start = chars_so_far;
+        let word_chars = m.as_str().chars().count();
+        chars_so_far += word_chars;
+        let char_end = chars_so_far;
+        prev_byte = m.end();
+        words.push((m.as_str(), char_start, char_end));
+    }
 
     if words.is_empty() {
         return Vec::new();
@@ -139,12 +152,13 @@ mod tests {
 
     #[test]
     fn char_mapping_maps_norm_to_orig() {
-        // "API" (3 bytes in original) was normalized to "эй пи ай" — 14 bytes
-        // in UTF-8. One span covers the whole normalized range and points at
-        // the original 3-byte word.
+        // "API" (3 chars in original) was normalized to "эй пи ай" — 8 chars
+        // in the normalized text. One span covers the whole normalized range
+        // and points at the original 3-char word. Both ends are codepoint
+        // (char) indices, matching the `CharMapping` contract.
         let spans = vec![CharMappingEntry {
             norm_start: 0,
-            norm_end: 14,
+            norm_end: 8,
             orig_start: 0,
             orig_end: 3,
         }];
@@ -153,5 +167,18 @@ mod tests {
         for w in &ts {
             assert_eq!(w.original_pos, (0, 3));
         }
+    }
+
+    #[test]
+    fn original_pos_is_codepoint_indexed_for_cyrillic() {
+        // Without char_mapping, original_pos falls back to the normalized
+        // offsets. Those must be codepoint indices, not UTF-8 byte offsets —
+        // the JS frontend matches them against `data-orig-start` attributes
+        // emitted by `wrapWordsWithOrigPos`, which uses JS string indices
+        // (UTF-16 code units = codepoints for BMP characters).
+        let ts = estimate_timestamps_single_chunk("привет мир", 1.0, None);
+        assert_eq!(ts.len(), 2);
+        assert_eq!(ts[0].original_pos, (0, 6));
+        assert_eq!(ts[1].original_pos, (7, 10));
     }
 }

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -25,12 +25,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use serde_json::json;
 use tokio::process::Command;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
+use super::engine::{EngineKind, TtsEngine};
 use super::{CharMappingEntry, SynthesizeOutput, TtsError, TtsSubprocess};
 
 /// Backoff schedule for respawn attempts. Each entry is the delay *before*
@@ -181,16 +183,6 @@ impl TtsSupervisor {
         Err(err)
     }
 
-    /// Run the first-time Silero warmup in the background, emitting the
-    /// `model_loading` → `model_loaded` / `model_error` lifecycle that the
-    /// frontend expects on startup. Same code path as post-respawn warmup —
-    /// callers don't need to duplicate the lifecycle plumbing.
-    pub async fn spawn_initial_warmup(&self) {
-        if let Some(handle) = self.current_handle().await {
-            self.spawn_warmup(handle);
-        }
-    }
-
     /// Run `warmup` against the freshly-spawned handle in a background task,
     /// mirroring the `model_loading` → `model_loaded` / `model_error`
     /// lifecycle that startup uses. Failures here do not invalidate the
@@ -212,17 +204,34 @@ impl TtsSupervisor {
             }
         });
     }
+}
 
-    // ── Proxied methods ───────────────────────────────────────────────────
+// ── TtsEngine impl ─────────────────────────────────────────────────────────────
 
-    pub async fn warmup(&self) -> Result<(), TtsError> {
+#[async_trait]
+impl TtsEngine for TtsSupervisor {
+    fn kind(&self) -> EngineKind {
+        EngineKind::Silero
+    }
+
+    async fn warmup(&self) -> Result<(), TtsError> {
         self.with_retry(|h| async move { h.warmup().await }).await
     }
 
-    pub async fn synthesize(
+    /// Run the first-time Silero warmup in the background, emitting the
+    /// `model_loading` → `model_loaded` / `model_error` lifecycle that the
+    /// frontend expects on startup. Same code path as post-respawn warmup —
+    /// callers don't need to duplicate the lifecycle plumbing.
+    async fn spawn_initial_warmup(&self) {
+        if let Some(handle) = self.current_handle().await {
+            self.spawn_warmup(handle);
+        }
+    }
+
+    async fn synthesize(
         &self,
         text: String,
-        speaker: String,
+        voice: String,
         sample_rate: u32,
         out_wav: String,
         char_mapping: Option<Vec<CharMappingEntry>>,
@@ -230,7 +239,7 @@ impl TtsSupervisor {
         // Convert once at the supervisor boundary; each retry below only bumps
         // the Arc refcount instead of memcpy-cloning the strings/Vec.
         let text: Arc<str> = Arc::from(text);
-        let speaker: Arc<str> = Arc::from(speaker);
+        let speaker: Arc<str> = Arc::from(voice);
         let out_wav: Arc<str> = Arc::from(out_wav);
         let char_mapping: Option<Arc<[CharMappingEntry]>> = char_mapping.map(Arc::from);
 
@@ -249,7 +258,7 @@ impl TtsSupervisor {
 
     /// Graceful shutdown. Does *not* respawn on Died — at this point we are
     /// tearing down anyway.
-    pub async fn shutdown(&self) -> Result<(), TtsError> {
+    async fn shutdown(&self) -> Result<(), TtsError> {
         let handle = match self.current_handle().await {
             Some(h) => h,
             None => return Ok(()),

--- a/src-tauri/src/tts/switcher.rs
+++ b/src-tauri/src/tts/switcher.rs
@@ -1,0 +1,268 @@
+//! Engine swap layer.
+//!
+//! [`EngineSwitcher`] holds the currently-active [`TtsEngine`] behind a
+//! `RwLock` so the user's "active engine" / "Piper voice" choice in Settings
+//! can be applied at runtime without restarting the app. Synthesis and warmup
+//! calls are forwarded to whichever engine is currently installed; swap
+//! decisions are driven from [`apply_config`](EngineSwitcher::apply_config).
+//!
+//! The factory closures for Piper and Silero live here (paths + emitter +
+//! ttsd command) so [`apply_config`] can rebuild either engine in-place.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use super::engine::{EngineKind, TtsEngine};
+use super::piper::PiperEngine;
+use super::supervisor::{CommandFactory, Emitter, TtsSupervisor};
+use super::{CharMappingEntry, SynthesizeOutput, TtsError};
+
+/// Currently-active engine plus the inputs needed to rebuild either side.
+pub struct EngineSwitcher {
+    inner: RwLock<Slot>,
+    /// Last-installed kind, mirrored as an atomic so the sync `kind()` impl
+    /// does not need to acquire the RwLock.
+    kind: AtomicU8,
+    piper_voices_dir: PathBuf,
+    ttsd_dir: PathBuf,
+    emitter: Emitter,
+}
+
+struct Slot {
+    engine: Arc<dyn TtsEngine>,
+    /// Currently-loaded Piper voice id, when the active engine is Piper.
+    /// Used to decide whether a `piper_voice` change requires a rebuild.
+    piper_voice: Option<String>,
+}
+
+const KIND_PIPER: u8 = 0;
+const KIND_SILERO: u8 = 1;
+
+fn kind_to_u8(k: EngineKind) -> u8 {
+    match k {
+        EngineKind::Piper => KIND_PIPER,
+        EngineKind::Silero => KIND_SILERO,
+    }
+}
+
+fn u8_to_kind(v: u8) -> EngineKind {
+    match v {
+        KIND_SILERO => EngineKind::Silero,
+        _ => EngineKind::Piper,
+    }
+}
+
+impl EngineSwitcher {
+    /// Construct a switcher around an already-built initial engine. The
+    /// caller must pass `initial_kind` matching the engine's `kind()` and,
+    /// when the engine is Piper, the voice id its `default_voice` was
+    /// constructed with.
+    pub fn new(
+        initial: Arc<dyn TtsEngine>,
+        initial_kind: EngineKind,
+        initial_piper_voice: Option<String>,
+        piper_voices_dir: PathBuf,
+        ttsd_dir: PathBuf,
+        emitter: Emitter,
+    ) -> Self {
+        Self {
+            inner: RwLock::new(Slot {
+                engine: initial,
+                piper_voice: initial_piper_voice,
+            }),
+            kind: AtomicU8::new(kind_to_u8(initial_kind)),
+            piper_voices_dir,
+            ttsd_dir,
+            emitter,
+        }
+    }
+
+    /// Reconcile the currently-active engine with `target_engine` /
+    /// `target_piper_voice`. A no-op when no rebuild is needed; otherwise
+    /// builds the new engine, swaps it in, and kicks off a background
+    /// warmup so the UI gets `model_loading` → `model_loaded` events.
+    ///
+    /// `target_engine` must be `"piper"` or `"silero"`. Unknown values
+    /// return [`TtsError::Ttsd`] with code `engine_unknown`.
+    pub async fn apply_config(
+        &self,
+        target_engine: &str,
+        target_piper_voice: &str,
+    ) -> Result<(), TtsError> {
+        let target_kind = parse_kind(target_engine)?;
+        let need_rebuild = {
+            let slot = self.inner.read().await;
+            let current_kind = u8_to_kind(self.kind.load(Ordering::SeqCst));
+            current_kind != target_kind
+                || (target_kind == EngineKind::Piper
+                    && slot.piper_voice.as_deref() != Some(target_piper_voice))
+        };
+        if !need_rebuild {
+            return Ok(());
+        }
+
+        let (new_engine, new_voice) = match target_kind {
+            EngineKind::Piper => {
+                let engine = self.build_piper(target_piper_voice.to_string());
+                (
+                    engine as Arc<dyn TtsEngine>,
+                    Some(target_piper_voice.to_string()),
+                )
+            }
+            EngineKind::Silero => {
+                let engine = self.build_silero()?;
+                (engine as Arc<dyn TtsEngine>, None)
+            }
+        };
+
+        {
+            let mut slot = self.inner.write().await;
+            slot.engine = Arc::clone(&new_engine);
+            slot.piper_voice = new_voice;
+        }
+        self.kind.store(kind_to_u8(target_kind), Ordering::SeqCst);
+
+        new_engine.spawn_initial_warmup().await;
+        Ok(())
+    }
+
+    fn build_piper(&self, voice: String) -> Arc<PiperEngine> {
+        Arc::new(PiperEngine::new(
+            self.piper_voices_dir.clone(),
+            voice,
+            Arc::clone(&self.emitter),
+        ))
+    }
+
+    fn build_silero(&self) -> Result<Arc<TtsSupervisor>, TtsError> {
+        let ttsd_dir = self.ttsd_dir.clone();
+        let factory: CommandFactory = Arc::new(move || {
+            let mut cmd = tokio::process::Command::new("uv");
+            cmd.args(["run", "python", "-m", "ttsd"])
+                .current_dir(&ttsd_dir);
+            cmd
+        });
+        let supervisor = TtsSupervisor::spawn(factory, Arc::clone(&self.emitter))?;
+        Ok(Arc::new(supervisor))
+    }
+
+    async fn current_engine(&self) -> Arc<dyn TtsEngine> {
+        Arc::clone(&self.inner.read().await.engine)
+    }
+}
+
+fn parse_kind(name: &str) -> Result<EngineKind, TtsError> {
+    match name {
+        "piper" => Ok(EngineKind::Piper),
+        "silero" => Ok(EngineKind::Silero),
+        other => Err(TtsError::Ttsd {
+            code: "engine_unknown".to_string(),
+            message: format!("неизвестный движок: \"{other}\""),
+        }),
+    }
+}
+
+#[async_trait]
+impl TtsEngine for EngineSwitcher {
+    fn kind(&self) -> EngineKind {
+        u8_to_kind(self.kind.load(Ordering::SeqCst))
+    }
+
+    async fn warmup(&self) -> Result<(), TtsError> {
+        self.current_engine().await.warmup().await
+    }
+
+    async fn spawn_initial_warmup(&self) {
+        self.current_engine().await.spawn_initial_warmup().await
+    }
+
+    async fn synthesize(
+        &self,
+        text: String,
+        voice: String,
+        sample_rate: u32,
+        out_wav: String,
+        char_mapping: Option<Vec<CharMappingEntry>>,
+    ) -> Result<SynthesizeOutput, TtsError> {
+        self.current_engine()
+            .await
+            .synthesize(text, voice, sample_rate, out_wav, char_mapping)
+            .await
+    }
+
+    async fn shutdown(&self) -> Result<(), TtsError> {
+        self.current_engine().await.shutdown().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tts::supervisor::test_helpers::recording_emitter;
+
+    fn fake_switcher() -> EngineSwitcher {
+        let (emitter, _) = recording_emitter();
+        let voices_dir = std::env::temp_dir().join("ruvox-test-voices");
+        let ttsd_dir = std::env::temp_dir().join("ruvox-test-ttsd");
+        let initial: Arc<dyn TtsEngine> = Arc::new(PiperEngine::new(
+            voices_dir.clone(),
+            "ruslan".to_string(),
+            Arc::clone(&emitter),
+        ));
+        EngineSwitcher::new(
+            initial,
+            EngineKind::Piper,
+            Some("ruslan".to_string()),
+            voices_dir,
+            ttsd_dir,
+            emitter,
+        )
+    }
+
+    #[test]
+    fn parse_kind_accepts_known_values() {
+        assert_eq!(parse_kind("piper").unwrap(), EngineKind::Piper);
+        assert_eq!(parse_kind("silero").unwrap(), EngineKind::Silero);
+    }
+
+    #[test]
+    fn parse_kind_rejects_unknown() {
+        let err = parse_kind("nemo").unwrap_err();
+        match err {
+            TtsError::Ttsd { code, .. } => assert_eq!(code, "engine_unknown"),
+            other => panic!("expected Ttsd error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_config_with_same_engine_and_voice_is_noop() {
+        let sw = fake_switcher();
+        // Same kind + same voice → no rebuild attempted.
+        sw.apply_config("piper", "ruslan").await.unwrap();
+        assert_eq!(sw.kind(), EngineKind::Piper);
+    }
+
+    #[tokio::test]
+    async fn apply_config_rebuilds_piper_on_voice_change() {
+        let sw = fake_switcher();
+        sw.apply_config("piper", "irina").await.unwrap();
+        // Engine kind unchanged, but the inner slot now references "irina".
+        assert_eq!(sw.kind(), EngineKind::Piper);
+        let slot = sw.inner.read().await;
+        assert_eq!(slot.piper_voice.as_deref(), Some("irina"));
+    }
+
+    #[tokio::test]
+    async fn apply_config_rejects_unknown_engine() {
+        let sw = fake_switcher();
+        let err = sw.apply_config("nemo", "ruslan").await.unwrap_err();
+        match err {
+            TtsError::Ttsd { code, .. } => assert_eq!(code, "engine_unknown"),
+            other => panic!("expected engine_unknown, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 
 use ruvox_tauri_lib::tts::supervisor::test_helpers::recording_emitter;
 use ruvox_tauri_lib::tts::supervisor::{CommandFactory, TtsSupervisor};
+// Bring the trait into scope so `sup.synthesize(...)` resolves to its
+// `TtsEngine` impl methods.
+use ruvox_tauri_lib::tts::TtsEngine;
 use tokio::process::Command;
 
 /// Resolve the mock script path. `cargo test` may be invoked from either

--- a/src/dialogs/Settings.tsx
+++ b/src/dialogs/Settings.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Alert,
+  Badge,
   Button,
   Checkbox,
   Divider,
@@ -11,6 +12,7 @@ import {
   Stack,
   Switch,
   Text,
+  Tooltip,
   useMantineColorScheme,
 } from '@mantine/core';
 import type { MantineColorScheme } from '@mantine/core';
@@ -18,10 +20,18 @@ import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { commands } from '../lib/tauri';
-import type { CleanupMode, UIConfigPatch } from '../lib/tauri';
+import type { CleanupMode, EngineKind, UIConfigPatch } from '../lib/tauri';
 import { formatError } from '../lib/errors';
+import { PIPER_VOICES } from '../lib/piperVoices';
+import {
+  applyEngineChange,
+  computeEngineFormState,
+  type AvailabilityMap,
+} from '../lib/engineSelection';
 
 interface SettingsFormValues {
+  engine: EngineKind;
+  piper_voice: string;
   speaker: string;
   sample_rate: number;
   notify_on_ready: boolean;
@@ -30,6 +40,22 @@ interface SettingsFormValues {
   max_cache_size_mb: number;
   theme: string;
 }
+
+// Phase 2: Silero is rendered but disabled. Phase 3 of #42 replaces this
+// with a runtime probe (`get_available_engines`) so the reason text reflects
+// the actual environment (no `uv`, no `ttsd/`, etc).
+const PHASE2_AVAILABILITY: AvailabilityMap = {
+  piper: { available: true, reason: null },
+  silero: {
+    available: false,
+    reason: 'Доступно после установки Python-стека (будет включено в следующей фазе #42).',
+  },
+};
+
+const ENGINE_OPTIONS: ReadonlyArray<{ value: EngineKind; label: string }> = [
+  { value: 'piper', label: 'Piper (по умолчанию, без Python)' },
+  { value: 'silero', label: 'Silero (Python ttsd)' },
+];
 
 interface SettingsModalProps {
   opened: boolean;
@@ -185,8 +211,11 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
   const { setColorScheme } = useMantineColorScheme();
   const [cleanupOpen, setCleanupOpen] = useState(false);
   const [cacheDir, setCacheDir] = useState<string>('');
+  const [coercedAlert, setCoercedAlert] = useState(false);
   const form = useForm<SettingsFormValues>({
     initialValues: {
+      engine: 'piper',
+      piper_voice: 'ruslan',
       speaker: 'xenia',
       sample_rate: 48000,
       notify_on_ready: true,
@@ -203,8 +232,11 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
   useEffect(() => {
     if (!opened) return;
     commands.getConfig().then((config) => {
+      const initial = computeEngineFormState(config, PHASE2_AVAILABILITY);
       form.setValues({
-        speaker: config.speaker,
+        engine: initial.engine,
+        piper_voice: initial.piperVoice,
+        speaker: initial.sileroSpeaker,
         sample_rate: config.sample_rate,
         notify_on_ready: config.notify_on_ready,
         notify_on_error: config.notify_on_error,
@@ -212,11 +244,29 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
         max_cache_size_mb: config.max_cache_size_mb,
         theme: config.theme,
       });
+      setCoercedAlert(initial.coercedAwayFromUnavailable);
     });
     commands.getCacheDir().then(setCacheDir).catch(() => setCacheDir(''));
     // form is excluded intentionally: setValues is stable, re-running on form change would loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [opened]);
+
+  const piperVoiceOptions = useMemo(
+    () => PIPER_VOICES.map((v) => ({ value: v.id, label: v.label })),
+    [],
+  );
+
+  const handleEngineChange = (next: EngineKind) => {
+    const current = {
+      engine: form.values.engine,
+      piperVoice: form.values.piper_voice,
+      sileroSpeaker: form.values.speaker,
+      coercedAwayFromUnavailable: coercedAlert,
+    };
+    const updated = applyEngineChange(current, next, PHASE2_AVAILABILITY);
+    form.setFieldValue('engine', updated.engine);
+    setCoercedAlert(updated.coercedAwayFromUnavailable);
+  };
 
   // Reset the nested cleanup modal's visibility when Settings closes, so
   // reopening Settings does not resurrect a stale nested-open state.
@@ -241,6 +291,8 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
 
   const handleSubmit = async (values: SettingsFormValues) => {
     const patch: UIConfigPatch = {
+      engine: values.engine,
+      piper_voice: values.piper_voice,
       speaker: values.speaker,
       sample_rate: values.sample_rate,
       notify_on_ready: values.notify_on_ready,
@@ -263,10 +315,10 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
       });
       onSaved?.();
       onClose();
-    } catch {
+    } catch (err) {
       notifications.show({
         title: 'Ошибка сохранения',
-        message: 'Не удалось сохранить настройки.',
+        message: formatError(err),
         color: 'red',
       });
     }
@@ -289,12 +341,55 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
             Синтез речи
           </Text>
 
+          {coercedAlert && (
+            <Alert color="yellow" variant="light">
+              Сохранённый движок недоступен — выбран Piper.
+            </Alert>
+          )}
+
           <Select
-            label="Голос"
-            data={SPEAKER_OPTIONS}
-            key={form.key('speaker')}
-            {...form.getInputProps('speaker')}
+            label="Движок"
+            description="Piper — встроенный, не требует Python."
+            data={ENGINE_OPTIONS.map((opt) => ({
+              value: opt.value,
+              label: opt.label,
+              disabled: !PHASE2_AVAILABILITY[opt.value].available,
+            }))}
+            value={form.values.engine}
+            onChange={(v) => v && handleEngineChange(v as EngineKind)}
           />
+
+          {!PHASE2_AVAILABILITY.silero.available && (
+            <Text size="xs" c="dimmed" mt={-8}>
+              Silero: {PHASE2_AVAILABILITY.silero.reason}
+            </Text>
+          )}
+
+          {form.values.engine === 'piper' ? (
+            <Select
+              label="Голос Piper"
+              data={piperVoiceOptions}
+              key={form.key('piper_voice')}
+              {...form.getInputProps('piper_voice')}
+              rightSection={
+                PIPER_VOICES.find((v) => v.id === form.values.piper_voice)?.recommended ? (
+                  <Tooltip label="Рекомендуется для технических текстов">
+                    <Badge size="xs" color="blue" variant="light">
+                      Рек.
+                    </Badge>
+                  </Tooltip>
+                ) : null
+              }
+              rightSectionWidth={60}
+            />
+          ) : (
+            <Select
+              label="Голос Silero"
+              data={SPEAKER_OPTIONS}
+              key={form.key('speaker')}
+              {...form.getInputProps('speaker')}
+            />
+          )}
 
           <Select
             label="Частота дискретизации"

--- a/src/dialogs/Settings.tsx
+++ b/src/dialogs/Settings.tsx
@@ -373,22 +373,42 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
           )}
 
           {form.values.engine === 'piper' ? (
-            <Select
-              label="Голос Piper"
-              data={piperVoiceOptions}
-              key={form.key('piper_voice')}
-              {...form.getInputProps('piper_voice')}
-              rightSection={
-                PIPER_VOICES.find((v) => v.id === form.values.piper_voice)?.recommended ? (
-                  <Tooltip label="Рекомендуется для технических текстов">
-                    <Badge size="xs" color="blue" variant="light">
-                      Рек.
-                    </Badge>
-                  </Tooltip>
-                ) : null
-              }
-              rightSectionWidth={60}
-            />
+            <Stack gap={6}>
+              <Select
+                label="Голос Piper"
+                description="При первом синтезе ~60 МБ загрузятся автоматически."
+                data={piperVoiceOptions}
+                key={form.key('piper_voice')}
+                {...form.getInputProps('piper_voice')}
+                rightSection={
+                  PIPER_VOICES.find((v) => v.id === form.values.piper_voice)?.recommended ? (
+                    <Tooltip label="Рекомендуется для технических текстов">
+                      <Badge size="xs" color="blue" variant="light">
+                        Рек.
+                      </Badge>
+                    </Tooltip>
+                  ) : null
+                }
+                rightSectionWidth={60}
+              />
+              <Group justify="flex-start">
+                <Button
+                  variant="default"
+                  size="xs"
+                  onClick={() =>
+                    commands.downloadPiperVoice(form.values.piper_voice).catch((err) => {
+                      notifications.show({
+                        title: 'Не удалось запустить загрузку',
+                        message: formatError(err),
+                        color: 'red',
+                      });
+                    })
+                  }
+                >
+                  Скачать сейчас
+                </Button>
+              </Group>
+            </Stack>
           ) : (
             <Select
               label="Голос Silero"

--- a/src/dialogs/Settings.tsx
+++ b/src/dialogs/Settings.tsx
@@ -41,21 +41,18 @@ interface SettingsFormValues {
   theme: string;
 }
 
-// Phase 2: Silero is rendered but disabled. Phase 3 of #42 replaces this
-// with a runtime probe (`get_available_engines`) so the reason text reflects
-// the actual environment (no `uv`, no `ttsd/`, etc).
-const PHASE2_AVAILABILITY: AvailabilityMap = {
-  piper: { available: true, reason: null },
-  silero: {
-    available: false,
-    reason: 'Доступно после установки Python-стека (будет включено в следующей фазе #42).',
-  },
-};
-
 const ENGINE_OPTIONS: ReadonlyArray<{ value: EngineKind; label: string }> = [
   { value: 'piper', label: 'Piper (по умолчанию, без Python)' },
   { value: 'silero', label: 'Silero (Python ttsd)' },
 ];
+
+/// Pessimistic default used until `getAvailableEngines()` resolves: Piper
+/// is always on; Silero is treated as unavailable so users don't briefly
+/// see it as enabled and click before the probe lands.
+const PESSIMISTIC_AVAILABILITY: AvailabilityMap = {
+  piper: { available: true, reason: null },
+  silero: { available: false, reason: 'Проверяю наличие Python-стека…' },
+};
 
 interface SettingsModalProps {
   opened: boolean;
@@ -212,6 +209,7 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
   const [cleanupOpen, setCleanupOpen] = useState(false);
   const [cacheDir, setCacheDir] = useState<string>('');
   const [coercedAlert, setCoercedAlert] = useState(false);
+  const [availability, setAvailability] = useState<AvailabilityMap>(PESSIMISTIC_AVAILABILITY);
   const form = useForm<SettingsFormValues>({
     initialValues: {
       engine: 'piper',
@@ -231,21 +229,30 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
 
   useEffect(() => {
     if (!opened) return;
-    commands.getConfig().then((config) => {
-      const initial = computeEngineFormState(config, PHASE2_AVAILABILITY);
-      form.setValues({
-        engine: initial.engine,
-        piper_voice: initial.piperVoice,
-        speaker: initial.sileroSpeaker,
-        sample_rate: config.sample_rate,
-        notify_on_ready: config.notify_on_ready,
-        notify_on_error: config.notify_on_error,
-        preview_dialog_enabled: config.preview_dialog_enabled,
-        max_cache_size_mb: config.max_cache_size_mb,
-        theme: config.theme,
+    Promise.all([commands.getConfig(), commands.getAvailableEngines()])
+      .then(([config, probed]) => {
+        setAvailability(probed);
+        const initial = computeEngineFormState(config, probed);
+        form.setValues({
+          engine: initial.engine,
+          piper_voice: initial.piperVoice,
+          speaker: initial.sileroSpeaker,
+          sample_rate: config.sample_rate,
+          notify_on_ready: config.notify_on_ready,
+          notify_on_error: config.notify_on_error,
+          preview_dialog_enabled: config.preview_dialog_enabled,
+          max_cache_size_mb: config.max_cache_size_mb,
+          theme: config.theme,
+        });
+        setCoercedAlert(initial.coercedAwayFromUnavailable);
+      })
+      .catch((err) => {
+        notifications.show({
+          title: 'Не удалось загрузить настройки',
+          message: formatError(err),
+          color: 'red',
+        });
       });
-      setCoercedAlert(initial.coercedAwayFromUnavailable);
-    });
     commands.getCacheDir().then(setCacheDir).catch(() => setCacheDir(''));
     // form is excluded intentionally: setValues is stable, re-running on form change would loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -263,7 +270,7 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
       sileroSpeaker: form.values.speaker,
       coercedAwayFromUnavailable: coercedAlert,
     };
-    const updated = applyEngineChange(current, next, PHASE2_AVAILABILITY);
+    const updated = applyEngineChange(current, next, availability);
     form.setFieldValue('engine', updated.engine);
     setCoercedAlert(updated.coercedAwayFromUnavailable);
   };
@@ -353,15 +360,15 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
             data={ENGINE_OPTIONS.map((opt) => ({
               value: opt.value,
               label: opt.label,
-              disabled: !PHASE2_AVAILABILITY[opt.value].available,
+              disabled: !availability[opt.value].available,
             }))}
             value={form.values.engine}
             onChange={(v) => v && handleEngineChange(v as EngineKind)}
           />
 
-          {!PHASE2_AVAILABILITY.silero.available && (
+          {!availability.silero.available && availability.silero.reason && (
             <Text size="xs" c="dimmed" mt={-8}>
-              Silero: {PHASE2_AVAILABILITY.silero.reason}
+              Silero: {availability.silero.reason}
             </Text>
           )}
 

--- a/src/lib/engineSelection.test.ts
+++ b/src/lib/engineSelection.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyEngineChange,
+  computeEngineFormState,
+  type AvailabilityMap,
+} from './engineSelection';
+
+const BOTH_AVAILABLE: AvailabilityMap = {
+  piper: { available: true, reason: null },
+  silero: { available: true, reason: null },
+};
+
+const ONLY_PIPER: AvailabilityMap = {
+  piper: { available: true, reason: null },
+  silero: { available: false, reason: 'Python-стек не установлен' },
+};
+
+const ONLY_SILERO: AvailabilityMap = {
+  piper: { available: false, reason: 'Голос не загружен' },
+  silero: { available: true, reason: null },
+};
+
+const NEITHER: AvailabilityMap = {
+  piper: { available: false, reason: 'oops' },
+  silero: { available: false, reason: 'oops' },
+};
+
+describe('computeEngineFormState', () => {
+  it('preserves saved engine when both are available', () => {
+    const s = computeEngineFormState(
+      { engine: 'silero', piper_voice: 'irina', speaker: 'baya' },
+      BOTH_AVAILABLE,
+    );
+    expect(s.engine).toBe('silero');
+    expect(s.piperVoice).toBe('irina');
+    expect(s.sileroSpeaker).toBe('baya');
+    expect(s.coercedAwayFromUnavailable).toBe(false);
+  });
+
+  it('coerces silero → piper when silero is unavailable', () => {
+    const s = computeEngineFormState(
+      { engine: 'silero', piper_voice: 'ruslan', speaker: 'xenia' },
+      ONLY_PIPER,
+    );
+    expect(s.engine).toBe('piper');
+    expect(s.coercedAwayFromUnavailable).toBe(true);
+  });
+
+  it('does not flag coercion when saved engine matches forced fallback', () => {
+    // piper is unavailable but the saved engine was already silero → no coercion.
+    const s = computeEngineFormState(
+      { engine: 'silero', piper_voice: 'ruslan', speaker: 'baya' },
+      ONLY_SILERO,
+    );
+    expect(s.engine).toBe('silero');
+    expect(s.coercedAwayFromUnavailable).toBe(false);
+  });
+
+  it('falls back to piper when both are unavailable', () => {
+    const s = computeEngineFormState(
+      { engine: 'silero', piper_voice: 'ruslan', speaker: 'xenia' },
+      NEITHER,
+    );
+    expect(s.engine).toBe('piper');
+    // Coerced because saved engine was silero, fallback chose piper.
+    expect(s.coercedAwayFromUnavailable).toBe(true);
+  });
+
+  it('uses defaults when config has empty voice fields', () => {
+    const s = computeEngineFormState(
+      { engine: 'piper', piper_voice: '', speaker: '' },
+      BOTH_AVAILABLE,
+    );
+    expect(s.piperVoice).toBe('ruslan');
+    expect(s.sileroSpeaker).toBe('xenia');
+  });
+});
+
+describe('applyEngineChange', () => {
+  const start = computeEngineFormState(
+    { engine: 'piper', piper_voice: 'ruslan', speaker: 'xenia' },
+    BOTH_AVAILABLE,
+  );
+
+  it('flips to the selected engine when available', () => {
+    const next = applyEngineChange(start, 'silero', BOTH_AVAILABLE);
+    expect(next.engine).toBe('silero');
+    // Voices preserved across the flip.
+    expect(next.piperVoice).toBe('ruslan');
+    expect(next.sileroSpeaker).toBe('xenia');
+  });
+
+  it('rejects a flip to an unavailable engine', () => {
+    const next = applyEngineChange(start, 'silero', ONLY_PIPER);
+    expect(next).toEqual(start);
+  });
+
+  it('clears the coercion alert after a manual change', () => {
+    const coerced = computeEngineFormState(
+      { engine: 'silero', piper_voice: 'ruslan', speaker: 'xenia' },
+      ONLY_PIPER,
+    );
+    expect(coerced.coercedAwayFromUnavailable).toBe(true);
+    const next = applyEngineChange(coerced, 'piper', ONLY_PIPER);
+    expect(next.coercedAwayFromUnavailable).toBe(false);
+  });
+});

--- a/src/lib/engineSelection.ts
+++ b/src/lib/engineSelection.ts
@@ -1,0 +1,89 @@
+// Pure reducer for the Settings engine selector. No React, no Tauri imports —
+// everything that needs to read or transform `(config, availability)` lives
+// here so it can be unit-tested with Vitest in isolation from the Tauri shell.
+
+import { DEFAULT_PIPER_VOICE } from './piperVoices';
+import type { EngineKind, UIConfig } from './tauri';
+
+export interface EngineAvailability {
+  /** Whether the engine can be selected from the UI. Phase 3 of #42 wires
+   *  this to a runtime probe of the ttsd / Python stack; in Phase 2 Silero
+   *  is unconditionally `false` and Piper is unconditionally `true`. */
+  available: boolean;
+  /** Russian-language explanation shown in a tooltip / Alert when
+   *  `available` is `false`. Null when the engine is available. */
+  reason: string | null;
+}
+
+export interface AvailabilityMap {
+  piper: EngineAvailability;
+  silero: EngineAvailability;
+}
+
+export interface EngineFormState {
+  engine: EngineKind;
+  /** Voice the user picked for Piper. Persisted across engine flips so the
+   *  Settings dialog re-shows it when they switch back. */
+  piperVoice: string;
+  /** Voice the user picked for Silero (`config.speaker`). Persisted across
+   *  engine flips for the same reason. */
+  sileroSpeaker: string;
+  /** When `true`, show an inline alert telling the user we coerced the form
+   *  away from their saved engine because it's currently unavailable. */
+  coercedAwayFromUnavailable: boolean;
+}
+
+/**
+ * Build the initial engine form state from a saved [`UIConfig`] and the
+ * runtime availability map. If the saved engine is unavailable, falls back
+ * to the recommended-available engine (currently Piper) and flags the
+ * coercion so the UI can surface a one-shot alert.
+ */
+export function computeEngineFormState(
+  config: Pick<UIConfig, 'engine' | 'piper_voice' | 'speaker'>,
+  availability: AvailabilityMap,
+): EngineFormState {
+  const savedEngine: EngineKind = config.engine === 'silero' ? 'silero' : 'piper';
+  const savedAvailable = availability[savedEngine].available;
+  const engine: EngineKind = savedAvailable
+    ? savedEngine
+    : pickFallbackEngine(savedEngine, availability);
+
+  return {
+    engine,
+    piperVoice: config.piper_voice || DEFAULT_PIPER_VOICE,
+    sileroSpeaker: config.speaker || 'xenia',
+    coercedAwayFromUnavailable: !savedAvailable && engine !== savedEngine,
+  };
+}
+
+/**
+ * Apply the user picking a different engine in the dropdown. Disabled
+ * engines (`availability[next].available === false`) are silently rejected
+ * — the dropdown must filter them out, but this is the defensive path.
+ * Voice fields are preserved so the saved choice round-trips when the user
+ * flips back.
+ */
+export function applyEngineChange(
+  state: EngineFormState,
+  next: EngineKind,
+  availability: AvailabilityMap,
+): EngineFormState {
+  if (!availability[next].available) {
+    return state;
+  }
+  return { ...state, engine: next, coercedAwayFromUnavailable: false };
+}
+
+function pickFallbackEngine(
+  unavailable: EngineKind,
+  availability: AvailabilityMap,
+): EngineKind {
+  const other: EngineKind = unavailable === 'piper' ? 'silero' : 'piper';
+  if (availability[other].available) {
+    return other;
+  }
+  // Both unavailable — return Piper so the UI still has a value to render.
+  // The save attempt will fail at the backend and the user gets the error.
+  return 'piper';
+}

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -31,39 +31,72 @@ export async function renderMermaidIn(
     if (node.dataset.mermaidSource === undefined) {
       node.dataset.mermaidSource = node.textContent ?? '';
     }
-    const source = node.dataset.mermaidSource.trim();
-    if (!source) continue;
+    const fullSource = node.dataset.mermaidSource.trim();
+    if (!fullSource) continue;
 
-    const id = `mermaid-${Date.now().toString(36)}-${renderCounter++}`;
-    // Render into a temporary off-screen container. Calling `mermaid.render`
-    // without a container makes the library inject and clean up its own host
-    // element on `document.body`, which is fragile inside Tauri's WebKit (the
-    // SVG sometimes never reaches the caller). An explicit container avoids
-    // that path entirely.
-    const host = document.createElement('div');
-    host.setAttribute('aria-hidden', 'true');
-    host.style.cssText = 'position:absolute;visibility:hidden;left:-99999px;top:-99999px;';
-    document.body.appendChild(host);
-    try {
-      const { svg, bindFunctions } = await mermaid.render(id, source, host);
-      node.innerHTML = svg;
-      bindFunctions?.(node);
-    } catch (e) {
-      // Show the source inside <pre> so line breaks survive HTML whitespace
-      // collapsing — the diagram code stays readable while the user (or we)
-      // figure out the syntax problem.
-      const pre = document.createElement('pre');
-      pre.className = 'mermaid-error';
-      pre.textContent = source;
-      node.replaceChildren(pre);
-      // eslint-disable-next-line no-console
-      console.error(
-        'mermaid render error:',
-        e,
-        '\n=== SOURCE FED TO mermaid.render ===\n' + JSON.stringify(source),
-      );
-    } finally {
-      host.remove();
+    // First attempt: full source. If it fails, retry with the part before the
+    // first blank line — when a markdown author forgets the closing ```, the
+    // mermaid fence absorbs the rest of the document and parsing fails on
+    // the trailing prose. Keeping the diagram visible matters more than
+    // surfacing the lost prose, which would have been hidden inside the
+    // fence anyway.
+    let lastError: unknown = null;
+    for (const candidate of candidateSources(fullSource)) {
+      try {
+        await renderInto(node, candidate);
+        lastError = null;
+        break;
+      } catch (e) {
+        lastError = e;
+      }
+    }
+
+    if (lastError !== null) {
+      renderError(node, fullSource, lastError);
     }
   }
+}
+
+function* candidateSources(source: string): Generator<string> {
+  yield source;
+  const firstBlock = source.split(/\n[ \t]*\n/, 1)[0];
+  if (firstBlock !== source && firstBlock.trim().length > 0) {
+    yield firstBlock;
+  }
+}
+
+async function renderInto(node: HTMLElement, source: string): Promise<void> {
+  const id = `mermaid-${Date.now().toString(36)}-${renderCounter++}`;
+  // Render into a temporary off-screen container. Calling `mermaid.render`
+  // without a container makes the library inject and clean up its own host
+  // element on `document.body`, which is fragile inside Tauri's WebKit (the
+  // SVG sometimes never reaches the caller). An explicit container avoids
+  // that path entirely.
+  const host = document.createElement('div');
+  host.setAttribute('aria-hidden', 'true');
+  host.style.cssText = 'position:absolute;visibility:hidden;left:-99999px;top:-99999px;';
+  document.body.appendChild(host);
+  try {
+    const { svg, bindFunctions } = await mermaid.render(id, source, host);
+    node.innerHTML = svg;
+    bindFunctions?.(node);
+  } finally {
+    host.remove();
+  }
+}
+
+function renderError(node: HTMLElement, source: string, error: unknown): void {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'mermaid-error';
+  const hint = document.createElement('div');
+  hint.style.cssText = 'color: var(--mantine-color-orange-6, #e67700); font-size: 0.85em; margin-bottom: 0.5em;';
+  hint.textContent =
+    'Не удалось отрендерить mermaid-диаграмму. Возможно, забыт закрывающий ``` после блока.';
+  const pre = document.createElement('pre');
+  pre.style.cssText = 'white-space: pre-wrap; margin: 0;';
+  pre.textContent = source;
+  wrapper.append(hint, pre);
+  node.replaceChildren(wrapper);
+  // eslint-disable-next-line no-console
+  console.error('mermaid render error:', error);
 }

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -35,14 +35,30 @@ export async function renderMermaidIn(
     if (!source) continue;
 
     const id = `mermaid-${Date.now().toString(36)}-${renderCounter++}`;
+    // Render into a temporary off-screen container. Calling `mermaid.render`
+    // without a container makes the library inject and clean up its own host
+    // element on `document.body`, which is fragile inside Tauri's WebKit (the
+    // SVG sometimes never reaches the caller). An explicit container avoids
+    // that path entirely.
+    const host = document.createElement('div');
+    host.setAttribute('aria-hidden', 'true');
+    host.style.cssText = 'position:absolute;visibility:hidden;left:-99999px;top:-99999px;';
+    document.body.appendChild(host);
     try {
-      const { svg, bindFunctions } = await mermaid.render(id, source);
+      const { svg, bindFunctions } = await mermaid.render(id, source, host);
       node.innerHTML = svg;
       bindFunctions?.(node);
     } catch (e) {
-      // Restore the source as plain text so users can see what failed.
-      node.textContent = source;
-      throw e;
+      // Show the source inside <pre> so line breaks survive HTML whitespace
+      // collapsing — the diagram code stays readable while the user (or we)
+      // figure out the syntax problem.
+      const pre = document.createElement('pre');
+      pre.className = 'mermaid-error';
+      pre.textContent = source;
+      node.replaceChildren(pre);
+      console.error('mermaid render error:', e);
+    } finally {
+      host.remove();
     }
   }
 }

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -56,7 +56,12 @@ export async function renderMermaidIn(
       pre.className = 'mermaid-error';
       pre.textContent = source;
       node.replaceChildren(pre);
-      console.error('mermaid render error:', e);
+      // eslint-disable-next-line no-console
+      console.error(
+        'mermaid render error:',
+        e,
+        '\n=== SOURCE FED TO mermaid.render ===\n' + JSON.stringify(source),
+      );
     } finally {
       host.remove();
     }

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -1,34 +1,48 @@
 import mermaid from 'mermaid';
 
-let initialized = false;
+let renderCounter = 0;
 
-function initMermaid(): void {
-  if (initialized) return;
-  mermaid.initialize({
-    startOnLoad: false,
-    theme: 'default',
-    securityLevel: 'loose',
-  });
-  initialized = true;
-}
-
-/** Render all .mermaid elements within the given container. */
-export async function renderMermaidIn(
-  container: HTMLElement,
-  colorScheme: 'light' | 'dark',
-): Promise<void> {
-  initMermaid();
+function configureMermaid(colorScheme: 'light' | 'dark'): void {
+  // Re-initialize on every call so colorScheme changes take effect on re-render.
   mermaid.initialize({
     startOnLoad: false,
     theme: colorScheme === 'dark' ? 'dark' : 'default',
     securityLevel: 'loose',
   });
+}
+
+/**
+ * Render all `.mermaid` elements within the container.
+ *
+ * Uses `mermaid.render(id, code)` directly with the element's `textContent`
+ * instead of `mermaid.run({ nodes })`. The latter reads `element.innerHTML` and
+ * runs `entityDecode` on it, which round-trips the diagram source through DOM
+ * serialization — fragile when the source contains characters that markdown-it
+ * escaped (`<`, `>`, `&`) and that the renderer then has to un-escape. Reading
+ * `textContent` gives us the raw, already-decoded source string in one step.
+ */
+export async function renderMermaidIn(
+  container: HTMLElement,
+  colorScheme: 'light' | 'dark',
+): Promise<void> {
+  configureMermaid(colorScheme);
   const nodes = container.querySelectorAll<HTMLElement>('.mermaid');
-  if (nodes.length === 0) return;
-  // mermaid.run() re-renders nodes that haven't been processed yet.
-  // Reset processed nodes so re-render works on colorScheme change.
-  nodes.forEach((n) => {
-    n.removeAttribute('data-processed');
-  });
-  await mermaid.run({ nodes: Array.from(nodes) });
+  for (const node of Array.from(nodes)) {
+    if (node.dataset.mermaidSource === undefined) {
+      node.dataset.mermaidSource = node.textContent ?? '';
+    }
+    const source = node.dataset.mermaidSource.trim();
+    if (!source) continue;
+
+    const id = `mermaid-${Date.now().toString(36)}-${renderCounter++}`;
+    try {
+      const { svg, bindFunctions } = await mermaid.render(id, source);
+      node.innerHTML = svg;
+      bindFunctions?.(node);
+    } catch (e) {
+      // Restore the source as plain text so users can see what failed.
+      node.textContent = source;
+      throw e;
+    }
+  }
 }

--- a/src/lib/notificationBridge.ts
+++ b/src/lib/notificationBridge.ts
@@ -170,6 +170,70 @@ export async function setupNotificationBridge(): Promise<() => void> {
     }),
   );
 
+  // Voice-download lifecycle: each voice gets its own toast id keyed on the
+  // voice id so concurrent downloads (rare but possible) don't trample each
+  // other. Progress events update the body with a kilobyte/megabyte tally;
+  // started/finished flip the toast colour and loading state.
+  const voiceToastId = (voice: string) => `voice-download-${voice}`;
+  const fmtMb = (bytes: number) => `${(bytes / (1024 * 1024)).toFixed(1)} МБ`;
+
+  unlisteners.push(
+    await events.voiceDownloadStarted((p) => {
+      notifications.show({
+        id: voiceToastId(p.voice),
+        title: `Загрузка голоса ${p.voice}`,
+        message: 'Запрашиваю файлы…',
+        loading: true,
+        autoClose: false,
+      });
+    }),
+  );
+
+  unlisteners.push(
+    await events.voiceDownloadProgress((p) => {
+      // `skipped: true` events are no-ops in the toast — they fire when the
+      // file is already on disk and we don't want to confuse the user with
+      // 0/0 readouts.
+      if (p.skipped) return;
+      const total = p.total_bytes ?? 0;
+      const file = p.file_kind === 'onnx' ? 'модель' : 'конфиг';
+      const message = total > 0
+        ? `${file} (${p.file_idx + 1}/${p.total_files}): ${fmtMb(p.downloaded_bytes)} / ${fmtMb(total)}`
+        : `${file}: ${fmtMb(p.downloaded_bytes)}`;
+      notifications.update({
+        id: voiceToastId(p.voice),
+        title: `Загрузка голоса ${p.voice}`,
+        message,
+        loading: true,
+        autoClose: false,
+      });
+    }),
+  );
+
+  unlisteners.push(
+    await events.voiceDownloadFinished((p) => {
+      if (p.ok) {
+        notifications.update({
+          id: voiceToastId(p.voice),
+          title: 'Голос загружен',
+          message: `Голос «${p.voice}» готов к использованию.`,
+          color: 'green',
+          loading: false,
+          autoClose: 3000,
+        });
+      } else {
+        notifications.update({
+          id: voiceToastId(p.voice),
+          title: 'Не удалось загрузить голос',
+          message: p.message ?? `Голос «${p.voice}» не загружен.`,
+          color: 'red',
+          loading: false,
+          autoClose: 8000,
+        });
+      }
+    }),
+  );
+
   return () => {
     for (const unlisten of unlisteners) {
       unlisten();

--- a/src/lib/piperVoices.ts
+++ b/src/lib/piperVoices.ts
@@ -1,0 +1,26 @@
+// Hand-mirrored copy of `src-tauri/src/tts/piper/catalog.rs`.
+// The Rust catalogue is the source of truth; this TS module exists only so
+// the Settings UI can render labels and the "Рекомендуется" badge without an
+// extra Tauri round-trip. Catalogue churn is rare (4 voices today), so a
+// build-time codegen step is not worth its weight.
+//
+// When you change `catalog.rs::VOICES`, mirror the change here.
+
+export interface PiperVoice {
+  id: string;
+  label: string;
+  recommended: boolean;
+}
+
+export const PIPER_VOICES: readonly PiperVoice[] = [
+  { id: 'denis', label: 'Денис (мужской)', recommended: false },
+  { id: 'dmitri', label: 'Дмитрий (мужской)', recommended: false },
+  { id: 'irina', label: 'Ирина (женский)', recommended: false },
+  { id: 'ruslan', label: 'Руслан (мужской)', recommended: true },
+];
+
+export const DEFAULT_PIPER_VOICE = 'ruslan';
+
+export function lookupPiperVoice(id: string): PiperVoice | undefined {
+  return PIPER_VOICES.find((v) => v.id === id);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -32,6 +32,8 @@ export interface WordTimestamp {
 
 export type Theme = 'light' | 'dark' | 'auto';
 
+export type EngineKind = 'piper' | 'silero';
+
 export interface UIConfig {
   speaker: string;
   sample_rate: number;
@@ -46,6 +48,11 @@ export interface UIConfig {
   player_hotkeys: Record<string, string>;
   window_geometry: [number, number, number, number] | null;
   preview_dialog_enabled: boolean;
+  /** Active TTS engine. Defaults to "piper" on fresh installs and on configs
+   *  that pre-date the engine selector. */
+  engine: EngineKind;
+  /** Active Piper voice id (e.g. "ruslan", "irina"). See piperVoices.ts. */
+  piper_voice: string;
 }
 
 export type UIConfigPatch = Partial<UIConfig>;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -143,6 +143,9 @@ export const commands = {
   getAvailableEngines: (): Promise<AvailableEngines> =>
     tauriInvoke('get_available_engines'),
 
+  downloadPiperVoice: (voice_id: string): Promise<void> =>
+    tauriInvoke('download_piper_voice', { voiceId: voice_id }),
+
   getTimestamps: (id: EntryId): Promise<WordTimestamp[]> =>
     tauriInvoke('get_timestamps', { id }),
 
@@ -171,6 +174,31 @@ export interface ModelErrorPayload { message: string; }
 export interface TtsErrorPayload { entry_id: EntryId; message: string; }
 export interface TtsFatalPayload { message: string; }
 export interface SynthesisProgressPayload { entry_id: EntryId; progress: number; }
+
+export interface VoiceDownloadStartedPayload {
+  engine: 'piper';
+  voice: string;
+}
+export interface VoiceDownloadProgressPayload {
+  engine: 'piper';
+  voice: string;
+  /** "json" or "onnx". */
+  file_kind: string;
+  file_idx: number;
+  total_files: number;
+  downloaded_bytes: number;
+  /** Server-supplied content-length; null when unknown. */
+  total_bytes: number | null;
+  /** Set when the file was already on disk and download was skipped. */
+  skipped?: boolean;
+}
+export interface VoiceDownloadFinishedPayload {
+  engine: 'piper';
+  voice: string;
+  ok: boolean;
+  /** Russian-language failure message, present when ok=false. */
+  message?: string;
+}
 
 export const events = {
   entryUpdated: (cb: (p: EntryUpdatedPayload) => void): Promise<UnlistenFn> =>
@@ -220,4 +248,13 @@ export const events = {
 
   trayReadLater: (cb: () => void): Promise<UnlistenFn> =>
     tauriListen<Record<string, never>>('tray_read_later', () => cb()),
+
+  voiceDownloadStarted: (cb: (p: VoiceDownloadStartedPayload) => void): Promise<UnlistenFn> =>
+    tauriListen<VoiceDownloadStartedPayload>('voice_download_started', (e) => cb(e.payload)),
+
+  voiceDownloadProgress: (cb: (p: VoiceDownloadProgressPayload) => void): Promise<UnlistenFn> =>
+    tauriListen<VoiceDownloadProgressPayload>('voice_download_progress', (e) => cb(e.payload)),
+
+  voiceDownloadFinished: (cb: (p: VoiceDownloadFinishedPayload) => void): Promise<UnlistenFn> =>
+    tauriListen<VoiceDownloadFinishedPayload>('voice_download_finished', (e) => cb(e.payload)),
 };

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -34,6 +34,16 @@ export type Theme = 'light' | 'dark' | 'auto';
 
 export type EngineKind = 'piper' | 'silero';
 
+export interface EngineAvailability {
+  available: boolean;
+  reason: string | null;
+}
+
+export interface AvailableEngines {
+  piper: EngineAvailability;
+  silero: EngineAvailability;
+}
+
 export interface UIConfig {
   speaker: string;
   sample_rate: number;
@@ -129,6 +139,9 @@ export const commands = {
 
   updateConfig: (patch: UIConfigPatch): Promise<void> =>
     tauriInvoke('update_config', { patch }),
+
+  getAvailableEngines: (): Promise<AvailableEngines> =>
+    tauriInvoke('get_available_engines'),
 
   getTimestamps: (id: EntryId): Promise<WordTimestamp[]> =>
     tauriInvoke('get_timestamps', { id }),


### PR DESCRIPTION
## Summary
- Replaces the Silero/Python `ttsd` sidecar with Piper as the primary engine
  (in-process via `piper-rs` + ONNX Runtime). Silero stays available as an
  opt-in alternative gated by a runtime probe of `ttsd/` + `uv`.
- Voice models live at `<data_local_dir>/ruvox/voices/piper/<voice>/…` and
  download themselves on first use; a manual "Скачать сейчас" button in
  Settings lets the user pre-fetch.
- Engine and `piper_voice` selections live in the existing Settings dialog,
  swap takes effect at runtime, and pre-#42 configs silently switch to Piper
  on next launch.

## Phases (one commit each)
- **Phase 1** `dfd9ee3` — `TtsEngine` trait + `PiperEngine` (hardcoded ruslan)
- **Phase 2** `e5e7801` — `UIConfig` keys + `EngineSwitcher` + Settings UI + Vitest reducer
- **Phase 3** `d936613` — `tts::availability` probe + `get_available_engines` command + smart migration
- **Phase 4** `24975f1` — `tts::piper::download` + `download_piper_voice` command + auto-retry on `voice_not_installed` + Mantine progress notification

## QA fixes (found while testing the four phases above)
- `e459b45` — Piper word-highlight timestamps emitted in codepoint indices, not UTF-8 byte offsets (Cyrillic input was off by 1 char per non-ASCII char).
- `e4eeede` — point `espeak-rs` at the full nixpkgs `espeak-ng-data` via `PIPER_ESPEAKNG_DATA_DIRECTORY`; previously fell back to skeleton defaults, producing wrong Russian stress on every Piper voice.
- `08a29d8` — Piper `length_scale=0.8`, ~20–30 % faster speech (still intelligible).
- `111e6ca`, `95d1008`, `a8f9164`, `2308a7e` — mermaid renderer rewrite: render via `mermaid.render(id, source, host)` into an off-screen container (the auto-injected `body` host was unreliable in Tauri WebKit), with a truncation fallback that keeps the diagram visible when the markdown author forgets the closing \`\`\`.

## Test plan
- [x] \`nix-shell --run "cargo test --manifest-path src-tauri/Cargo.toml --all-features"\` — 716 unit + 1 golden + 1 supervisor green
- [x] \`nix-shell --run "pnpm typecheck"\` — clean
- [x] \`nix-shell --run "pnpm test:unit"\` — 8 Vitest cases pass
- [x] \`nix-shell --run "cargo clippy --manifest-path src-tauri/Cargo.toml --all-features -- -D warnings"\` — clean
- [x] Manual: open Settings; verify Silero is disabled with reason text outside nix-shell, available with \`uv\` + \`ttsd/\` present.
- [x] Manual: pick \`ruslan\` (recommended badge visible), click "Скачать сейчас"; ~60 MB toast progresses; first synthesis works.
- [x] Manual: delete \`~/.local/share/ruvox/voices/piper/ruslan/\` and synthesize a fresh entry; auto-download fires, then synthesis succeeds.
- [x] Manual: switch to Silero (when available), confirm \`model_loading\` toast shows ttsd warmup; switch back to Piper.
- [x] Manual: play a Piper-narrated entry — word highlight tracks the spoken word in the right position.
- [x] Manual: paste an entry with a \`\`\`mermaid block — diagram renders (not raw text, not "Syntax error").

Refs #42