### PR TITLE
test(ttsd): dedup and parametrize Python test suite

### DIFF
--- a/ttsd/tests/test_main_stub.py
+++ b/ttsd/tests/test_main_stub.py
@@ -7,9 +7,9 @@ import sys
 import pytest
 
 
-@pytest.mark.slow
-def test_warmup_and_shutdown() -> None:
-    """Spawn python -m ttsd, send warmup, expect ok response, then shutdown."""
+@pytest.fixture
+def ttsd_process():
+    """Spawn `python -m ttsd` with piped stdio and terminate it on teardown."""
     proc = subprocess.Popen(
         [sys.executable, "-m", "ttsd"],
         stdin=subprocess.PIPE,
@@ -18,31 +18,7 @@ def test_warmup_and_shutdown() -> None:
         text=True,
     )
     try:
-        # Send warmup
-        assert proc.stdin is not None
-        proc.stdin.write('{"cmd": "warmup"}\n')
-        proc.stdin.flush()
-
-        # Read warmup response
-        assert proc.stdout is not None
-        line = proc.stdout.readline()
-        response = json.loads(line)
-        assert response["ok"] is True
-        assert "version" in response
-        assert response["version"] == "0.1.0"
-
-        # Send shutdown
-        proc.stdin.write('{"cmd": "shutdown"}\n')
-        proc.stdin.flush()
-
-        # Read shutdown response
-        line = proc.stdout.readline()
-        response = json.loads(line)
-        assert response["ok"] is True
-
-        # Process should exit cleanly
-        proc.wait(timeout=5)
-        assert proc.returncode == 0
+        yield proc
     finally:
         if proc.poll() is None:
             proc.terminate()
@@ -50,34 +26,51 @@ def test_warmup_and_shutdown() -> None:
 
 
 @pytest.mark.slow
-def test_bad_input_returns_error() -> None:
+def test_warmup_and_shutdown(ttsd_process) -> None:
+    """Send warmup, expect ok response, then shutdown."""
+    proc = ttsd_process
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+
+    proc.stdin.write('{"cmd": "warmup"}\n')
+    proc.stdin.flush()
+
+    line = proc.stdout.readline()
+    response = json.loads(line)
+    assert response["ok"] is True
+    assert "version" in response
+    assert response["version"] == "0.1.0"
+
+    proc.stdin.write('{"cmd": "shutdown"}\n')
+    proc.stdin.flush()
+
+    line = proc.stdout.readline()
+    response = json.loads(line)
+    assert response["ok"] is True
+
+    # Process should exit cleanly
+    proc.wait(timeout=5)
+    assert proc.returncode == 0
+
+
+@pytest.mark.slow
+def test_bad_input_returns_error(ttsd_process) -> None:
     """Malformed JSON should return an ErrResponse with error='bad_input'."""
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "ttsd"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    try:
-        assert proc.stdin is not None
-        assert proc.stdout is not None
+    proc = ttsd_process
+    assert proc.stdin is not None
+    assert proc.stdout is not None
 
-        # Send invalid JSON (missing required fields)
-        proc.stdin.write('{"cmd": "synthesize"}\n')
-        proc.stdin.flush()
+    # Send invalid JSON (missing required fields)
+    proc.stdin.write('{"cmd": "synthesize"}\n')
+    proc.stdin.flush()
 
-        line = proc.stdout.readline()
-        response = json.loads(line)
-        assert response["ok"] is False
-        assert response["error"] == "bad_input"
+    line = proc.stdout.readline()
+    response = json.loads(line)
+    assert response["ok"] is False
+    assert response["error"] == "bad_input"
 
-        # Clean shutdown
-        proc.stdin.write('{"cmd": "shutdown"}\n')
-        proc.stdin.flush()
-        proc.wait(timeout=5)
-        assert proc.returncode == 0
-    finally:
-        if proc.poll() is None:
-            proc.terminate()
-            proc.wait(timeout=5)
+    # Clean shutdown
+    proc.stdin.write('{"cmd": "shutdown"}\n')
+    proc.stdin.flush()
+    proc.wait(timeout=5)
+    assert proc.returncode == 0

--- a/ttsd/tests/test_main_unit.py
+++ b/ttsd/tests/test_main_unit.py
@@ -150,20 +150,19 @@ def test_handle_synthesize_empty_text(use_engine):
     assert "empty" in resp.message
 
 
