### PR TITLE
test(pipeline): convert symbols/abbreviations tests to test-case tables

### DIFF
--- a/src-tauri/src/pipeline/normalizers/abbreviations.rs
+++ b/src-tauri/src/pipeline/normalizers/abbreviations.rs
@@ -164,552 +164,145 @@ pub fn as_word() -> &'static HashMap<&'static str, &'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     fn normalizer() -> AbbreviationNormalizer {
         AbbreviationNormalizer::new()
     }
 
-    // --- AS_WORD tests ---
-
-    #[test]
-    fn test_json_as_word() {
-        assert_eq!(normalizer().normalize("JSON"), "джейсон");
-    }
-
-    #[test]
-    fn test_yaml_as_word() {
-        assert_eq!(normalizer().normalize("YAML"), "ямл");
-    }
-
-    #[test]
-    fn test_toml_as_word() {
-        assert_eq!(normalizer().normalize("TOML"), "томл");
-    }
-
-    #[test]
-    fn test_rest_as_word() {
-        assert_eq!(normalizer().normalize("REST"), "рест");
-    }
-
-    #[test]
-    fn test_ajax_as_word() {
-        assert_eq!(normalizer().normalize("AJAX"), "эйджакс");
-    }
-
-    #[test]
-    fn test_crud_as_word() {
-        assert_eq!(normalizer().normalize("CRUD"), "крад");
-    }
-
-    #[test]
-    fn test_cors_as_word() {
-        assert_eq!(normalizer().normalize("CORS"), "корс");
-    }
-
-    #[test]
-    fn test_oauth_as_word() {
-        assert_eq!(normalizer().normalize("OAuth"), "о ауз");
-    }
-
-    #[test]
-    fn test_gif_as_word() {
-        assert_eq!(normalizer().normalize("GIF"), "гиф");
-    }
-
-    #[test]
-    fn test_jpeg_as_word() {
-        assert_eq!(normalizer().normalize("JPEG"), "джейпег");
-    }
-
-    #[test]
-    fn test_png_spelled_out() {
-        // PNG is not in AS_WORD, so it gets spelled out
-        assert_eq!(normalizer().normalize("PNG"), "пи эн джи");
-    }
-
-    #[test]
-    fn test_ram_as_word() {
-        assert_eq!(normalizer().normalize("RAM"), "рам");
-    }
-
-    #[test]
-    fn test_rom_as_word() {
-        assert_eq!(normalizer().normalize("ROM"), "ром");
-    }
-
-    #[test]
-    fn test_lan_as_word() {
-        assert_eq!(normalizer().normalize("LAN"), "лан");
-    }
-
-    #[test]
-    fn test_wan_as_word() {
-        assert_eq!(normalizer().normalize("WAN"), "ван");
-    }
-
-    #[test]
-    fn test_spa_as_word() {
-        assert_eq!(normalizer().normalize("SPA"), "спа");
-    }
-
-    #[test]
-    fn test_dom_as_word() {
-        assert_eq!(normalizer().normalize("DOM"), "дом");
-    }
-
-    #[test]
-    fn test_gui_as_word() {
-        assert_eq!(normalizer().normalize("GUI"), "гуи");
-    }
-
-    #[test]
-    fn test_imap_as_word() {
-        assert_eq!(normalizer().normalize("IMAP"), "ай мап");
-    }
-
-    #[test]
-    fn test_pop_as_word() {
-        assert_eq!(normalizer().normalize("POP"), "поп");
-    }
-
-    // --- Spelled out tests ---
-
-    #[test]
-    fn test_http_spelled_out() {
-        assert_eq!(normalizer().normalize("HTTP"), "эйч ти ти пи");
-    }
-
-    #[test]
-    fn test_https_spelled_out() {
-        assert_eq!(normalizer().normalize("HTTPS"), "эйч ти ти пи эс");
-    }
-
-    #[test]
-    fn test_html_spelled_out() {
-        assert_eq!(normalizer().normalize("HTML"), "эйч ти эм эл");
-    }
-
-    #[test]
-    fn test_css_spelled_out() {
-        assert_eq!(normalizer().normalize("CSS"), "си эс эс");
-    }
-
-    #[test]
-    fn test_xml_spelled_out() {
-        assert_eq!(normalizer().normalize("XML"), "экс эм эл");
-    }
-
-    #[test]
-    fn test_url_spelled_out() {
-        assert_eq!(normalizer().normalize("URL"), "ю ар эл");
-    }
-
-    #[test]
-    fn test_uri_spelled_out() {
-        assert_eq!(normalizer().normalize("URI"), "ю ар ай");
-    }
-
-    #[test]
-    fn test_api_spelled_out() {
-        assert_eq!(normalizer().normalize("API"), "эй пи ай");
-    }
-
-    #[test]
-    fn test_sdk_spelled_out() {
-        assert_eq!(normalizer().normalize("SDK"), "эс ди кей");
-    }
-
-    #[test]
-    fn test_cli_spelled_out() {
-        assert_eq!(normalizer().normalize("CLI"), "си эл ай");
-    }
-
-    #[test]
-    fn test_ide_spelled_out() {
-        assert_eq!(normalizer().normalize("IDE"), "ай ди и");
-    }
-
-    #[test]
-    fn test_ssl_spelled_out() {
-        assert_eq!(normalizer().normalize("SSL"), "эс эс эл");
-    }
-
-    #[test]
-    fn test_tls_spelled_out() {
-        assert_eq!(normalizer().normalize("TLS"), "ти эл эс");
-    }
-
-    #[test]
-    fn test_ssh_spelled_out() {
-        assert_eq!(normalizer().normalize("SSH"), "эс эс эйч");
-    }
-
-    #[test]
-    fn test_vpn_spelled_out() {
-        assert_eq!(normalizer().normalize("VPN"), "ви пи эн");
-    }
-
-    #[test]
-    fn test_jwt_spelled_out() {
-        assert_eq!(normalizer().normalize("JWT"), "джей дабл ю ти");
-    }
-
-    #[test]
-    fn test_xss_spelled_out() {
-        assert_eq!(normalizer().normalize("XSS"), "экс эс эс");
-    }
-
-    #[test]
-    fn test_csrf_spelled_out() {
-        assert_eq!(normalizer().normalize("CSRF"), "си эс ар эф");
-    }
-
-    #[test]
-    fn test_tcp_spelled_out() {
-        assert_eq!(normalizer().normalize("TCP"), "ти си пи");
-    }
-
-    #[test]
-    fn test_udp_spelled_out() {
-        assert_eq!(normalizer().normalize("UDP"), "ю ди пи");
-    }
-
-    #[test]
-    fn test_ftp_spelled_out() {
-        assert_eq!(normalizer().normalize("FTP"), "эф ти пи");
-    }
-
-    #[test]
-    fn test_dns_spelled_out() {
-        assert_eq!(normalizer().normalize("DNS"), "ди эн эс");
-    }
-
-    #[test]
-    fn test_smtp_spelled_out() {
-        assert_eq!(normalizer().normalize("SMTP"), "эс эм ти пи");
-    }
-
-    #[test]
-    fn test_ip_spelled_out() {
-        assert_eq!(normalizer().normalize("IP"), "ай пи");
-    }
-
-    #[test]
-    fn test_cpu_spelled_out() {
-        assert_eq!(normalizer().normalize("CPU"), "си пи ю");
-    }
-
-    #[test]
-    fn test_gpu_spelled_out() {
-        assert_eq!(normalizer().normalize("GPU"), "джи пи ю");
-    }
-
-    #[test]
-    fn test_ssd_spelled_out() {
-        assert_eq!(normalizer().normalize("SSD"), "эс эс ди");
-    }
-
-    #[test]
-    fn test_hdd_spelled_out() {
-        assert_eq!(normalizer().normalize("HDD"), "эйч ди ди");
-    }
-
-    #[test]
-    fn test_usb_spelled_out() {
-        assert_eq!(normalizer().normalize("USB"), "ю эс би");
-    }
-
-    #[test]
-    fn test_hdmi_spelled_out() {
-        assert_eq!(normalizer().normalize("HDMI"), "эйч ди эм ай");
-    }
-
-    #[test]
-    fn test_ui_spelled_out() {
-        assert_eq!(normalizer().normalize("UI"), "ю ай");
-    }
-
-    #[test]
-    fn test_ux_spelled_out() {
-        assert_eq!(normalizer().normalize("UX"), "ю экс");
-    }
-
-    #[test]
-    fn test_ci_spelled_out() {
-        assert_eq!(normalizer().normalize("CI"), "си ай");
-    }
-
-    #[test]
-    fn test_cd_spelled_out() {
-        assert_eq!(normalizer().normalize("CD"), "си ди");
-    }
-
-    #[test]
-    fn test_ai_spelled_out() {
-        assert_eq!(normalizer().normalize("AI"), "эй ай");
-    }
-
-    #[test]
-    fn test_ml_spelled_out() {
-        assert_eq!(normalizer().normalize("ML"), "эм эл");
-    }
-
-    #[test]
-    fn test_nlp_spelled_out() {
-        assert_eq!(normalizer().normalize("NLP"), "эн эл пи");
-    }
-
-    #[test]
-    fn test_cv_spelled_out() {
-        assert_eq!(normalizer().normalize("CV"), "си ви");
-    }
-
-    #[test]
-    fn test_sql_spelled_out() {
-        assert_eq!(normalizer().normalize("SQL"), "эс кью эл");
-    }
-
-    #[test]
-    fn test_orm_spelled_out() {
-        assert_eq!(normalizer().normalize("ORM"), "о ар эм");
-    }
-
-    #[test]
-    fn test_mvc_spelled_out() {
-        assert_eq!(normalizer().normalize("MVC"), "эм ви си");
-    }
-
-    #[test]
-    fn test_mvp_spelled_out() {
-        assert_eq!(normalizer().normalize("MVP"), "эм ви пи");
-    }
-
-    #[test]
-    fn test_iot_special_case() {
-        assert_eq!(normalizer().normalize("IoT"), "ай о ти");
-    }
-
-    #[test]
-    fn test_ssr_spelled_out() {
-        assert_eq!(normalizer().normalize("SSR"), "эс эс ар");
-    }
-
-    #[test]
-    fn test_ssg_spelled_out() {
-        assert_eq!(normalizer().normalize("SSG"), "эс эс джи");
-    }
-
-    #[test]
-    fn test_csr_spelled_out() {
-        assert_eq!(normalizer().normalize("CSR"), "си эс ар");
-    }
-
-    #[test]
-    fn test_pwa_spelled_out() {
-        assert_eq!(normalizer().normalize("PWA"), "пи дабл ю эй");
-    }
-
-    #[test]
-    fn test_svg_spelled_out() {
-        assert_eq!(normalizer().normalize("SVG"), "эс ви джи");
-    }
-
-    // --- Letter map tests ---
-
-    #[test]
-    fn test_letter_a() {
-        assert_eq!(normalizer().normalize("A"), "эй");
-    }
-
-    #[test]
-    fn test_letter_b() {
-        assert_eq!(normalizer().normalize("B"), "би");
-    }
-
-    #[test]
-    fn test_letter_c() {
-        assert_eq!(normalizer().normalize("C"), "си");
-    }
-
-    #[test]
-    fn test_letter_d() {
-        assert_eq!(normalizer().normalize("D"), "ди");
-    }
-
-    #[test]
-    fn test_letter_e() {
-        assert_eq!(normalizer().normalize("E"), "и");
-    }
-
-    #[test]
-    fn test_letter_f() {
-        assert_eq!(normalizer().normalize("F"), "эф");
-    }
-
-    #[test]
-    fn test_letter_g() {
-        assert_eq!(normalizer().normalize("G"), "джи");
-    }
-
-    #[test]
-    fn test_letter_h() {
-        assert_eq!(normalizer().normalize("H"), "эйч");
-    }
-
-    #[test]
-    fn test_letter_i() {
-        assert_eq!(normalizer().normalize("I"), "ай");
-    }
-
-    #[test]
-    fn test_letter_j() {
-        assert_eq!(normalizer().normalize("J"), "джей");
-    }
-
-    #[test]
-    fn test_letter_k() {
-        assert_eq!(normalizer().normalize("K"), "кей");
-    }
-
-    #[test]
-    fn test_letter_l() {
-        assert_eq!(normalizer().normalize("L"), "эл");
-    }
-
-    #[test]
-    fn test_letter_m() {
-        assert_eq!(normalizer().normalize("M"), "эм");
-    }
-
-    #[test]
-    fn test_letter_n() {
-        assert_eq!(normalizer().normalize("N"), "эн");
-    }
-
-    #[test]
-    fn test_letter_o() {
-        assert_eq!(normalizer().normalize("O"), "о");
-    }
-
-    #[test]
-    fn test_letter_p() {
-        assert_eq!(normalizer().normalize("P"), "пи");
-    }
-
-    #[test]
-    fn test_letter_q() {
-        assert_eq!(normalizer().normalize("Q"), "кью");
-    }
-
-    #[test]
-    fn test_letter_r() {
-        assert_eq!(normalizer().normalize("R"), "ар");
-    }
-
-    #[test]
-    fn test_letter_s() {
-        assert_eq!(normalizer().normalize("S"), "эс");
-    }
-
-    #[test]
-    fn test_letter_t() {
-        assert_eq!(normalizer().normalize("T"), "ти");
-    }
-
-    #[test]
-    fn test_letter_u() {
-        assert_eq!(normalizer().normalize("U"), "ю");
-    }
-
-    #[test]
-    fn test_letter_v() {
-        assert_eq!(normalizer().normalize("V"), "ви");
-    }
-
-    #[test]
-    fn test_letter_w() {
-        assert_eq!(normalizer().normalize("W"), "дабл ю");
-    }
-
-    #[test]
-    fn test_letter_x() {
-        assert_eq!(normalizer().normalize("X"), "экс");
-    }
-
-    #[test]
-    fn test_letter_y() {
-        assert_eq!(normalizer().normalize("Y"), "уай");
-    }
-
-    #[test]
-    fn test_letter_z() {
-        assert_eq!(normalizer().normalize("Z"), "зед");
-    }
-
-    // --- Case insensitivity tests ---
-
-    #[test]
-    fn test_json_lowercase() {
-        assert_eq!(normalizer().normalize("json"), "джейсон");
-    }
-
-    #[test]
-    fn test_json_mixed_case() {
-        assert_eq!(normalizer().normalize("Json"), "джейсон");
-    }
-
-    #[test]
-    fn test_api_lowercase() {
-        assert_eq!(normalizer().normalize("api"), "эй пи ай");
-    }
-
-    #[test]
-    fn test_api_mixed_case() {
-        assert_eq!(normalizer().normalize("Api"), "эй пи ай");
-    }
-
-    // --- Unknown abbreviations ---
-
-    #[test]
-    fn test_xyz_spelled_out() {
-        assert_eq!(normalizer().normalize("XYZ"), "экс уай зед");
-    }
-
-    #[test]
-    fn test_abc_spelled_out() {
-        assert_eq!(normalizer().normalize("ABC"), "эй би си");
-    }
-
-    #[test]
-    fn test_qrs_spelled_out() {
-        assert_eq!(normalizer().normalize("QRS"), "кью ар эс");
-    }
-
-    #[test]
-    fn test_wxyz_spelled_out() {
-        assert_eq!(normalizer().normalize("WXYZ"), "дабл ю экс уай зед");
-    }
-
-    // --- Mixed case special cases ---
-
-    #[test]
-    fn test_ios_special() {
-        assert_eq!(normalizer().normalize("iOS"), "ай оу эс");
-    }
-
-    #[test]
-    fn test_macos_special() {
-        assert_eq!(normalizer().normalize("macOS"), "мак оу эс");
-    }
-
-    #[test]
-    fn test_devops_as_word() {
-        assert_eq!(normalizer().normalize("DevOps"), "девопс");
-    }
-
-    #[test]
-    fn test_graphql_special() {
-        assert_eq!(normalizer().normalize("GraphQL"), "граф кью эл");
+    #[test_case("JSON" => "джейсон"; "json")]
+    #[test_case("YAML" => "ямл"; "yaml")]
+    #[test_case("TOML" => "томл"; "toml")]
+    #[test_case("REST" => "рест"; "rest")]
+    #[test_case("AJAX" => "эйджакс"; "ajax")]
+    #[test_case("CRUD" => "крад"; "crud")]
+    #[test_case("CORS" => "корс"; "cors")]
+    #[test_case("OAuth" => "о ауз"; "oauth")]
+    #[test_case("GIF" => "гиф"; "gif")]
+    #[test_case("JPEG" => "джейпег"; "jpeg")]
+    #[test_case("PNG" => "пи эн джи"; "png_spelled_out")]
+    #[test_case("RAM" => "рам"; "ram")]
+    #[test_case("ROM" => "ром"; "rom")]
+    #[test_case("LAN" => "лан"; "lan")]
+    #[test_case("WAN" => "ван"; "wan")]
+    #[test_case("SPA" => "спа"; "spa")]
+    #[test_case("DOM" => "дом"; "dom")]
+    #[test_case("GUI" => "гуи"; "gui")]
+    #[test_case("IMAP" => "ай мап"; "imap")]
+    #[test_case("POP" => "поп"; "pop")]
+    fn as_word_lookup(input: &str) -> String {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("HTTP" => "эйч ти ти пи"; "http")]
+    #[test_case("HTTPS" => "эйч ти ти пи эс"; "https")]
+    #[test_case("HTML" => "эйч ти эм эл"; "html")]
+    #[test_case("CSS" => "си эс эс"; "css")]
+    #[test_case("XML" => "экс эм эл"; "xml")]
+    #[test_case("URL" => "ю ар эл"; "url")]
+    #[test_case("URI" => "ю ар ай"; "uri")]
+    #[test_case("API" => "эй пи ай"; "api")]
+    #[test_case("SDK" => "эс ди кей"; "sdk")]
+    #[test_case("CLI" => "си эл ай"; "cli")]
+    #[test_case("IDE" => "ай ди и"; "ide")]
+    #[test_case("SSL" => "эс эс эл"; "ssl")]
+    #[test_case("TLS" => "ти эл эс"; "tls")]
+    #[test_case("SSH" => "эс эс эйч"; "ssh")]
+    #[test_case("VPN" => "ви пи эн"; "vpn")]
+    #[test_case("JWT" => "джей дабл ю ти"; "jwt")]
+    #[test_case("XSS" => "экс эс эс"; "xss")]
+    #[test_case("CSRF" => "си эс ар эф"; "csrf")]
+    #[test_case("TCP" => "ти си пи"; "tcp")]
+    #[test_case("UDP" => "ю ди пи"; "udp")]
+    #[test_case("FTP" => "эф ти пи"; "ftp")]
+    #[test_case("DNS" => "ди эн эс"; "dns")]
+    #[test_case("SMTP" => "эс эм ти пи"; "smtp")]
+    #[test_case("IP" => "ай пи"; "ip")]
+    #[test_case("CPU" => "си пи ю"; "cpu")]
+    #[test_case("GPU" => "джи пи ю"; "gpu")]
+    #[test_case("SSD" => "эс эс ди"; "ssd")]
+    #[test_case("HDD" => "эйч ди ди"; "hdd")]
+    #[test_case("USB" => "ю эс би"; "usb")]
+    #[test_case("HDMI" => "эйч ди эм ай"; "hdmi")]
+    #[test_case("UI" => "ю ай"; "ui")]
+    #[test_case("UX" => "ю экс"; "ux")]
+    #[test_case("CI" => "си ай"; "ci")]
+    #[test_case("CD" => "си ди"; "cd")]
+    #[test_case("AI" => "эй ай"; "ai")]
+    #[test_case("ML" => "эм эл"; "ml")]
+    #[test_case("NLP" => "эн эл пи"; "nlp")]
+    #[test_case("CV" => "си ви"; "cv")]
+    #[test_case("SQL" => "эс кью эл"; "sql")]
+    #[test_case("ORM" => "о ар эм"; "orm")]
+    #[test_case("MVC" => "эм ви си"; "mvc")]
+    #[test_case("MVP" => "эм ви пи"; "mvp")]
+    #[test_case("IoT" => "ай о ти"; "iot_special_case")]
+    #[test_case("SSR" => "эс эс ар"; "ssr")]
+    #[test_case("SSG" => "эс эс джи"; "ssg")]
+    #[test_case("CSR" => "си эс ар"; "csr")]
+    #[test_case("PWA" => "пи дабл ю эй"; "pwa")]
+    #[test_case("SVG" => "эс ви джи"; "svg")]
+    fn spelled_out(input: &str) -> String {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("A" => "эй"; "a")]
+    #[test_case("B" => "би"; "b")]
+    #[test_case("C" => "си"; "c")]
+    #[test_case("D" => "ди"; "d")]
+    #[test_case("E" => "и"; "e")]
+    #[test_case("F" => "эф"; "f")]
+    #[test_case("G" => "джи"; "g")]
+    #[test_case("H" => "эйч"; "h")]
+    #[test_case("I" => "ай"; "i")]
+    #[test_case("J" => "джей"; "j")]
+    #[test_case("K" => "кей"; "k")]
+    #[test_case("L" => "эл"; "l")]
+    #[test_case("M" => "эм"; "m")]
+    #[test_case("N" => "эн"; "n")]
+    #[test_case("O" => "о"; "o")]
+    #[test_case("P" => "пи"; "p")]
+    #[test_case("Q" => "кью"; "q")]
+    #[test_case("R" => "ар"; "r")]
+    #[test_case("S" => "эс"; "s")]
+    #[test_case("T" => "ти"; "t")]
+    #[test_case("U" => "ю"; "u")]
+    #[test_case("V" => "ви"; "v")]
+    #[test_case("W" => "дабл ю"; "w")]
+    #[test_case("X" => "экс"; "x")]
+    #[test_case("Y" => "уай"; "y")]
+    #[test_case("Z" => "зед"; "z")]
+    fn letter(input: &str) -> String {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("json" => "джейсон"; "json_lowercase")]
+    #[test_case("Json" => "джейсон"; "json_mixed_case")]
+    #[test_case("api" => "эй пи ай"; "api_lowercase")]
+    #[test_case("Api" => "эй пи ай"; "api_mixed_case")]
+    fn case_insensitive(input: &str) -> String {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("XYZ" => "экс уай зед"; "xyz")]
+    #[test_case("ABC" => "эй би си"; "abc")]
+    #[test_case("QRS" => "кью ар эс"; "qrs")]
+    #[test_case("WXYZ" => "дабл ю экс уай зед"; "wxyz")]
+    fn unknown_abbreviation(input: &str) -> String {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("iOS" => "ай оу эс"; "ios")]
+    #[test_case("macOS" => "мак оу эс"; "macos")]
+    #[test_case("DevOps" => "девопс"; "devops")]
+    #[test_case("GraphQL" => "граф кью эл"; "graphql")]
+    fn special_case(input: &str) -> String {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("" => ""; "empty_string")]
+    fn edge_case(input: &str) -> String {
+        normalizer().normalize(input)
     }
 
     // --- Public accessors ---
@@ -727,12 +320,5 @@ mod tests {
         let map = as_word();
         assert_eq!(map.get("json"), Some(&"джейсон"));
         assert_eq!(map.get("api"), None); // api is spelled out, not in AS_WORD
-    }
-
-    // --- Edge cases ---
-
-    #[test]
-    fn test_empty_string() {
-        assert_eq!(normalizer().normalize(""), "");
     }
 }

