### PR TITLE
ci: run frontend unit tests in typescript job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - run: cargo test --manifest-path src-tauri/Cargo.toml --all-features
 
   typescript:
-    name: TypeScript (typecheck)
+    name: TypeScript (typecheck + vitest)
     needs: changes
     if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
+      - run: pnpm test:unit
 
   ttsd:
     name: ttsd (ruff + pytest)


### PR DESCRIPTION
## Summary
- The `typescript` CI job ran `pnpm typecheck` but never executed the vitest unit tests (`src/lib/engineSelection.test.ts`), so a broken unit test would not fail CI.
- Add a `pnpm test:unit` step right after `pnpm typecheck` in the `typescript` job.

## Why
Part of the "RuVox test health" epic (task S1). The `dorny/paths-filter` filter for the `typescript` job already includes `src/**` and `.github/workflows/ci.yml`, so no filter changes were needed — any change to test files or this workflow already triggers the job.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm test:unit` passes locally (8 tests in `src/lib/engineSelection.test.ts`)
- [x] `pnpm typecheck` passes locally
- [ ] CI run on this PR is green