-def test_handle_synthesize_value_error_is_bad_input(use_engine):
-    use_engine(FakeEngine(loaded=True, synth_exc=ValueError("bad char")))
+@pytest.mark.parametrize(
+    "exc, expected_error, expected_substr",
+    [
+        pytest.param(ValueError("bad char"), "bad_input", "bad char", id="value_error_to_bad_input"),
+        pytest.param(RuntimeError("boom"), "synthesis_failed", "boom", id="runtime_error_to_synthesis_failed"),
+    ],
+)
+def test_handle_synthesize_exception_mapping(use_engine, exc, expected_error, expected_substr):
+    use_engine(FakeEngine(loaded=True, synth_exc=exc))
     resp = ttsd_main._handle_synthesize(_make_synth_request())
     assert isinstance(resp, ttsd_main.ErrResponse)
-    assert resp.error == "bad_input"
-    assert "bad char" in resp.message
-
-
-def test_handle_synthesize_generic_error_is_synthesis_failed(use_engine):
-    use_engine(FakeEngine(loaded=True, synth_exc=RuntimeError("boom")))
-    resp = ttsd_main._handle_synthesize(_make_synth_request())
-    assert isinstance(resp, ttsd_main.ErrResponse)
-    assert resp.error == "synthesis_failed"
-    assert "boom" in resp.message
+    assert resp.error == expected_error
+    assert expected_substr in resp.message
 
 
 def test_handle_synthesize_ok_without_char_mapping(use_engine):

--- a/ttsd/tests/test_protocol.py
+++ b/ttsd/tests/test_protocol.py
@@ -119,16 +119,15 @@ class TestOkSynthesize:
 
 
 class TestOkWarmup:
-    def test_ok_warmup_has_version(self) -> None:
-        resp = OkWarmup(version="0.1.0")
+    @pytest.mark.parametrize("version", ["0.1.0", "1.2.3-test"])
+    def test_ok_warmup_has_version_and_serializes(self, version: str) -> None:
+        resp = OkWarmup(version=version)
         assert resp.ok is True
-        assert resp.version == "0.1.0"
+        assert resp.version == version
 
-    def test_ok_warmup_serializes(self) -> None:
-        resp = OkWarmup(version="0.1.0")
         data = resp.model_dump()
         assert data["ok"] is True
-        assert data["version"] == "0.1.0"
+        assert data["version"] == version
 
 
 class TestOkShutdown:
@@ -139,17 +138,22 @@ class TestOkShutdown:
 
 
 class TestErrResponse:
-    def test_err_response_model_not_loaded(self) -> None:
-        resp = ErrResponse(error="model_not_loaded", message="Model not loaded")
+    @pytest.mark.parametrize(
+        "error, message",
+        [
+            ("model_not_loaded", "Model not loaded"),
+            ("bad_input", "text must not be empty"),
+        ],
+    )
+    def test_err_response_valid_error_codes(self, error: str, message: str) -> None:
+        resp = ErrResponse(error=error, message=message)  # type: ignore[arg-type]
         assert resp.ok is False
-        assert resp.error == "model_not_loaded"
+        assert resp.error == error
 
-    def test_err_response_bad_input(self) -> None:
-        resp = ErrResponse(error="bad_input", message="text must not be empty")
         data = resp.model_dump()
         assert data["ok"] is False
-        assert data["error"] == "bad_input"
-        assert data["message"] == "text must not be empty"
+        assert data["error"] == error
+        assert data["message"] == message
 
     def test_err_response_invalid_error_code_raises(self) -> None:
         with pytest.raises(ValidationError):

--- a/ttsd/tests/test_silero.py
+++ b/ttsd/tests/test_silero.py
@@ -7,7 +7,7 @@ in CI without the ML stack.
 
 import pytest
 
-from ttsd.chunking import sanitize_for_silero, split_into_chunks
+from ttsd.chunking import MAX_CHUNK_SIZE, sanitize_for_silero, split_into_chunks
 
 
 def _import_silero_engine():
@@ -37,7 +37,7 @@ def test_silero_load_and_synthesize(tmp_path):
 
 
 @pytest.mark.slow
-def test_silero_second_load_is_noop(tmp_path):
+def test_silero_second_load_is_noop():
     """Calling load() twice must not raise or reset the model."""
     engine = _import_silero_engine()()
     engine.load()
@@ -59,6 +59,24 @@ def test_silero_empty_text_raises(tmp_path):
         )
 
 