--- a/src-tauri/src/pipeline/normalizers/symbols.rs
+++ b/src-tauri/src/pipeline/normalizers/symbols.rs
@@ -133,597 +133,188 @@ impl Default for SymbolNormalizer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     fn normalizer() -> SymbolNormalizer {
         SymbolNormalizer::new()
     }
 
-    // --- Arrow operators ---
-
-    #[test]
-    fn test_arrow_right() {
-        assert_eq!(normalizer().normalize("->"), "стрелка");
-    }
-
-    #[test]
-    fn test_arrow_fat() {
-        assert_eq!(normalizer().normalize("=>"), "толстая стрелка");
-    }
-
-    #[test]
-    fn test_arrow_left() {
-        assert_eq!(normalizer().normalize("<-"), "стрелка влево");
-    }
-
-    #[test]
-    fn test_arrow_bidirectional() {
-        assert_eq!(normalizer().normalize("<->"), "двунаправленная стрелка");
-    }
-
-    // --- Comparison operators ---
-
-    #[test]
-    fn test_gte() {
-        assert_eq!(normalizer().normalize(">="), "больше или равно");
-    }
-
-    #[test]
-    fn test_lte() {
-        assert_eq!(normalizer().normalize("<="), "меньше или равно");
-    }
-
-    #[test]
-    fn test_neq() {
-        assert_eq!(normalizer().normalize("!="), "не равно");
-    }
-
-    #[test]
-    fn test_eqeq() {
-        assert_eq!(normalizer().normalize("=="), "равно равно");
-    }
-
-    #[test]
-    fn test_strict_eq() {
-        assert_eq!(normalizer().normalize("==="), "строго равно");
-    }
-
-    #[test]
-    fn test_strict_neq() {
-        assert_eq!(normalizer().normalize("!=="), "строго не равно");
-    }
-
-    #[test]
-    fn test_lt() {
-        assert_eq!(normalizer().normalize("<"), "меньше");
-    }
-
-    #[test]
-    fn test_gt() {
-        assert_eq!(normalizer().normalize(">"), "больше");
-    }
-
-    #[test]
-    fn test_eq() {
-        assert_eq!(normalizer().normalize("="), "равно");
-    }
-
-    // --- Logical operators ---
-
-    #[test]
-    fn test_and() {
-        assert_eq!(normalizer().normalize("&&"), "и");
-    }
-
-    #[test]
-    fn test_or() {
-        assert_eq!(normalizer().normalize("||"), "или");
-    }
-
-    #[test]
-    fn test_bang() {
-        assert_eq!(normalizer().normalize("!"), "восклицательный знак");
-    }
-
-    #[test]
-    fn test_nullish_coalescing() {
-        assert_eq!(normalizer().normalize("??"), "нулевое слияние");
-    }
-
-    #[test]
-    fn test_optional_chain() {
-        assert_eq!(normalizer().normalize("?."), "опциональная цепочка");
-    }
-
-    #[test]
-    fn test_question_mark() {
-        assert_eq!(normalizer().normalize("?"), "вопросительный знак");
-    }
-
-    // --- Arithmetic operators ---
-
-    #[test]
-    fn test_plus() {
-        assert_eq!(normalizer().normalize("+"), "плюс");
-    }
-
-    #[test]
-    fn test_minus() {
-        assert_eq!(normalizer().normalize("-"), "минус");
-    }
-
-    #[test]
-    fn test_mul() {
-        assert_eq!(normalizer().normalize("*"), "умножить");
-    }
-
-    #[test]
-    fn test_div() {
-        assert_eq!(normalizer().normalize("/"), "делить");
-    }
-
-    #[test]
-    fn test_pow() {
-        assert_eq!(normalizer().normalize("**"), "степень");
-    }
-
-    #[test]
-    fn test_floor_div() {
-        assert_eq!(normalizer().normalize("//"), "целочисленное деление");
-    }
-
-    #[test]
-    fn test_percent() {
-        assert_eq!(normalizer().normalize("%"), "процент");
-    }
-
-    #[test]
-    fn test_inc() {
-        assert_eq!(normalizer().normalize("++"), "плюс плюс");
-    }
-
-    #[test]
-    fn test_dec() {
-        assert_eq!(normalizer().normalize("--"), "минус минус");
-    }
-
-    // --- Assignment operators ---
-
-    #[test]
-    fn test_plus_assign() {
-        assert_eq!(normalizer().normalize("+="), "плюс равно");
-    }
-
-    #[test]
-    fn test_minus_assign() {
-        assert_eq!(normalizer().normalize("-="), "минус равно");
-    }
-
-    #[test]
-    fn test_mul_assign() {
-        assert_eq!(normalizer().normalize("*="), "умножить равно");
-    }
-
-    #[test]
-    fn test_div_assign() {
-        assert_eq!(normalizer().normalize("/="), "делить равно");
-    }
-
-    #[test]
-    fn test_walrus() {
-        assert_eq!(normalizer().normalize(":="), "присваивание");
-    }
-
-    // --- Bitwise operators ---
-
-    #[test]
-    fn test_bitwise_and() {
-        assert_eq!(normalizer().normalize("&"), "амперсанд");
-    }
-
-    #[test]
-    fn test_pipe() {
-        assert_eq!(normalizer().normalize("|"), "пайп");
-    }
-
-    #[test]
-    fn test_caret() {
-        assert_eq!(normalizer().normalize("^"), "каретка");
-    }
-
-    #[test]
-    fn test_tilde() {
-        assert_eq!(normalizer().normalize("~"), "тильда");
-    }
-
-    #[test]
-    fn test_shl() {
-        assert_eq!(normalizer().normalize("<<"), "сдвиг влево");
-    }
-
-    #[test]
-    fn test_shr() {
-        assert_eq!(normalizer().normalize(">>"), "сдвиг вправо");
-    }
-
-    // --- Scope / access operators ---
-
-    #[test]
-    fn test_double_colon() {
-        assert_eq!(normalizer().normalize("::"), "двойное двоеточие");
-    }
-
-    #[test]
-    fn test_dot() {
-        assert_eq!(normalizer().normalize("."), "точка");
-    }
-
-    #[test]
-    fn test_comma() {
-        assert_eq!(normalizer().normalize(","), "запятая");
-    }
-
-    #[test]
-    fn test_colon() {
-        assert_eq!(normalizer().normalize(":"), "двоеточие");
-    }
-
-    #[test]
-    fn test_semicolon() {
-        assert_eq!(normalizer().normalize(";"), "точка с запятой");
-    }
-
-    // --- Brackets ---
-
-    #[test]
-    fn test_paren_open() {
-        assert_eq!(normalizer().normalize("("), "открывающая скобка");
-    }
-
-    #[test]
-    fn test_paren_close() {
-        assert_eq!(normalizer().normalize(")"), "закрывающая скобка");
-    }
-
-    #[test]
-    fn test_bracket_open() {
-        assert_eq!(normalizer().normalize("["), "открывающая квадратная скобка");
-    }
-
-    #[test]
-    fn test_bracket_close() {
-        assert_eq!(normalizer().normalize("]"), "закрывающая квадратная скобка");
-    }
-
-    #[test]
-    fn test_brace_open() {
-        assert_eq!(normalizer().normalize("{"), "открывающая фигурная скобка");
-    }
-
-    #[test]
-    fn test_brace_close() {
-        assert_eq!(normalizer().normalize("}"), "закрывающая фигурная скобка");
-    }
-
-    // --- Punctuation ---
-
-    #[test]
-    fn test_ellipsis() {
-        assert_eq!(normalizer().normalize("..."), "троеточие");
-    }
-
-    #[test]
-    fn test_underscore() {
-        assert_eq!(normalizer().normalize("_"), "нижнее подчёркивание");
-    }
-
-    #[test]
-    fn test_backslash() {
-        assert_eq!(normalizer().normalize("\\"), "бэкслэш");
-    }
-
-    // --- Special characters ---
-
-    #[test]
-    fn test_at() {
-        assert_eq!(normalizer().normalize("@"), "собака");
-    }
-
-    #[test]
-    fn test_hash() {
-        assert_eq!(normalizer().normalize("#"), "решётка");
-    }
-
-    #[test]
-    fn test_dollar() {
-        assert_eq!(normalizer().normalize("$"), "доллар");
-    }
-
-    // --- Quotes ---
-
-    #[test]
-    fn test_double_quote() {
-        assert_eq!(normalizer().normalize("\""), "кавычка");
-    }
-
-    #[test]
-    fn test_single_quote() {
-        assert_eq!(normalizer().normalize("'"), "апостроф");
-    }
-
-    #[test]
-    fn test_backtick() {
-        assert_eq!(normalizer().normalize("`"), "обратная кавычка");
-    }
-
-    #[test]
-    fn test_lquote() {
-        assert_eq!(normalizer().normalize("«"), "открывающая кавычка");
-    }
-
-    #[test]
-    fn test_rquote() {
-        assert_eq!(normalizer().normalize("»"), "закрывающая кавычка");
-    }
-
-    // --- Unicode symbols ---
-
-    #[test]
-    fn test_copyright() {
-        assert_eq!(normalizer().normalize("©"), "копирайт");
-    }
-
-    #[test]
-    fn test_registered() {
-        assert_eq!(normalizer().normalize("®"), "зарегистрировано");
-    }
-
-    #[test]
-    fn test_trademark() {
-        assert_eq!(normalizer().normalize("™"), "торговая марка");
-    }
-
-    #[test]
-    fn test_degree() {
-        assert_eq!(normalizer().normalize("°"), "градус");
-    }
-
-    #[test]
-    fn test_plus_minus() {
-        assert_eq!(normalizer().normalize("±"), "плюс минус");
-    }
-
-    // --- Greek letters (lowercase) ---
-
-    #[test]
-    fn test_alpha() {
-        assert_eq!(normalizer().normalize("α"), "альфа");
-    }
-
-    #[test]
-    fn test_beta() {
-        assert_eq!(normalizer().normalize("β"), "бета");
-    }
-
-    #[test]
-    fn test_gamma() {
-        assert_eq!(normalizer().normalize("γ"), "гамма");
-    }
-
-    #[test]
-    fn test_delta() {
-        assert_eq!(normalizer().normalize("δ"), "дельта");
-    }
-
-    #[test]
-    fn test_epsilon() {
-        assert_eq!(normalizer().normalize("ε"), "эпсилон");
-    }
-
-    #[test]
-    fn test_lambda() {
-        assert_eq!(normalizer().normalize("λ"), "лямбда");
-    }
-
-    #[test]
-    fn test_pi() {
-        assert_eq!(normalizer().normalize("π"), "пи");
-    }
-
-    #[test]
-    fn test_sigma() {
-        assert_eq!(normalizer().normalize("σ"), "сигма");
-    }
-
-    #[test]
-    fn test_tau() {
-        assert_eq!(normalizer().normalize("τ"), "тау");
-    }
-
-    #[test]
-    fn test_phi() {
-        assert_eq!(normalizer().normalize("φ"), "фи");
-    }
-
-    #[test]
-    fn test_omega() {
-        assert_eq!(normalizer().normalize("ω"), "омега");
-    }
-
-    // --- Greek letters (uppercase) ---
-
-    #[test]
-    fn test_alpha_upper() {
-        assert_eq!(normalizer().normalize("Α"), "альфа");
-    }
-
-    #[test]
-    fn test_beta_upper() {
-        assert_eq!(normalizer().normalize("Β"), "бета");
-    }
-
-    #[test]
-    fn test_gamma_upper() {
-        assert_eq!(normalizer().normalize("Γ"), "гамма");
-    }
-
-    #[test]
-    fn test_delta_upper() {
-        assert_eq!(normalizer().normalize("Δ"), "дельта");
-    }
-
-    #[test]
-    fn test_lambda_upper() {
-        assert_eq!(normalizer().normalize("Λ"), "лямбда");
-    }
-
-    #[test]
-    fn test_pi_upper() {
-        assert_eq!(normalizer().normalize("Π"), "пи");
-    }
-
-    #[test]
-    fn test_sigma_upper() {
-        assert_eq!(normalizer().normalize("Σ"), "сигма");
-    }
-
-    #[test]
-    fn test_omega_upper() {
-        assert_eq!(normalizer().normalize("Ω"), "омега");
-    }
-
-    // --- Math symbols ---
-
-    #[test]
-    fn test_infinity() {
-        assert_eq!(normalizer().normalize("∞"), "бесконечность");
-    }
-
-    #[test]
-    fn test_in() {
-        assert_eq!(normalizer().normalize("∈"), "принадлежит");
-    }
-
-    #[test]
-    fn test_not_in() {
-        assert_eq!(normalizer().normalize("∉"), "не принадлежит");
-    }
-
-    #[test]
-    fn test_for_all() {
-        assert_eq!(normalizer().normalize("∀"), "для всех");
-    }
-
-    #[test]
-    fn test_exists() {
-        assert_eq!(normalizer().normalize("∃"), "существует");
-    }
-
-    #[test]
-    fn test_empty_set() {
-        assert_eq!(normalizer().normalize("∅"), "пустое множество");
-    }
-
-    #[test]
-    fn test_intersection() {
-        assert_eq!(normalizer().normalize("∩"), "пересечение");
-    }
-
-    #[test]
-    fn test_union() {
-        assert_eq!(normalizer().normalize("∪"), "объединение");
-    }
-
-    #[test]
-    fn test_subset() {
-        assert_eq!(normalizer().normalize("⊂"), "подмножество");
-    }
-
-    #[test]
-    fn test_not_equal_unicode() {
-        assert_eq!(normalizer().normalize("≠"), "не равно");
-    }
-
-    #[test]
-    fn test_approx() {
-        assert_eq!(normalizer().normalize("≈"), "приблизительно равно");
-    }
-
-    #[test]
-    fn test_lte_unicode() {
-        assert_eq!(normalizer().normalize("≤"), "меньше или равно");
-    }
-
-    #[test]
-    fn test_gte_unicode() {
-        assert_eq!(normalizer().normalize("≥"), "больше или равно");
-    }
-
-    #[test]
-    fn test_times() {
-        assert_eq!(normalizer().normalize("×"), "умножить");
-    }
-
-    #[test]
-    fn test_divide_unicode() {
-        assert_eq!(normalizer().normalize("÷"), "разделить");
-    }
-
-    #[test]
-    fn test_sqrt() {
-        assert_eq!(normalizer().normalize("√"), "корень");
-    }
-
-    #[test]
-    fn test_sum() {
-        assert_eq!(normalizer().normalize("∑"), "сумма");
-    }
-
-    #[test]
-    fn test_product() {
-        assert_eq!(normalizer().normalize("∏"), "произведение");
-    }
-
-    // --- Arrow symbols (Unicode) ---
-
-    #[test]
-    fn test_arrow_unicode_right() {
-        assert_eq!(normalizer().normalize("→"), "стрелка");
-    }
-
-    #[test]
-    fn test_arrow_unicode_left() {
-        assert_eq!(normalizer().normalize("←"), "стрелка влево");
-    }
-
-    #[test]
-    fn test_arrow_unicode_bidir() {
-        assert_eq!(normalizer().normalize("↔"), "двунаправленная стрелка");
-    }
-
-    #[test]
-    fn test_double_arrow_right() {
-        assert_eq!(normalizer().normalize("⇒"), "следует");
-    }
-
-    #[test]
-    fn test_double_arrow_left() {
-        assert_eq!(normalizer().normalize("⇐"), "следует из");
-    }
-
-    #[test]
-    fn test_double_arrow_bidir() {
-        assert_eq!(normalizer().normalize("⇔"), "эквивалентно");
-    }
-
-    // --- Unknown symbol passthrough ---
-
-    #[test]
-    fn test_unknown_symbol_passthrough() {
-        assert_eq!(normalizer().normalize("§"), "§");
-    }
-
-    #[test]
-    fn test_unknown_word_passthrough() {
-        assert_eq!(normalizer().normalize("hello"), "hello");
+    #[test_case("->" => "стрелка"; "right")]
+    #[test_case("=>" => "толстая стрелка"; "fat")]
+    #[test_case("<-" => "стрелка влево"; "left")]
+    #[test_case("<->" => "двунаправленная стрелка"; "bidirectional")]
+    fn arrow_operator(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case(">=" => "больше или равно"; "gte")]
+    #[test_case("<=" => "меньше или равно"; "lte")]
+    #[test_case("!=" => "не равно"; "neq")]
+    #[test_case("==" => "равно равно"; "eqeq")]
+    #[test_case("===" => "строго равно"; "strict_eq")]
+    #[test_case("!==" => "строго не равно"; "strict_neq")]
+    #[test_case("<" => "меньше"; "lt")]
+    #[test_case(">" => "больше"; "gt")]
+    #[test_case("=" => "равно"; "eq")]
+    fn comparison_operator(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("&&" => "и"; "and")]
+    #[test_case("||" => "или"; "or")]
+    #[test_case("!" => "восклицательный знак"; "bang")]
+    #[test_case("??" => "нулевое слияние"; "nullish_coalescing")]
+    #[test_case("?." => "опциональная цепочка"; "optional_chain")]
+    #[test_case("?" => "вопросительный знак"; "question_mark")]
+    fn logical_operator(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("+" => "плюс"; "plus")]
+    #[test_case("-" => "минус"; "minus")]
+    #[test_case("*" => "умножить"; "mul")]
+    #[test_case("/" => "делить"; "div")]
+    #[test_case("**" => "степень"; "pow")]
+    #[test_case("//" => "целочисленное деление"; "floor_div")]
+    #[test_case("%" => "процент"; "percent")]
+    #[test_case("++" => "плюс плюс"; "inc")]
+    #[test_case("--" => "минус минус"; "dec")]
+    fn arithmetic_operator(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("+=" => "плюс равно"; "plus_assign")]
+    #[test_case("-=" => "минус равно"; "minus_assign")]
+    #[test_case("*=" => "умножить равно"; "mul_assign")]
+    #[test_case("/=" => "делить равно"; "div_assign")]
+    #[test_case(":=" => "присваивание"; "walrus")]
+    fn assignment_operator(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("&" => "амперсанд"; "bitwise_and")]
+    #[test_case("|" => "пайп"; "pipe")]
+    #[test_case("^" => "каретка"; "caret")]
+    #[test_case("~" => "тильда"; "tilde")]
+    #[test_case("<<" => "сдвиг влево"; "shl")]
+    #[test_case(">>" => "сдвиг вправо"; "shr")]
+    fn bitwise_operator(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("::" => "двойное двоеточие"; "double_colon")]
+    #[test_case("." => "точка"; "dot")]
+    #[test_case("," => "запятая"; "comma")]
+    #[test_case(":" => "двоеточие"; "colon")]
+    #[test_case(";" => "точка с запятой"; "semicolon")]
+    fn scope_operator(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("(" => "открывающая скобка"; "paren_open")]
+    #[test_case(")" => "закрывающая скобка"; "paren_close")]
+    #[test_case("[" => "открывающая квадратная скобка"; "bracket_open")]
+    #[test_case("]" => "закрывающая квадратная скобка"; "bracket_close")]
+    #[test_case("{" => "открывающая фигурная скобка"; "brace_open")]
+    #[test_case("}" => "закрывающая фигурная скобка"; "brace_close")]
+    fn bracket(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("..." => "троеточие"; "ellipsis")]
+    #[test_case("_" => "нижнее подчёркивание"; "underscore")]
+    #[test_case("\\" => "бэкслэш"; "backslash")]
+    fn punctuation(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("@" => "собака"; "at")]
+    #[test_case("#" => "решётка"; "hash")]
+    #[test_case("$" => "доллар"; "dollar")]
+    fn special_character(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("\"" => "кавычка"; "double_quote")]
+    #[test_case("'" => "апостроф"; "single_quote")]
+    #[test_case("`" => "обратная кавычка"; "backtick")]
+    #[test_case("«" => "открывающая кавычка"; "lquote")]
+    #[test_case("»" => "закрывающая кавычка"; "rquote")]
+    fn quote(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("©" => "копирайт"; "copyright")]
+    #[test_case("®" => "зарегистрировано"; "registered")]
+    #[test_case("™" => "торговая марка"; "trademark")]
+    #[test_case("°" => "градус"; "degree")]
+    #[test_case("±" => "плюс минус"; "plus_minus")]
+    fn unicode_symbol(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("α" => "альфа"; "alpha")]
+    #[test_case("β" => "бета"; "beta")]
+    #[test_case("γ" => "гамма"; "gamma")]
+    #[test_case("δ" => "дельта"; "delta")]
+    #[test_case("ε" => "эпсилон"; "epsilon")]
+    #[test_case("λ" => "лямбда"; "lambda")]
+    #[test_case("π" => "пи"; "pi")]
+    #[test_case("σ" => "сигма"; "sigma")]
+    #[test_case("τ" => "тау"; "tau")]
+    #[test_case("φ" => "фи"; "phi")]
+    #[test_case("ω" => "омега"; "omega")]
+    fn greek_letter_lower(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("Α" => "альфа"; "alpha_upper")]
+    #[test_case("Β" => "бета"; "beta_upper")]
+    #[test_case("Γ" => "гамма"; "gamma_upper")]
+    #[test_case("Δ" => "дельта"; "delta_upper")]
+    #[test_case("Λ" => "лямбда"; "lambda_upper")]
+    #[test_case("Π" => "пи"; "pi_upper")]
+    #[test_case("Σ" => "сигма"; "sigma_upper")]
+    #[test_case("Ω" => "омега"; "omega_upper")]
+    fn greek_letter_upper(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("∞" => "бесконечность"; "infinity")]
+    #[test_case("∈" => "принадлежит"; "in_set")]
+    #[test_case("∉" => "не принадлежит"; "not_in")]
+    #[test_case("∀" => "для всех"; "for_all")]
+    #[test_case("∃" => "существует"; "exists")]
+    #[test_case("∅" => "пустое множество"; "empty_set")]
+    #[test_case("∩" => "пересечение"; "intersection")]
+    #[test_case("∪" => "объединение"; "union")]
+    #[test_case("⊂" => "подмножество"; "subset")]
+    #[test_case("≠" => "не равно"; "not_equal_unicode")]
+    #[test_case("≈" => "приблизительно равно"; "approx")]
+    #[test_case("≤" => "меньше или равно"; "lte_unicode")]
+    #[test_case("≥" => "больше или равно"; "gte_unicode")]
+    #[test_case("×" => "умножить"; "times")]
+    #[test_case("÷" => "разделить"; "divide_unicode")]
+    #[test_case("√" => "корень"; "sqrt")]
+    #[test_case("∑" => "сумма"; "sum")]
+    #[test_case("∏" => "произведение"; "product")]
+    fn math_symbol(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("→" => "стрелка"; "arrow_unicode_right")]
+    #[test_case("←" => "стрелка влево"; "arrow_unicode_left")]
+    #[test_case("↔" => "двунаправленная стрелка"; "arrow_unicode_bidir")]
+    #[test_case("⇒" => "следует"; "double_arrow_right")]
+    #[test_case("⇐" => "следует из"; "double_arrow_left")]
+    #[test_case("⇔" => "эквивалентно"; "double_arrow_bidir")]
+    fn arrow_symbol(input: &str) -> &str {
+        normalizer().normalize(input)
+    }
+
+    #[test_case("§" => "§"; "unknown_symbol_passthrough")]
+    #[test_case("hello" => "hello"; "unknown_word_passthrough")]
+    fn passthrough(input: &str) -> &str {
+        normalizer().normalize(input)
     }
 }


