### PR TITLE
fix(ui/viewer): scope Ctrl/Cmd+A to the text viewer

### DIFF
--- a/src/components/TextViewer.tsx
+++ b/src/components/TextViewer.tsx
@@ -111,6 +111,35 @@ export function TextViewer({ entry }: Props) {
     });
   }, [content, format, colorScheme]);
 
+  // Ctrl/Cmd+A while focus/selection is inside the viewer should select
+  // only the rendered text, not the whole window. Skip when the user is
+  // typing in an input/textarea/contentEditable so default behavior wins.
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (!(e.ctrlKey || e.metaKey) || e.key !== 'a') return;
+      const container = containerRef.current;
+      if (!container) return;
+      const active = document.activeElement as HTMLElement | null;
+      if (
+        active &&
+        (active.tagName === 'INPUT' ||
+          active.tagName === 'TEXTAREA' ||
+          active.isContentEditable)
+      ) {
+        return;
+      }
+      const sel = window.getSelection();
+      if (!sel || !sel.focusNode || !container.contains(sel.focusNode)) return;
+      e.preventDefault();
+      const range = document.createRange();
+      range.selectNodeContents(container);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, []);
+
   // Click-to-zoom: when user clicks a rendered mermaid SVG, show it in a modal.
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary
- Ctrl/Cmd+A previously selected the entire window because nothing scoped the keystroke to the viewer.
- Intercept the shortcut when the selection is already inside the viewer; replace it with `selectNodeContents` on the viewer container.
- Skip the interception for input/textarea/contentEditable so the composer's Ctrl+A still selects the input text.

## Test plan
- [x] `pnpm typecheck`
- [x] Manual: click into the text viewer, Ctrl+A — only viewer content is selected. Focus the new-text input, Ctrl+A — input text is selected as before.