### PR TITLE
fix(nix): production flake builds for slim and full variants

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,14 @@
             pnpmConfigHook
             pkg-config
             wrapGAppsHook3
+            # cmake: espeak-rs-sys 0.1.9 vendors libespeak-ng and builds it
+            # via cmake from its own build.rs.
+            cmake
+            # bindgenHook: sets LIBCLANG_PATH and BINDGEN_EXTRA_CLANG_ARGS
+            # (with the C system header search paths from stdenv.cc) so
+            # bindgen invocations in espeak-rs-sys's build script can find
+            # `<stdio.h>` etc. inside the hermetic sandbox.
+            rustPlatform.bindgenHook
           ];
 
           # Transitive deps (gtk3, glib, libsoup_3, wayland, x11, libGL,
@@ -142,11 +150,36 @@
             # the full ru_dict / phondata / intonations files instead of
             # the skeleton defaults that produce wrong Russian stress.
             espeak-ng
+            # onnxruntime — `ort` is configured with `load-dynamic` and
+            # dlopens libonnxruntime.so at runtime via ORT_DYLIB_PATH (set
+            # in preFixup). At build time `ort-sys` probes pkg-config for
+            # libonnxruntime; nixpkgs onnxruntime ships a .pc, so the probe
+            # succeeds and the build script becomes a no-op.
+            onnxruntime
+            # sonic — espeak-ng's CMakeLists has
+            # `find_library(SONIC_LIB sonic)` and falls back to git-cloning
+            # https://github.com/waywardgeek/sonic if not found, which is
+            # blocked by the nix sandbox. Providing the system library
+            # short-circuits the FetchContent path.
+            sonic
           ];
 
           # Single target is enough for Nix — we only want a usable binary,
           # not an OS-native package.  "deb" is the cheapest Linux bundle.
           tauriBundleType = "deb";
+
+          # espeak-ng on Linux pins `path_home[N_PATH_HOME=160]` and then
+          # writes `<path_home>/<phoneme-file>` into an 180-byte buffer
+          # (compiledata.c::LoadSpect). The nix sandbox phsource path is
+          # `/build/<src>/target/.../espeak-rs-sys-<hash>/out/build/espeak-ng-data/../phsource`,
+          # already over 180 bytes, so snprintf truncates filenames and the
+          # phoneme compiler errors out with "Bad vowel file" / "Failed to
+          # open: ...vwl_en_us_nyc/a_ra". Bumping the buffer to 1024 fixes
+          # the `cargo tauri build` cmake step deterministically.
+          preBuild = ''
+            substituteInPlace "$NIX_BUILD_TOP/cargo-vendor-dir/espeak-rs-sys-0.1.9/espeak-ng/src/libespeak-ng/speech.h" \
+              --replace-fail 'N_PATH_HOME_DEF  160' 'N_PATH_HOME_DEF  1024'
+          '';
 
           preFixup = ''
             gappsWrapperArgs+=(
@@ -154,6 +187,7 @@
               --prefix LD_LIBRARY_PATH : ${extraRuntimeLibPath}
               --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1
               --set-default PIPER_ESPEAKNG_DATA_DIRECTORY ${pkgs.espeak-ng}/share
+              --set-default ORT_DYLIB_PATH ${pkgs.onnxruntime}/lib/libonnxruntime.so
             )
           '';
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,7 +79,15 @@ byteorder = "1.5"
 # does not work inside the nix sandbox.
 piper-rs = "0.1.9"
 ort = { version = "=2.0.0-rc.9", default-features = false, features = ["load-dynamic"] }
-ort-sys = "=2.0.0-rc.9"
+# `ort-sys` must mirror `ort`'s feature flags. Without `default-features =
+# false, features = ["load-dynamic"]` cargo's feature unification can drag
+# `download-binaries` back in (the `ort` crate transitively re-enables it
+# when any other dependency in the workspace touches `ort-sys` with default
+# features), and the build script then unconditionally GETs a prebuilt
+# onnxruntime tarball from parcel.pyke.io — which fails inside the nix
+# sandbox. With `load-dynamic` the build script becomes a no-op and
+# onnxruntime is dlopened at runtime via `ORT_DYLIB_PATH`.
+ort-sys = { version = "=2.0.0-rc.9", default-features = false, features = ["load-dynamic"] }
 async-trait = "0.1"
 
 # On-demand Piper voice download (Phase 4 of #42). `rustls-tls` keeps us off


### PR DESCRIPTION
Closes #47.

## Summary

Production flake `nix build` had been silently broken for both `.#ruvox`
(slim) and `.#ruvox-with-silero` (full) since #42 introduced piper-rs.
Three orthogonal issues:

1. `ort-sys` could pick up `download-binaries` via cargo feature
   unification → build.rs tried to GET parcel.pyke.io (sandbox blocks
   network).
2. `espeak-rs-sys`'s vendored libespeak-ng cmake clones sonic from git
   via `FetchContent` if `find_library(SONIC_LIB sonic)` fails (also
   network).
3. After both above are fixed, espeak-ng's phoneme compiler hits a
   180-byte snprintf truncation on the long nix sandbox build path,
   crashing with `Bad vowel file: 'vwl_en_us_nyc/a_raised'`.

Fixes:
- `ort-sys = { default-features = false, features = ["load-dynamic"] }`
- `pkgs.sonic` + `pkgs.onnxruntime` to `buildInputs`; `cmake` and
  `rustPlatform.bindgenHook` to `nativeBuildInputs`
- `--set-default ORT_DYLIB_PATH ...` on the `gappsWrapperArgs`
- `preBuild` patch bumping `N_PATH_HOME_DEF` from 160 to 1024 in the
  vendored `speech.h`

## Test plan

- [x] \`nix build .#ruvox\` succeeds locally
- [x] \`nix build .#ruvox-with-silero\` succeeds locally
- [x] \`nix path-info -r ./result-slim | grep ttsd\` is empty (slim
      stays slim)
- [x] \`nix path-info -r ./result-full | grep ttsd\` finds
      \`ruvox-ttsd-0.1.0\` (full bundles the sidecar)
- [x] both closures contain \`onnxruntime\` + \`sonic\`
- [ ] CI \`nix\` job (added in #43) stays green