### PR DESCRIPTION
## Summary

Part of the "Оздоровление тестов RuVox" epic, task S6b: apply the S6a pattern
(numbers.rs, `test-case` 3.3.1 dev-dep) to `symbols.rs` and `abbreviations.rs`
— replace one-assertion-per-test functions with `#[test_case(input => expected;
"name")]` tables, grouped one function per test category. Production code is
untouched; the diff is confined to `mod tests` in both files.

## Reconciliation

Coverage is strictly 1:1: every original test case became one `#[test_case]`
row with unchanged expectations. Verified mechanically by diffing the multiset
of `(input, expected)` pairs extracted from the old `assert_eq!` calls against
the new `test_case` attributes — exact match, no additions/removals.

### symbols.rs — 111 tests before, 111 rows after (17 category functions)

| Category function      | Cases |
|-------------------------|------:|
| arrow_operator          | 4 |
| comparison_operator     | 9 |
| logical_operator        | 6 |
| arithmetic_operator     | 9 |
| assignment_operator     | 5 |
| bitwise_operator        | 6 |
| scope_operator          | 5 |
| bracket                 | 6 |
| punctuation             | 3 |
| special_character       | 3 |
| quote                   | 5 |
| unicode_symbol          | 5 |
| greek_letter_lower      | 11 |
| greek_letter_upper      | 8 |
| math_symbol             | 18 |
| arrow_symbol            | 6 |
| passthrough             | 2 |
| **Total**               | **111** |