+def _assert_covers_source(text: str, chunks: list[tuple[str, int]]) -> None:
+    """Every chunk must sit at its declared start position, stay within
+    MAX_CHUNK_SIZE, and the gaps between (and after) chunks must be
+    whitespace-only — i.e. the chunks collectively cover all non-whitespace
+    content of the source text, in order, with nothing dropped or duplicated.
+    """
+    for chunk_text, start in chunks:
+        assert text[start : start + len(chunk_text)] == chunk_text
+        assert len(chunk_text) <= MAX_CHUNK_SIZE
+
+    for (chunk_text, start), (_, next_start) in zip(chunks, chunks[1:], strict=False):
+        gap = text[start + len(chunk_text) : next_start]
+        assert gap.strip() == ""
+
+    last_text, last_start = chunks[-1]
+    assert text[last_start + len(last_text) :].strip() == ""
+
+
 class TestSplitIntoChunks:
     """Unit tests for split_into_chunks that do not need the model."""
 
@@ -75,6 +93,10 @@ class TestSplitIntoChunks:
         # Every chunk must be non-empty
         for chunk_text, _ in chunks:
             assert chunk_text.strip()
+        _assert_covers_source(text, chunks)
+        # Every split but the last must land right after a sentence boundary.
+        for chunk_text, _ in chunks[:-1]:
+            assert chunk_text.rstrip().endswith(".")
 
     def test_chunks_cover_full_text(self):
         sentence = "Слово слово слово. "
@@ -83,12 +105,14 @@ class TestSplitIntoChunks:
         # The start positions must be ordered
         starts = [s for _, s in chunks]
         assert starts == sorted(starts)
+        _assert_covers_source(text, chunks)
 
     def test_start_positions_non_negative(self):
         text = "A" * 2000
         chunks = split_into_chunks(text)
         for _, start in chunks:
             assert start >= 0
+        _assert_covers_source(text, chunks)
 
 
 class TestSanitizeForSilero:

--- a/ttsd/tests/test_timestamps.py
+++ b/ttsd/tests/test_timestamps.py
@@ -1,5 +1,8 @@
 """Unit tests for timestamps.py — no torch required."""
 
