### PR TITLE
test(tts): isolate filesystem paths in tts tests

### DIFF
--- a/src-tauri/src/tts/availability.rs
+++ b/src-tauri/src/tts/availability.rs
@@ -86,7 +86,8 @@ mod tests {
 
     #[test]
     fn piper_is_always_available() {
-        let res = probe(&std::env::temp_dir());
+        let dir = tempfile::TempDir::new().unwrap();
+        let res = probe(dir.path());
         assert!(res.piper.available);
         assert!(res.piper.reason.is_none());
     }
@@ -98,16 +99,9 @@ mod tests {
         assert!(!probe_result.silero.available);
         let reason = probe_result.silero.reason.expect("reason set");
         assert!(reason.contains("ttsd"));
-    }
-
-    #[test]
-    fn silero_reason_is_in_russian() {
-        // Smoke: every reason we surface to the user must be Cyrillic. Lets
-        // future probes (e.g. torch sniff) break loudly if someone ships an
+        // Every reason we surface to the user must be Cyrillic. Lets future
+        // probes (e.g. torch sniff) break loudly if someone ships an
         // English string by accident.
-        let dir = tempfile::TempDir::new().unwrap();
-        let r = probe(dir.path()).silero;
-        let reason = r.reason.unwrap();
         assert!(
             reason.chars().any(|c| matches!(c, 'А'..='я' | 'ё' | 'Ё')),
             "reason should be Russian: {reason}"

--- a/src-tauri/src/tts/switcher.rs
+++ b/src-tauri/src/tts/switcher.rs
@@ -204,23 +204,30 @@ mod tests {
     use super::*;
     use crate::tts::supervisor::test_helpers::recording_emitter;
 
-    fn fake_switcher() -> EngineSwitcher {
+    /// Builds a switcher backed by per-call `TempDir`s so parallel test runs
+    /// never collide on a shared `/tmp/ruvox-test-*` path. The guards must
+    /// be kept alive for the duration of the test (dropping them removes
+    /// the directories).
+    fn fake_switcher() -> (EngineSwitcher, tempfile::TempDir, tempfile::TempDir) {
         let (emitter, _) = recording_emitter();
-        let voices_dir = std::env::temp_dir().join("ruvox-test-voices");
-        let ttsd_dir = std::env::temp_dir().join("ruvox-test-ttsd");
+        let voices_tmp = tempfile::TempDir::new().expect("voices tempdir");
+        let ttsd_tmp = tempfile::TempDir::new().expect("ttsd tempdir");
+        let voices_dir = voices_tmp.path().to_path_buf();
+        let ttsd_dir = ttsd_tmp.path().to_path_buf();
         let initial: Arc<dyn TtsEngine> = Arc::new(PiperEngine::new(
             voices_dir.clone(),
             "ruslan".to_string(),
             Arc::clone(&emitter),
         ));
-        EngineSwitcher::new(
+        let switcher = EngineSwitcher::new(
             initial,
             EngineKind::Piper,
             Some("ruslan".to_string()),
             voices_dir,
             ttsd_dir,
             emitter,
-        )
+        );
+        (switcher, voices_tmp, ttsd_tmp)
     }
 
     #[test]
@@ -240,7 +247,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_config_with_same_engine_and_voice_is_noop() {
-        let sw = fake_switcher();
+        let (sw, _voices_tmp, _ttsd_tmp) = fake_switcher();
         // Same kind + same voice → no rebuild attempted.
         sw.apply_config("piper", "ruslan").await.unwrap();
         assert_eq!(sw.kind(), EngineKind::Piper);
@@ -248,7 +255,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_config_rebuilds_piper_on_voice_change() {
-        let sw = fake_switcher();
+        let (sw, _voices_tmp, _ttsd_tmp) = fake_switcher();
         sw.apply_config("piper", "irina").await.unwrap();
         // Engine kind unchanged, but the inner slot now references "irina".
         assert_eq!(sw.kind(), EngineKind::Piper);
@@ -258,7 +265,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_config_rejects_unknown_engine() {
-        let sw = fake_switcher();
+        let (sw, _voices_tmp, _ttsd_tmp) = fake_switcher();
         let err = sw.apply_config("nemo", "ruslan").await.unwrap_err();
         match err {
             TtsError::Ttsd { code, .. } => assert_eq!(code, "engine_unknown"),

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -43,7 +43,7 @@ fn mock_script_path() -> PathBuf {
 fn build_factory() -> CommandFactory {
     let script = mock_script_path();
     Arc::new(move || {
-        let mut cmd = Command::new("python");
+        let mut cmd = Command::new("python3");
         cmd.arg(&script);
         cmd
     })
@@ -55,13 +55,20 @@ async fn supervisor_respawns_after_subprocess_suicide() {
     let (emitter, log) = recording_emitter();
     let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
 
+    // The mock never actually writes a WAV file — it only echoes the
+    // protocol — but the output path is still routed through a per-test
+    // TempDir so no run ever touches a shared `/tmp/ruvox-mock-out-*.wav`.
+    let out_dir = tempfile::TempDir::new().expect("tempdir for mock wav outputs");
+    let out_wav_1 = out_dir.path().join("ruvox-mock-out-1.wav");
+    let out_wav_2 = out_dir.path().join("ruvox-mock-out-2.wav");
+
     // First call goes through cleanly — the mock counts this as call #1.
     let first = sup
         .synthesize(
             "hello".to_string(),
             "xenia".to_string(),
             48_000,
-            "/tmp/ruvox-mock-out-1.wav".to_string(),
+            out_wav_1.to_string_lossy().into_owned(),
             None,
         )
         .await
@@ -76,7 +83,7 @@ async fn supervisor_respawns_after_subprocess_suicide() {
             "world".to_string(),
             "xenia".to_string(),
             48_000,
-            "/tmp/ruvox-mock-out-2.wav".to_string(),
+            out_wav_2.to_string_lossy().into_owned(),
             None,
         )
         .await


### PR DESCRIPTION
## Summary
- `switcher.rs`: `fake_switcher` now creates per-call `tempfile::TempDir`s for the Piper voices dir and ttsd dir instead of shared `std::env::temp_dir().join("ruvox-test-*")` paths, avoiding collisions across parallel test runs. The dir guards are returned alongside the switcher and kept alive for the test's duration.
- `availability.rs`: `piper_is_always_available` now probes a `TempDir` instead of the shared temp dir. `silero_unavailable_when_ttsd_dir_missing_pyproject` and `silero_reason_is_in_russian` are merged into a single test with one `TempDir` setup and both assertions (unavailable + Cyrillic reason).
- `tests/supervisor.rs`: mock output wav paths are now placed inside a per-test `TempDir` instead of hardcoded `/tmp/ruvox-mock-out-{1,2}.wav`; the mock subprocess command switches from `python` to `python3`.
- No behavioral changes to what the tests assert.

## Test plan
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml` — clean
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --features test-helpers -- -D warnings` — clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 716 passed, 0 failed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --features test-helpers --test supervisor` — 1 passed, 0 failed