### PR TITLE
test(ttsd): cover main loop error paths without torch

### DIFF
--- a/ttsd/tests/test_main_unit.py
+++ b/ttsd/tests/test_main_unit.py
@@ -1,0 +1,281 @@
+"""Unit tests for ttsd.main — cover the request loop and handler error paths.
+
+These tests use a fake engine (no torch/Silero) and monkeypatched stdin/stdout,
+so they run in CI under the default (`not slow`) marker set. They intentionally
+never import ttsd.silero.
+"""
+
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from ttsd import main as ttsd_main
+from ttsd.protocol import CharMappingEntry, SynthesizeRequest
+
+
+class FakeEngine:
+    """Minimal stand-in for SileroEngine with no ML dependencies."""
+
+    def __init__(self, *, loaded=False, load_exc=None, synth_exc=None):
+        self._loaded = loaded
+        self._load_exc = load_exc
+        self._synth_exc = synth_exc
+        self.load_called = False
+        self.synth_calls: list[dict] = []
+
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    def load(self) -> None:
+        self.load_called = True
+        if self._load_exc is not None:
+            raise self._load_exc
+        self._loaded = True
+
+    def synthesize(self, *, text, speaker, sample_rate, out_wav, char_mapping=None):
+        self.synth_calls.append(
+            {
+                "text": text,
+                "speaker": speaker,
+                "sample_rate": sample_rate,
+                "out_wav": out_wav,
+                "char_mapping": char_mapping,
+            }
+        )
+        if self._synth_exc is not None:
+            raise self._synth_exc
+        return SimpleNamespace(timestamps=[], duration_sec=1.5)
+
+
+@pytest.fixture
+def use_engine(monkeypatch):
+    """Install a FakeEngine as the module singleton and return it."""
+
+    def _install(engine: FakeEngine) -> FakeEngine:
+        monkeypatch.setattr(ttsd_main, "_engine", engine)
+        return engine
+
+    return _install
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine(monkeypatch):
+    # Ensure no leftover singleton from another test; the lazy _get_engine would
+    # otherwise import ttsd.silero (torch) if left as None and exercised.
+    monkeypatch.setattr(ttsd_main, "_engine", None)
+    yield
+
+
+def _make_synth_request(text="привет", char_mapping=None) -> SynthesizeRequest:
+    return SynthesizeRequest(
+        cmd="synthesize",
+        text=text,
+        speaker="xenia",
+        sample_rate=48000,
+        out_wav="/tmp/out.wav",
+        char_mapping=char_mapping,
+    )
+
+
+def _run_main(monkeypatch, stdin) -> tuple[int, list[dict]]:
+    """Run main() with the given stdin object, returning (rc, parsed responses)."""
+    out = io.StringIO()
+    monkeypatch.setattr(ttsd_main.sys, "stdin", stdin)
+    monkeypatch.setattr(ttsd_main.sys, "stdout", out)
+    rc = ttsd_main.main()
+    responses = [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+    return rc, responses
+
+
+# ---------------------------------------------------------------------------
+# _write_response / _setup_logging
+# ---------------------------------------------------------------------------
+
+
+def test_write_response_emits_json_line(monkeypatch):
+    out = io.StringIO()
+    monkeypatch.setattr(ttsd_main.sys, "stdout", out)
+    ttsd_main._write_response(ttsd_main.OkShutdown())
+    written = out.getvalue()
+    assert written.endswith("\n")
+    assert json.loads(written) == {"ok": True}
+
+
+def test_setup_logging_runs():
+    # Should not raise; configures a stderr handler.
+    ttsd_main._setup_logging()
+
+
+# ---------------------------------------------------------------------------
+# _handle_warmup
+# ---------------------------------------------------------------------------
+
+
+def test_handle_warmup_ok(use_engine):
+    engine = use_engine(FakeEngine())
+    resp = ttsd_main._handle_warmup()
+    assert engine.load_called
+    assert isinstance(resp, ttsd_main.OkWarmup)
+    assert resp.ok is True
+    assert resp.version == ttsd_main.__version__
+
+
+def test_handle_warmup_failure_returns_model_not_loaded(use_engine):
+    use_engine(FakeEngine(load_exc=RuntimeError("no network")))
+    resp = ttsd_main._handle_warmup()
+    assert isinstance(resp, ttsd_main.ErrResponse)
+    assert resp.error == "model_not_loaded"
+    assert "no network" in resp.message
+
+
+# ---------------------------------------------------------------------------
+# _handle_synthesize
+# ---------------------------------------------------------------------------
+
+
+def test_handle_synthesize_not_loaded(use_engine):
+    use_engine(FakeEngine(loaded=False))
+    resp = ttsd_main._handle_synthesize(_make_synth_request())
+    assert isinstance(resp, ttsd_main.ErrResponse)
+    assert resp.error == "model_not_loaded"
+
+
+def test_handle_synthesize_empty_text(use_engine):
+    use_engine(FakeEngine(loaded=True))
+    resp = ttsd_main._handle_synthesize(_make_synth_request(text="   "))
+    assert isinstance(resp, ttsd_main.ErrResponse)
+    assert resp.error == "bad_input"
+    assert "empty" in resp.message
+
+
+def test_handle_synthesize_value_error_is_bad_input(use_engine):
+    use_engine(FakeEngine(loaded=True, synth_exc=ValueError("bad char")))
+    resp = ttsd_main._handle_synthesize(_make_synth_request())
+    assert isinstance(resp, ttsd_main.ErrResponse)
+    assert resp.error == "bad_input"
+    assert "bad char" in resp.message
+
+
+def test_handle_synthesize_generic_error_is_synthesis_failed(use_engine):
+    use_engine(FakeEngine(loaded=True, synth_exc=RuntimeError("boom")))
+    resp = ttsd_main._handle_synthesize(_make_synth_request())
+    assert isinstance(resp, ttsd_main.ErrResponse)
+    assert resp.error == "synthesis_failed"
+    assert "boom" in resp.message
+
+
+def test_handle_synthesize_ok_without_char_mapping(use_engine):
+    engine = use_engine(FakeEngine(loaded=True))
+    resp = ttsd_main._handle_synthesize(_make_synth_request())
+    assert isinstance(resp, ttsd_main.OkSynthesize)
+    assert resp.ok is True
+    assert resp.duration_sec == 1.5
+    assert engine.synth_calls[0]["char_mapping"] is None
+
+
+def test_handle_synthesize_ok_builds_char_mapping_dicts(use_engine):
+    engine = use_engine(FakeEngine(loaded=True))
+    mapping = [CharMappingEntry(norm_start=0, norm_end=3, orig_start=10, orig_end=13)]
+    resp = ttsd_main._handle_synthesize(_make_synth_request(char_mapping=mapping))
+    assert isinstance(resp, ttsd_main.OkSynthesize)
+    passed = engine.synth_calls[0]["char_mapping"]
+    assert passed == [{"norm_start": 0, "norm_end": 3, "orig_start": 10, "orig_end": 13}]
+
+
+# ---------------------------------------------------------------------------
+# _handle_shutdown
+# ---------------------------------------------------------------------------
+
+
+def test_handle_shutdown():
+    resp = ttsd_main._handle_shutdown()
+    assert isinstance(resp, ttsd_main.OkShutdown)
+    assert resp.ok is True
+
+
+# ---------------------------------------------------------------------------
+# main() loop
+# ---------------------------------------------------------------------------
+
+
+def test_main_warmup_then_shutdown(monkeypatch, use_engine):
+    use_engine(FakeEngine())
+    stdin = io.StringIO('{"cmd": "warmup"}\n{"cmd": "shutdown"}\n')
+    rc, responses = _run_main(monkeypatch, stdin)
+    assert rc == 0
+    assert responses[0]["ok"] is True
+    assert responses[0]["version"] == ttsd_main.__version__
+    assert responses[1] == {"ok": True}
+
+
+def test_main_synthesize_dispatch(monkeypatch, use_engine):
+    use_engine(FakeEngine(loaded=True))
+    req = _make_synth_request().model_dump_json()
+    stdin = io.StringIO(req + "\n" + '{"cmd": "shutdown"}\n')
+    rc, responses = _run_main(monkeypatch, stdin)
+    assert rc == 0
+    assert responses[0]["ok"] is True
+    assert responses[0]["duration_sec"] == 1.5
+
+
+def test_main_skips_blank_lines(monkeypatch, use_engine):
+    use_engine(FakeEngine())
+    stdin = io.StringIO("\n   \n{\"cmd\": \"shutdown\"}\n")
+    rc, responses = _run_main(monkeypatch, stdin)
+    assert rc == 0
+    # Only the shutdown produced a response; blank lines yielded nothing.
+    assert responses == [{"ok": True}]
+
+
+def test_main_invalid_json_returns_bad_input(monkeypatch, use_engine):
+    use_engine(FakeEngine())
+    stdin = io.StringIO('{"cmd": "synthesize"}\n{"cmd": "shutdown"}\n')
+    rc, responses = _run_main(monkeypatch, stdin)
+    assert rc == 0
+    assert responses[0]["ok"] is False
+    assert responses[0]["error"] == "bad_input"
+
+
+def test_main_unknown_cmd(monkeypatch, use_engine):
+    use_engine(FakeEngine())
+
+    # RequestAdapter's discriminated union cannot produce an unknown cmd, so we
+    # stub validate_json to return a request object with an out-of-range cmd,
+    # which is the only way to reach the else-branch.
+    fake_adapter = SimpleNamespace(validate_json=lambda line: SimpleNamespace(cmd="bogus"))
+    monkeypatch.setattr(ttsd_main, "RequestAdapter", fake_adapter)
+    stdin = io.StringIO('{"cmd": "bogus"}\n')
+    rc, responses = _run_main(monkeypatch, stdin)
+    assert rc == 0
+    assert responses[0]["ok"] is False
+    assert responses[0]["error"] == "bad_input"
+    assert "unknown cmd: bogus" in responses[0]["message"]
+
+
+class _RaisingStdin:
+    """An stdin whose iteration raises the given exception on first next()."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise self._exc
+
+
+def test_main_keyboard_interrupt_returns_zero(monkeypatch, use_engine):
+    use_engine(FakeEngine())
+    rc, responses = _run_main(monkeypatch, _RaisingStdin(KeyboardInterrupt()))
+    assert rc == 0
+    assert responses == []
+
+
+def test_main_fatal_error_returns_one(monkeypatch, use_engine):
+    use_engine(FakeEngine())
+    rc, responses = _run_main(monkeypatch, _RaisingStdin(RuntimeError("stdin exploded")))
+    assert rc == 1
+    assert responses == []

--- a/ttsd/tests/test_silero.py
+++ b/ttsd/tests/test_silero.py
@@ -1,13 +1,24 @@
-"""Smoke tests for SileroEngine — require torch and Silero model download."""
+"""Smoke tests for SileroEngine — require torch and Silero model download.
+
+The TestSplitIntoChunks / TestSanitizeForSilero classes exercise the torch-free
+helpers in ttsd.chunking and intentionally do NOT import ttsd.silero, so they run
+in CI without the ML stack.
+"""
 
 import pytest
 
-from ttsd.silero import SileroEngine
+from ttsd.chunking import sanitize_for_silero, split_into_chunks
+
+
+def _import_silero_engine():
+    from ttsd.silero import SileroEngine
+
+    return SileroEngine
 
 
 @pytest.mark.slow
 def test_silero_load_and_synthesize(tmp_path):
-    engine = SileroEngine()
+    engine = _import_silero_engine()()
     engine.load()
     assert engine.is_loaded()
 
@@ -28,7 +39,7 @@ def test_silero_load_and_synthesize(tmp_path):
 @pytest.mark.slow
 def test_silero_second_load_is_noop(tmp_path):
     """Calling load() twice must not raise or reset the model."""
-    engine = SileroEngine()
+    engine = _import_silero_engine()()
     engine.load()
     model_before = engine._model
     engine.load()
@@ -37,7 +48,7 @@ def test_silero_second_load_is_noop(tmp_path):
 
 @pytest.mark.slow
 def test_silero_empty_text_raises(tmp_path):
-    engine = SileroEngine()
+    engine = _import_silero_engine()()
     engine.load()
     with pytest.raises(ValueError, match="empty"):
         engine.synthesize(
@@ -49,17 +60,17 @@ def test_silero_empty_text_raises(tmp_path):
 
 
 class TestSplitIntoChunks:
-    """Unit tests for _split_into_chunks that do not need the model."""
+    """Unit tests for split_into_chunks that do not need the model."""
 
     def test_short_text_single_chunk(self):
         text = "Привет мир"
-        chunks = SileroEngine._split_into_chunks(text)
+        chunks = split_into_chunks(text)
         assert chunks == [(text, 0)]
 
     def test_long_text_splits_on_sentence_boundary(self):
         sentence = "Это предложение. "
         text = sentence * 60  # well over MAX_CHUNK_SIZE
-        chunks = SileroEngine._split_into_chunks(text)
+        chunks = split_into_chunks(text)
         assert len(chunks) > 1
         # Every chunk must be non-empty
         for chunk_text, _ in chunks:
@@ -68,28 +79,28 @@ class TestSplitIntoChunks:
     def test_chunks_cover_full_text(self):
         sentence = "Слово слово слово. "
         text = sentence * 60
-        chunks = SileroEngine._split_into_chunks(text)
+        chunks = split_into_chunks(text)
         # The start positions must be ordered
         starts = [s for _, s in chunks]
         assert starts == sorted(starts)
 
     def test_start_positions_non_negative(self):
         text = "A" * 2000
-        chunks = SileroEngine._split_into_chunks(text)
+        chunks = split_into_chunks(text)
         for _, start in chunks:
             assert start >= 0
 
 
 class TestSanitizeForSilero:
     def test_newlines_replaced_by_space(self):
-        result = SileroEngine._sanitize_for_silero("один\nдва")
+        result = sanitize_for_silero("один\nдва")
         assert "\n" not in result
         assert "один два" == result
 
     def test_multiple_spaces_collapsed(self):
-        result = SileroEngine._sanitize_for_silero("один   два")
+        result = sanitize_for_silero("один   два")
         assert result == "один два"
 
     def test_leading_trailing_stripped(self):
-        result = SileroEngine._sanitize_for_silero("  текст  ")
+        result = sanitize_for_silero("  текст  ")
         assert result == "текст"

--- a/ttsd/tests/test_timestamps.py
+++ b/ttsd/tests/test_timestamps.py
@@ -1,6 +1,11 @@
 """Unit tests for timestamps.py — no torch required."""
 
-from ttsd.timestamps import estimate_timestamps_chunked, extract_words_with_positions
+from ttsd.timestamps import (
+    _map_via_positional,
+    _map_via_spans,
+    estimate_timestamps_chunked,
+    extract_words_with_positions,
+)
 
 
 class TestExtractWords:
@@ -111,3 +116,66 @@ class TestEstimateTimestampsChunked:
         result = estimate_timestamps_chunked(text, [(0, 4, 1.0)], None)
         assert len(result) == 1
         assert isinstance(result[0], WordTimestamp)
+
+    def test_char_mapping_pydantic_span_entries(self):
+        # Shape 1 via real CharMappingEntry objects — exercises the hasattr
+        # branch of _is_span_entry (non-dict span with a norm_start attribute).
+        from ttsd.protocol import CharMappingEntry
+
+        text = "слово"
+        spans = [CharMappingEntry(norm_start=0, norm_end=5, orig_start=100, orig_end=105)]
+        result = estimate_timestamps_chunked(text, [(0, 5, 1.0)], spans)
+        assert len(result) == 1
+        assert result[0].original_pos == (100, 105)
+
+    def test_timestamps_rounded_to_three_decimals(self):
+        # "a"(1 char) + "bb"(2 chars), total 3, duration 1.0s.
+        # w1 end = round(1/3, 3) = 0.333; w2 end = round(1.0, 3) = 1.0.
+        result = estimate_timestamps_chunked("a bb", [(0, 4, 1.0)], None)
+        assert len(result) == 2
+        assert result[0].start == 0.0
+        assert result[0].end == 0.333
+        assert result[1].start == 0.333
+        assert result[1].end == 1.0
+
+
+class TestMapViaSpans:
+    def test_merges_multiple_overlapping_spans(self):
+        spans = [
+            {"norm_start": 0, "norm_end": 3, "orig_start": 10, "orig_end": 13},
+            {"norm_start": 3, "norm_end": 6, "orig_start": 13, "orig_end": 16},
+        ]
+        # Range [1, 5) overlaps both spans → widen to min orig_start / max orig_end.
+        assert _map_via_spans(spans, 1, 5) == (10, 16)
+
+    def test_break_stops_at_span_past_range(self):
+        # The out-of-order poison span (index 2) would widen orig_end to 999 if
+        # reached, but the loop must break at the sorted span whose norm_start
+        # is >= norm_end before ever getting there.
+        spans = [
+            {"norm_start": 0, "norm_end": 2, "orig_start": 0, "orig_end": 2},
+            {"norm_start": 10, "norm_end": 12, "orig_start": 20, "orig_end": 22},
+            {"norm_start": 1, "norm_end": 2, "orig_start": 500, "orig_end": 999},
+        ]
+        assert _map_via_spans(spans, 0, 3) == (0, 2)
+
+    def test_no_overlap_falls_back_to_norm_positions(self):
+        # All spans end at/before norm_start → no overlap → fallback (norm_start, norm_end).
+        spans = [{"norm_start": 0, "norm_end": 2, "orig_start": 0, "orig_end": 2}]
+        assert _map_via_spans(spans, 5, 8) == (5, 8)
+
+
+class TestMapViaPositional:
+    def test_empty_char_map_falls_back(self):
+        assert _map_via_positional([], 3, 7) == (3, 7)
+
+    def test_indices_clamped_within_bounds(self):
+        # char_map shorter than the requested norm positions → indices clamp to
+        # the last available entry.
+        char_map = [[5, 6]]
+        assert _map_via_positional(char_map, 10, 20) == (5, 6)
+
+    def test_negative_norm_end_clamped_to_zero(self):
+        # norm_end - 1 can be negative; end_idx must clamp up to 0.
+        char_map = [[5, 6], [6, 7]]
+        assert _map_via_positional(char_map, 0, 0) == (5, 6)

--- a/ttsd/ttsd/chunking.py
+++ b/ttsd/ttsd/chunking.py
@@ -1,0 +1,66 @@
+"""Torch-free text utilities for Silero synthesis.
+
+Extracted from silero.py so the pure text-processing helpers (chunk splitting,
+sanitisation) can be imported and unit-tested without pulling in numpy/torch/scipy.
+"""
+from __future__ import annotations
+
+import re
+
+# Maximum characters per TTS chunk (Silero limit is ~1000-1500)
+MAX_CHUNK_SIZE = 900
+
+
+def split_into_chunks(text: str) -> list[tuple[str, int]]:
+    """Split text into chunks for TTS processing.
+
+    Returns list of (chunk_text, start_position) tuples.
+    """
+    if len(text) <= MAX_CHUNK_SIZE:
+        return [(text, 0)]
+
+    chunks: list[tuple[str, int]] = []
+    current_pos = 0
+
+    while current_pos < len(text):
+        chunk_end = min(current_pos + MAX_CHUNK_SIZE, len(text))
+
+        if chunk_end >= len(text):
+            chunks.append((text[current_pos:], current_pos))
+            break
+
+        chunk_text = text[current_pos:chunk_end]
+
+        best_split = -1
+        for match in re.finditer(r"[.!?]\s+", chunk_text):
+            best_split = match.end()
+
+        if best_split == -1:
+            for match in re.finditer(r"[,;:]\s+", chunk_text):
+                best_split = match.end()
+
+        if best_split == -1:
+            for match in re.finditer(r"\s+", chunk_text):
+                best_split = match.end()
+
+        if best_split == -1 or best_split < len(chunk_text) // 2:
+            best_split = MAX_CHUNK_SIZE
+
+        actual_chunk = text[current_pos : current_pos + best_split].strip()
+        if actual_chunk:
+            chunks.append((actual_chunk, current_pos))
+
+        current_pos += best_split
+
+    return chunks
+
+
+def sanitize_for_silero(text: str) -> str:
+    """Remove newlines and collapse spaces before passing to Silero.
+
+    Silero's character-level tokenizer does not handle control characters;
+    newlines cause a fatal abort inside prepare_tts_model_input.
+    """
+    text = re.sub(r"\s*\n\s*", " ", text)
+    text = re.sub(r" +", " ", text)
+    return text.strip()

--- a/ttsd/ttsd/main.py
+++ b/ttsd/ttsd/main.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ValidationError
 
@@ -15,11 +16,25 @@ from ttsd.protocol import (
     RequestAdapter,
     SynthesizeRequest,
 )
-from ttsd.silero import SileroEngine
+
+if TYPE_CHECKING:
+    from ttsd.silero import SileroEngine
 
 logger = logging.getLogger("ttsd")
 
-_engine = SileroEngine()
+# The engine is created lazily so importing this module (and unit-testing the
+# request loop) does not pull in torch/numpy/scipy via ttsd.silero. Tests may
+# override the singleton by setting ttsd.main._engine to a stub.
+_engine: "SileroEngine | None" = None
+
+
+def _get_engine() -> "SileroEngine":
+    global _engine
+    if _engine is None:
+        from ttsd.silero import SileroEngine
+
+        _engine = SileroEngine()
+    return _engine
 
 
 def _setup_logging() -> None:
@@ -41,7 +56,7 @@ def _handle_warmup() -> OkWarmup | ErrResponse:
     model_error and may retry.
     """
     try:
-        _engine.load()
+        _get_engine().load()
     except Exception as exc:
         logger.exception("warmup failed")
         return ErrResponse(error="model_not_loaded", message=str(exc))
@@ -49,7 +64,8 @@ def _handle_warmup() -> OkWarmup | ErrResponse:
 
 
 def _handle_synthesize(req: SynthesizeRequest) -> OkSynthesize | ErrResponse:
-    if not _engine.is_loaded():
+    engine = _get_engine()
+    if not engine.is_loaded():
         return ErrResponse(
             error="model_not_loaded",
             message="Silero model is not loaded; send warmup first",
@@ -62,7 +78,7 @@ def _handle_synthesize(req: SynthesizeRequest) -> OkSynthesize | ErrResponse:
         char_mapping = (
             [entry.model_dump() for entry in req.char_mapping] if req.char_mapping else None
         )
-        result = _engine.synthesize(
+        result = engine.synthesize(
             text=req.text,
             speaker=req.speaker,
             sample_rate=req.sample_rate,

--- a/ttsd/ttsd/silero.py
+++ b/ttsd/ttsd/silero.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -10,13 +9,21 @@ import numpy as np
 import torch
 from scipy.io import wavfile
 
+from ttsd.chunking import MAX_CHUNK_SIZE, sanitize_for_silero, split_into_chunks
 from ttsd.protocol import WordTimestamp
 from ttsd.timestamps import estimate_timestamps_chunked
 
 logger = logging.getLogger("ttsd.silero")
 
-# Maximum characters per TTS chunk (Silero limit is ~1000-1500)
-MAX_CHUNK_SIZE = 900
+# MAX_CHUNK_SIZE / split_into_chunks / sanitize_for_silero now live in ttsd.chunking
+# (torch-free) and are re-exported here for backwards compatibility.
+__all__ = [
+    "MAX_CHUNK_SIZE",
+    "SileroEngine",
+    "SynthesisOutput",
+    "sanitize_for_silero",
+    "split_into_chunks",
+]
 
 
 @dataclass
@@ -72,7 +79,7 @@ class SileroEngine:
         if not text.strip():
             raise ValueError("text must not be empty")
 
-        chunks = self._split_into_chunks(text)
+        chunks = split_into_chunks(text)
         logger.debug("Synthesizing %d chars in %d chunks", len(text), len(chunks))
 
         audio_parts: list[np.ndarray] = []
@@ -80,7 +87,7 @@ class SileroEngine:
 
         for i, (chunk_text, chunk_start) in enumerate(chunks):
             logger.debug("Chunk %d/%d: %d chars", i + 1, len(chunks), len(chunk_text))
-            silero_text = self._sanitize_for_silero(chunk_text)
+            silero_text = sanitize_for_silero(chunk_text)
             with torch.no_grad():
                 audio = self._model.apply_tts(  # type: ignore[union-attr]
                     text=silero_text,
@@ -102,58 +109,3 @@ class SileroEngine:
         timestamps = estimate_timestamps_chunked(text, chunk_durations, char_mapping)
 
         return SynthesisOutput(timestamps=timestamps, duration_sec=duration_sec)
-
-    @staticmethod
-    def _split_into_chunks(text: str) -> list[tuple[str, int]]:
-        """Split text into chunks for TTS processing.
-
-        Returns list of (chunk_text, start_position) tuples.
-        """
-        if len(text) <= MAX_CHUNK_SIZE:
-            return [(text, 0)]
-
-        chunks: list[tuple[str, int]] = []
-        current_pos = 0
-
-        while current_pos < len(text):
-            chunk_end = min(current_pos + MAX_CHUNK_SIZE, len(text))
-
-            if chunk_end >= len(text):
-                chunks.append((text[current_pos:], current_pos))
-                break
-
-            chunk_text = text[current_pos:chunk_end]
-
-            best_split = -1
-            for match in re.finditer(r"[.!?]\s+", chunk_text):
-                best_split = match.end()
-
-            if best_split == -1:
-                for match in re.finditer(r"[,;:]\s+", chunk_text):
-                    best_split = match.end()
-
-            if best_split == -1:
-                for match in re.finditer(r"\s+", chunk_text):
-                    best_split = match.end()
-
-            if best_split == -1 or best_split < len(chunk_text) // 2:
-                best_split = MAX_CHUNK_SIZE
-
-            actual_chunk = text[current_pos : current_pos + best_split].strip()
-            if actual_chunk:
-                chunks.append((actual_chunk, current_pos))
-
-            current_pos += best_split
-
-        return chunks
-
-    @staticmethod
-    def _sanitize_for_silero(text: str) -> str:
-        """Remove newlines and collapse spaces before passing to Silero.
-
-        Silero's character-level tokenizer does not handle control characters;
-        newlines cause a fatal abort inside prepare_tts_model_input.
-        """
-        text = re.sub(r"\s*\n\s*", " ", text)
-        text = re.sub(r" +", " ", text)
-        return text.strip()


### PR DESCRIPTION
## Summary

Epic "RuVox test health", task S4. `ttsd/main.py` had zero CI coverage: every existing test that touched it (`test_main_stub.py`) is `@pytest.mark.slow`, and `pyproject.toml` sets `addopts = "-m 'not slow'"`, so CI never ran them. `silero.py` also imported torch/numpy/scipy at module top, which prevented importing the request loop (or the pure text helpers) without the full ML stack.

## Changes

- **New `ttsd/chunking.py`** (torch-free): moves `MAX_CHUNK_SIZE`, `split_into_chunks`, `sanitize_for_silero` out of `silero.py`. `silero.py` imports and re-exports them; behavior is unchanged.
- **Lazy engine in `main.py`**: the `SileroEngine` singleton is now created lazily via `_get_engine()`, so importing `ttsd.main` no longer pulls in torch. Tests can override the singleton with a stub. The stdin/stdout JSON protocol is unchanged.
- **New `tests/test_main_unit.py`** (no `slow` marker): fake engine + stubbed stdin/stdout cover every handler and `main()` branch.
- **`tests/test_silero.py`**: `TestSplitIntoChunks` / `TestSanitizeForSilero` now target `ttsd.chunking` and no longer import `ttsd.silero`; the slow smoke tests import the engine lazily.
- **`tests/test_timestamps.py`**: added gap tests for `_map_via_spans` and `_map_via_positional`.

## Covered branches

`main.py`: `_setup_logging`, `_write_response`; `_handle_warmup` ok + failure (`model_not_loaded`); `_handle_synthesize` not-loaded / empty-text / `ValueError` / generic `Exception` / char_mapping build (with and without); `_handle_shutdown`; `main()` warmup+shutdown dispatch, synthesize dispatch, blank-line skip, invalid-JSON `bad_input`, unknown cmd, `KeyboardInterrupt` (rc 0), fatal error (rc 1).

`timestamps.py`: multi-span merge, `break` branch, no-overlap fallback in `_map_via_spans`; pydantic `CharMappingEntry` span path (`_is_span_entry` hasattr branch); positional index clamping, negative `norm_end` clamp, empty `char_map`; 3-decimal rounding.

## Gates

- `ruff check .` — clean
- `pytest` (default `not slow`) — 64 passed, 5 deselected (was 38 passed)
- new unit tests execute (not skipped); `pytest --collect-only -m slow` still collects `test_main_stub.py` and the silero smoke tests
- confirmed `import ttsd.main` / `import ttsd.chunking` load neither torch nor numpy