+import pytest
+
+from ttsd.protocol import CharMappingEntry
 from ttsd.timestamps import (
     _map_via_positional,
     _map_via_spans,
@@ -79,35 +82,47 @@ class TestEstimateTimestampsChunked:
         ts = result[0]
         assert ts.original_pos == (0, 5)
 
-    def test_char_mapping_dict_shape(self):
-        # Dict shape: {"char_map": [[orig_start, orig_end], ...]} indexed by norm pos
-        text = "ab"
-        # norm positions 0,1 → orig positions 10,11; norm positions 1,2 → 11,12
-        char_map = [[10, 12], [11, 13]]
-        mapping = {"char_map": char_map}
-        result = estimate_timestamps_chunked(text, [(0, len(text), 1.0)], mapping)
+    @pytest.mark.parametrize(
+        "text, chunks, mapping, expected_pos",
+        [
+            pytest.param(
+                "ab",
+                [(0, 2, 1.0)],
+                {"char_map": [[10, 12], [11, 13]]},
+                (10, 13),
+                id="dict_shape",
+                # norm_start=0, norm_end=2 → start_idx=0, end_idx=1 → orig_start=10, orig_end=13
+            ),
+            pytest.param(
+                "слово",
+                [(0, 5, 1.0)],
+                [{"norm_start": 0, "norm_end": 5, "orig_start": 100, "orig_end": 105}],
+                (100, 105),
+                id="span_list_of_dicts",
+            ),
+            pytest.param(
+                "abc",
+                [(0, 3, 1.0)],
+                [[5, 6], [6, 7], [7, 8]],
+                (5, 8),
+                id="positional_list",
+                # norm_start=0, norm_end=3 → start_idx=0, end_idx=2 → orig [5,8]
+            ),
+            pytest.param(
+                "слово",
+                [(0, 5, 1.0)],
+                [CharMappingEntry(norm_start=0, norm_end=5, orig_start=100, orig_end=105)],
+                (100, 105),
+                id="pydantic_span_entries",
+                # Exercises the hasattr branch of _is_span_entry (non-dict span
+                # with a norm_start attribute) via real CharMappingEntry objects.
+            ),
+        ],
+    )
+    def test_char_mapping_shapes(self, text, chunks, mapping, expected_pos):
+        result = estimate_timestamps_chunked(text, chunks, mapping)
         assert len(result) == 1
-        # norm_start=0, norm_end=2 → start_idx=0, end_idx=1 → orig_start=10, orig_end=13
-        assert result[0].original_pos == (10, 13)
-
-    def test_char_mapping_span_list_of_dicts(self):
-        # Shape 1: list of dicts with norm_start/norm_end/orig_start/orig_end
-        text = "слово"
-        spans = [
-            {"norm_start": 0, "norm_end": 5, "orig_start": 100, "orig_end": 105},
-        ]
-        result = estimate_timestamps_chunked(text, [(0, 5, 1.0)], spans)
-        assert len(result) == 1
-        assert result[0].original_pos == (100, 105)
-
-    def test_char_mapping_positional_list(self):
-        # Shape 3: plain list [[orig_start, orig_end], ...]
-        text = "abc"
-        char_map = [[5, 6], [6, 7], [7, 8]]
-        result = estimate_timestamps_chunked(text, [(0, 3, 1.0)], char_map)
-        assert len(result) == 1
-        # norm_start=0, norm_end=3 → start_idx=0, end_idx=2 → orig [5,8]
-        assert result[0].original_pos == (5, 8)
+        assert result[0].original_pos == expected_pos
 
     def test_timestamps_are_pydantic_models(self):
         from ttsd.protocol import WordTimestamp
@@ -116,17 +131,6 @@ class TestEstimateTimestampsChunked:
         result = estimate_timestamps_chunked(text, [(0, 4, 1.0)], None)
         assert len(result) == 1
         assert isinstance(result[0], WordTimestamp)
-
-    def test_char_mapping_pydantic_span_entries(self):
-        # Shape 1 via real CharMappingEntry objects — exercises the hasattr
-        # branch of _is_span_entry (non-dict span with a norm_start attribute).
-        from ttsd.protocol import CharMappingEntry
-
-        text = "слово"
-        spans = [CharMappingEntry(norm_start=0, norm_end=5, orig_start=100, orig_end=105)]
-        result = estimate_timestamps_chunked(text, [(0, 5, 1.0)], spans)
-        assert len(result) == 1
-        assert result[0].original_pos == (100, 105)
 
     def test_timestamps_rounded_to_three_decimals(self):
         # "a"(1 char) + "bb"(2 chars), total 3, duration 1.0s.


### PR DESCRIPTION
## Summary

Epic "RuVox test suite health" — task S4b: deduplicate and parametrize the ttsd Python test suite.

- `tests/test_main_stub.py`: extracted the repeated subprocess spawn/teardown code into a `ttsd_process` pytest fixture. Both `@pytest.mark.slow` tests kept as-is (unique coverage — they exercise the real subprocess protocol end-to-end, spawning the actual `python -m ttsd` process, which the fast unit tests in `test_main_unit.py` do not cover).
- `tests/test_protocol.py`: parametrized `TestErrResponse` (`test_err_response_valid_error_codes`) and `TestOkWarmup` (`test_ok_warmup_has_version_and_serializes`) over their input variants instead of duplicating near-identical bodies. `TestOkWarmup` also gained an extra version-string case as a side effect of merging.
- `tests/test_timestamps.py`: collapsed the four char_mapping shape tests (dict shape, span list of dicts, positional list, pydantic span entries) into a single `test_char_mapping_shapes` parametrize block — four near-identical bodies deduplicated into one parametrized test, coverage unchanged (each original test maps 1:1 to a parametrize case).
- `tests/test_main_unit.py`: parametrized the two `_handle_synthesize` exception-mapping tests (`ValueError` -> `bad_input`, `RuntimeError` -> `synthesis_failed`) into `test_handle_synthesize_exception_mapping`.
- `tests/test_silero.py`:
  - Removed the unused `tmp_path` argument from `test_silero_second_load_is_noop` (never referenced in the body).
  - Strengthened `TestSplitIntoChunks` assertions (non-torch, fast) with a shared `_assert_covers_source` helper that checks: each chunk sits at its declared start position and reconstructs the exact source slice, every chunk stays within `MAX_CHUNK_SIZE`, and the gaps between/after chunks are whitespace-only (i.e. no content is dropped or duplicated). Also added a boundary check that splits happen right after a sentence-ending `.` where the algorithm is expected to prefer sentence boundaries.

## Test count

- Before: 69 collected (64 fast + 5 slow)
- After: 69 collected (64 fast + 5 slow) — unchanged

Coverage preserved 1:1 (a couple of parametrized cases pick up an extra input variant for free, nothing was dropped). No unique slow subprocess/model coverage was removed.

## Gates

- `ruff check .` in `ttsd/` — clean
- `python -m pytest` (default `not slow` marker) — 64 passed, 5 deselected
- `python -m pytest --collect-only -m slow` — 5 collected, no collection errors

## Test plan

- [x] `ruff check .`
- [x] `pytest` (fast suite) green
- [x] `pytest --collect-only -m slow` collects without errors
