### PR TITLE
fix(tts): wrap supervisor spawn in tauri runtime block_on

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -269,7 +269,12 @@ fn try_build_silero(
             .current_dir(&ttsd_dir);
         cmd
     });
-    Ok(Arc::new(tts::TtsSupervisor::spawn(factory, emitter)?))
+    // tokio::process::Command::spawn requires an active tokio runtime
+    // context; the Tauri setup hook runs synchronously, so enter the
+    // runtime explicitly via block_on (the inner spawn returns instantly).
+    let supervisor =
+        tauri::async_runtime::block_on(async move { tts::TtsSupervisor::spawn(factory, emitter) })?;
+    Ok(Arc::new(supervisor))
 }
 
 /// Spawn the tray-command handler loop and return the channel sender.


### PR DESCRIPTION
## Summary
- Restore the `tauri::async_runtime::block_on(...)` wrapper around `TtsSupervisor::spawn` lost during the setup-extraction refactor in a4eeff9.
- Without it, cold start panicked when the persisted config selected Silero (`tokio::process::Command::spawn` requires an active tokio runtime, which is not attached inside the Tauri setup closure).

## Test plan
- [x] `cargo test --release` (716 passed)
- [x] Manual: production binary launched from desktop entry with `engine = "silero"` — no longer crashes, window renders, UI works as before.