### PR TITLE
test(tts): cover multi-span mapping and non-died retry passthrough

### DIFF
--- a/src-tauri/src/storage/schema.rs
+++ b/src-tauri/src/storage/schema.rs
@@ -56,8 +56,8 @@ pub struct HistoryFile {
 
 /// Word-level timestamp entry inside `{uuid}.timestamps.json`.
 ///
-/// `original_pos` is a two-element tuple `[start, end]` — char byte offsets
-/// in `TextEntry.original_text` used for word highlighting in the UI.
+/// `original_pos` is a two-element tuple `[start, end]` — Unicode codepoint
+/// offsets in `TextEntry.original_text` used for word highlighting in the UI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WordTimestamp {
     pub word: String,

--- a/src-tauri/src/tts/piper/timestamps.rs
+++ b/src-tauri/src/tts/piper/timestamps.rs
@@ -169,6 +169,55 @@ mod tests {
         }
     }
 
+    fn span(
+        norm_start: usize,
+        norm_end: usize,
+        orig_start: usize,
+        orig_end: usize,
+    ) -> CharMappingEntry {
+        CharMappingEntry {
+            norm_start,
+            norm_end,
+            orig_start,
+            orig_end,
+        }
+    }
+
+    #[test]
+    fn map_via_spans_merges_multiple_overlapping_spans() {
+        // Three spans intersect [2, 10). The result must be the smallest
+        // original interval that contains them all: min(orig_start) over the
+        // intersecting spans, max(orig_end). The middle span lowers best_start
+        // (2 < 5) but leaves best_end untouched (6 < 8); the last span raises
+        // best_end (14 > 8) but leaves best_start untouched (10 > 2) — so every
+        // arm of both `match` blocks is exercised.
+        let spans = vec![span(0, 4, 5, 8), span(4, 8, 2, 6), span(8, 12, 10, 14)];
+        assert_eq!(map_via_spans(&spans, 2, 10), (2, 14));
+    }
+
+    #[test]
+    fn map_via_spans_breaks_on_span_starting_at_or_after_norm_end() {
+        // Once a span begins at/after norm_end the scan stops: later spans are
+        // assumed sorted and cannot intersect. The trailing span here *would*
+        // intersect [0, 5) if reached, so a result of (0, 3) — not (0, 200) —
+        // proves the early `break` fired.
+        let spans = vec![
+            span(0, 3, 0, 3),
+            span(5, 10, 50, 60),  // norm_start (5) >= norm_end (5) → break
+            span(1, 2, 100, 200), // unreachable due to the break above
+        ];
+        assert_eq!(map_via_spans(&spans, 0, 5), (0, 3));
+    }
+
+    #[test]
+    fn map_via_spans_falls_back_to_norm_offsets_when_no_span_intersects() {
+        // Every span ends at/before norm_start, so all are skipped and neither
+        // best_start nor best_end is set. The fallback returns the normalized
+        // offsets unchanged.
+        let spans = vec![span(0, 5, 0, 3), span(5, 8, 3, 6)];
+        assert_eq!(map_via_spans(&spans, 10, 15), (10, 15));
+    }
+
     #[test]
     fn original_pos_is_codepoint_indexed_for_cyrillic() {
         // Without char_mapping, original_pos falls back to the normalized

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -340,4 +340,34 @@ mod tests {
         // 1 initial /bin/cat + 3 ENOENT retries.
         assert_eq!(counter.load(Ordering::SeqCst), 4);
     }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn with_retry_propagates_non_died_error_without_respawn() {
+        // A non-`Died` error (here `Timeout`) must be surfaced to the caller
+        // as-is: no respawn is attempted and no `ttsd_restarting` event fires.
+        // The factory records how many times it is asked to build a Command —
+        // exactly once (the initial spawn) proves no respawn happened.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = Arc::clone(&counter);
+        let factory: CommandFactory = Arc::new(move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+            Command::new("cat")
+        });
+
+        let (emitter, log) = recording_emitter();
+        let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
+
+        let res: Result<(), TtsError> = sup.with_retry(|_h| async { Err(TtsError::Timeout) }).await;
+        assert!(matches!(res, Err(TtsError::Timeout)));
+
+        // Only the initial spawn ran; the error path did not respawn.
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        let log = log.lock().unwrap();
+        let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            !names.contains(&"ttsd_restarting"),
+            "non-Died error must not trigger a restart, got events: {names:?}"
+        );
+    }
 }


### PR DESCRIPTION
Part of the "RuVox test health" epic (S14): targeted tests for TTS mapping and supervisor retry, plus a docstring fix. Production code is unchanged apart from the docstring.

## Added tests

- `map_via_spans_merges_multiple_overlapping_spans` — three intersecting spans; result is the smallest original interval containing them all (min `orig_start`, max `orig_end`). Exercises every arm of both `best_start`/`best_end` match blocks.
- `map_via_spans_breaks_on_span_starting_at_or_after_norm_end` — proves the early `break` fires: a trailing span that would otherwise intersect is not reached.
- `map_via_spans_falls_back_to_norm_offsets_when_no_span_intersects` — no span intersects, so the fallback returns the normalized offsets unchanged.
- `with_retry_propagates_non_died_error_without_respawn` — a non-`Died` error (`Timeout`) is surfaced as-is: no respawn (factory invoked exactly once) and no `ttsd_restarting` event. Uses `recording_emitter` and `#[tokio::test(start_paused = true)]`, matching the existing supervisor tests.

## Docstring fix

`WordTimestamp.original_pos` in `src-tauri/src/storage/schema.rs` said "char byte offsets"; the code operates on Unicode codepoint indices (confirmed by `piper/timestamps.rs` tests). Updated the doc accordingly.

## Gates

- `cargo fmt --manifest-path src-tauri/Cargo.toml` — clean
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `cargo test --manifest-path src-tauri/Cargo.toml` — 721 passed, 0 failed (incl. the 4 new tests)