### PR TITLE
test(storage): share test helpers and make created_at deterministic

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1062,13 +1062,7 @@ fn apply_config_patch(config: &mut UIConfig, patch: UIConfigPatch) {
 #[cfg(test)]
 mod synthesis_tests {
     use super::*;
-    use tempfile::TempDir;
-
-    fn make_storage() -> (StorageService, TempDir) {
-        let dir = TempDir::new().unwrap();
-        let svc = StorageService::with_cache_dir(dir.path().to_path_buf()).unwrap();
-        (svc, dir)
-    }
+    use crate::storage::test_util::make_service;
 
     #[tokio::test]
     async fn run_normalization_returns_normalized_text_and_mapping() {
@@ -1090,7 +1084,7 @@ mod synthesis_tests {
 
     #[tokio::test]
     async fn finalize_audio_files_falls_back_to_wav_when_opus_encode_fails() {
-        let (storage, _dir) = make_storage();
+        let (storage, _dir) = make_service();
         let entry = storage.add_entry("text".to_string()).unwrap();
         let id = entry.id;
 

--- a/src-tauri/src/storage/eviction.rs
+++ b/src-tauri/src/storage/eviction.rs
@@ -274,16 +274,9 @@ pub fn run_startup_cleanup(svc: &StorageService, target_bytes: u64) -> Result<St
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::schema::WordTimestamp;
+    use crate::storage::test_util::{make_ready_entry, make_ready_entry_at, make_service};
     use std::fs;
     use std::path::Path;
-    use tempfile::TempDir;
-
-    fn make_service() -> (StorageService, TempDir) {
-        let dir = TempDir::new().unwrap();
-        let svc = StorageService::with_cache_dir(dir.path().to_path_buf()).unwrap();
-        (svc, dir)
-    }
 
     /// Mark a file's mtime far enough in the past that the orphan sweep won't
     /// treat it as "recent" and skip it.
@@ -291,29 +284,6 @@ mod tests {
         let aged = SystemTime::now() - (RECENT_FILE_GRACE * 2);
         // Setting access time too keeps the call cross-platform; we only care about mtime.
         let _ = filetime::set_file_mtime(path, filetime::FileTime::from_system_time(aged));
-    }
-
-    /// Create an entry already populated with on-disk audio + timestamps of
-    /// the requested sizes. Returns the entry id.
-    fn make_ready_entry(svc: &StorageService, audio_bytes: usize, ts_words: usize) -> EntryId {
-        let entry = svc.add_entry("test".into()).unwrap();
-        let id = entry.id;
-        let audio_filename = svc.save_audio(&id, &vec![0u8; audio_bytes]).unwrap();
-        let words: Vec<WordTimestamp> = (0..ts_words)
-            .map(|i| WordTimestamp {
-                word: format!("w{i}"),
-                start: i as f64,
-                end: i as f64 + 0.5,
-                original_pos: (0, 1),
-            })
-            .collect();
-        let ts_filename = svc.save_timestamps(&id, &words).unwrap();
-        let mut updated = entry.clone();
-        updated.audio_path = Some(audio_filename);
-        updated.timestamps_path = Some(ts_filename);
-        updated.status = EntryStatus::Ready;
-        svc.update_entry(updated).unwrap();
-        id
     }
 
     #[test]
@@ -364,12 +334,11 @@ mod tests {
     fn evict_to_size_drops_oldest_first_keeping_entry() {
         let (svc, _dir) = make_service();
 
-        // Three entries with distinct created_at (sleep between adds).
-        let id1 = make_ready_entry(&svc, 10_000, 0);
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let id2 = make_ready_entry(&svc, 10_000, 0);
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let id3 = make_ready_entry(&svc, 10_000, 0);
+        // Three entries with distinct, explicit created_at (oldest to newest).
+        let base = chrono::Local::now().naive_local();
+        let id1 = make_ready_entry_at(&svc, 10_000, 0, base);
+        let id2 = make_ready_entry_at(&svc, 10_000, 0, base + chrono::Duration::seconds(1));
+        let id3 = make_ready_entry_at(&svc, 10_000, 0, base + chrono::Duration::seconds(2));
 
         // Target is small enough to force at least the oldest two to be evicted.
         let stats = svc.evict_to_size(15_000, false).unwrap();
@@ -394,9 +363,9 @@ mod tests {
     #[test]
     fn evict_to_size_with_delete_texts_removes_entries() {
         let (svc, _dir) = make_service();
-        let id1 = make_ready_entry(&svc, 5_000, 0);
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let id2 = make_ready_entry(&svc, 5_000, 0);
+        let base = chrono::Local::now().naive_local();
+        let id1 = make_ready_entry_at(&svc, 5_000, 0, base);
+        let id2 = make_ready_entry_at(&svc, 5_000, 0, base + chrono::Duration::seconds(1));
 
         let stats = svc.evict_to_size(1, true).unwrap();
         // target 1 byte → both entries must be removed.
@@ -474,9 +443,9 @@ mod tests {
     #[test]
     fn evict_to_size_skips_processing_entries() {
         let (svc, _dir) = make_service();
-        let id_old = make_ready_entry(&svc, 10_000, 0);
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let id_proc = make_ready_entry(&svc, 10_000, 0);
+        let base = chrono::Local::now().naive_local();
+        let id_old = make_ready_entry_at(&svc, 10_000, 0, base);
+        let id_proc = make_ready_entry_at(&svc, 10_000, 0, base + chrono::Duration::seconds(1));
         // Force the older one into Processing — eviction loop must skip it
         // even though it would otherwise be picked first.
         let mut e = svc.get_entry(&id_old).unwrap();

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1,3 +1,5 @@
 pub mod eviction;
 pub mod schema;
 pub mod service;
+#[cfg(test)]
+pub(crate) mod test_util;

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -517,13 +517,8 @@ fn remove_file_if_exists(path: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::test_util::{add_entry_at, make_service};
     use tempfile::TempDir;
-
-    fn make_service() -> (StorageService, TempDir) {
-        let dir = TempDir::new().unwrap();
-        let svc = StorageService::with_cache_dir(dir.path().to_path_buf()).unwrap();
-        (svc, dir)
-    }
 
     #[test]
     fn new_creates_dirs() {
@@ -591,10 +586,9 @@ mod tests {
     #[test]
     fn get_all_entries_newest_first() {
         let (svc, _dir) = make_service();
-        let e1 = svc.add_entry("first".to_string()).unwrap();
-        // Small sleep to ensure distinct timestamps.
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let e2 = svc.add_entry("second".to_string()).unwrap();
+        let base = Local::now().naive_local();
+        let e1 = add_entry_at(&svc, "first", base);
+        let e2 = add_entry_at(&svc, "second", base + chrono::Duration::seconds(1));
 
         let all = svc.get_all_entries();
         assert_eq!(all.len(), 2);

--- a/src-tauri/src/storage/test_util.rs
+++ b/src-tauri/src/storage/test_util.rs
@@ -1,0 +1,77 @@
+//! Test-only helpers shared by the storage unit tests (`service.rs`,
+//! `eviction.rs`) and by the synthesis tests in `crate::commands`.
+//!
+//! Unlike `tts::supervisor::test_helpers`, this module doesn't need a
+//! `test-helpers` Cargo feature: every consumer lives inside this crate, so
+//! plain `#[cfg(test)]` + `pub(crate)` (see the `mod` declaration in
+//! `storage/mod.rs`) is enough.
+
+use chrono::{Local, NaiveDateTime};
+use tempfile::TempDir;
+
+use crate::storage::schema::{EntryId, EntryStatus, TextEntry, WordTimestamp};
+use crate::storage::service::StorageService;
+
+/// Build a [`StorageService`] backed by a fresh temp dir. The returned
+/// [`TempDir`] must be kept alive for as long as the service is used —
+/// dropping it removes the directory from disk.
+pub(crate) fn make_service() -> (StorageService, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let svc = StorageService::with_cache_dir(dir.path().to_path_buf()).unwrap();
+    (svc, dir)
+}
+
+/// Add a plain entry and immediately overwrite its `created_at` with an
+/// explicit value. Lets tests build entries with well-ordered timestamps
+/// without sleeping between `add_entry` calls.
+pub(crate) fn add_entry_at(
+    svc: &StorageService,
+    text: &str,
+    created_at: NaiveDateTime,
+) -> TextEntry {
+    let mut entry = svc.add_entry(text.to_string()).unwrap();
+    entry.created_at = created_at;
+    svc.update_entry(entry.clone()).unwrap();
+    entry
+}
+
+/// Create an entry already populated with on-disk audio + timestamps of the
+/// requested sizes, using `Local::now()` as `created_at`. Suitable when a
+/// test doesn't assert anything about ordering between entries.
+pub(crate) fn make_ready_entry(
+    svc: &StorageService,
+    audio_bytes: usize,
+    ts_words: usize,
+) -> EntryId {
+    make_ready_entry_at(svc, audio_bytes, ts_words, Local::now().naive_local())
+}
+
+/// Same as [`make_ready_entry`] but with an explicit `created_at`, so tests
+/// that assert oldest/newest ordering get distinct, deterministic timestamps
+/// instead of relying on `thread::sleep` between calls.
+pub(crate) fn make_ready_entry_at(
+    svc: &StorageService,
+    audio_bytes: usize,
+    ts_words: usize,
+    created_at: NaiveDateTime,
+) -> EntryId {
+    let entry = add_entry_at(svc, "test", created_at);
+    let id = entry.id;
+    let audio_filename = svc.save_audio(&id, &vec![0u8; audio_bytes]).unwrap();
+    let words: Vec<WordTimestamp> = (0..ts_words)
+        .map(|i| WordTimestamp {
+            word: format!("w{i}"),
+            start: i as f64,
+            end: i as f64 + 0.5,
+            original_pos: (0, 1),
+        })
+        .collect();
+    let ts_filename = svc.save_timestamps(&id, &words).unwrap();
+
+    let mut updated = svc.get_entry(&id).unwrap();
+    updated.audio_path = Some(audio_filename);
+    updated.timestamps_path = Some(ts_filename);
+    updated.status = EntryStatus::Ready;
+    svc.update_entry(updated).unwrap();
+    id
+}


### PR DESCRIPTION
## Summary
- Extract the byte-for-byte-duplicated `make_service()` / `make_ready_entry()` test helpers (previously living separately in `storage/service.rs`, `storage/eviction.rs`, and as `make_storage()` in `commands/mod.rs`) into a single `storage::test_util` module, following the existing `tts::supervisor::test_helpers` pattern (`#[cfg(test)]` + `pub(crate)`, no need for a Cargo feature since every consumer is intra-crate).
- Add `add_entry_at()` / `make_ready_entry_at()` so tests can set `created_at` explicitly instead of relying on `thread::sleep` to get distinct, ordered timestamps.
- Remove every `thread::sleep` in the storage tests that existed only to force ordering (`service.rs::get_all_entries_newest_first`, `eviction.rs::evict_to_size_drops_oldest_first_keeping_entry`, `evict_to_size_with_delete_texts_removes_entries`, `evict_to_size_skips_processing_entries`).
- No behavioral changes to production code; `write_sine_wav`/audio helpers are untouched (out of scope, tracked separately).

## Test plan
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (717 passed, 0 failed)
- [x] `grep -rn "thread::sleep" src-tauri/src/storage/` returns no hits (only a doc-comment mention)