### abbreviations.rs — 109 tests before, 109 after (107 converted + 2 kept as-is)

| Category function      | Cases |
|-------------------------|------:|
| as_word_lookup          | 20 |
| spelled_out             | 48 |
| letter                  | 26 |
| case_insensitive        | 4 |
| unknown_abbreviation    | 4 |
| special_case            | 4 |
| edge_case               | 1 |
| **Converted subtotal**  | **107** |
| `test_letter_map_accessible` (kept as `#[test]`) | 1 |
| `test_as_word_accessible` (kept as `#[test]`) | 1 |
| **Total**               | **109** |

The two kept-as-is tests assert on the `letter_map()` / `as_word()` public
accessors directly (map contents/length), not through `normalize()`, so they
don't fit the `input => expected` table shape and were left untouched.

Two naming adjustments were needed to compile:
- `∈` case renamed from `"in"` to `"in_set"` — `in` is a Rust keyword and
  can't be used as a `test_case` name (it becomes part of the generated
  function identifier).
- The `as_word` category function in `abbreviations.rs` was named
  `as_word_lookup` instead of `as_word`, since a bare `as_word` would shadow
  the module's `pub fn as_word()` accessor (imported via `use super::*;`)
  used by `test_as_word_accessible`.

## Test plan

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — clean
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 694 passed, 0 failed (lib), golden fixture test passed
- [x] `cargo test --lib pipeline::normalizers::symbols` — 111 passed
- [x] `cargo test --lib pipeline::normalizers::abbreviations` — 109 passed
- [x] Diffed lines before `mod tests` in both files against `HEAD` — byte-identical (no production code touched)