### PR TITLE
test(pipeline): convert code/urls/english/code_blocks tests to test_case tables

### DIFF
--- a/src-tauri/src/pipeline/normalizers/code.rs
+++ b/src-tauri/src/pipeline/normalizers/code.rs
@@ -657,446 +657,88 @@ impl Default for CodeIdentifierNormalizer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     fn normalizer() -> CodeIdentifierNormalizer {
         CodeIdentifierNormalizer::new()
     }
 
-    // --- CamelCase ---
+    // --- CamelCase / PascalCase (normalize_camel_case) ---
 
-    #[test]
-    fn camel_get_user_data() {
-        assert_eq!(
-            normalizer().normalize_camel_case("getUserData"),
-            "гет юзер дата"
-        );
+    #[test_case("getUserData" => "гет юзер дата"; "get_user_data")]
+    #[test_case("myVariable" => "май вэриабл"; "my_variable")]
+    #[test_case("isValid" => "из вэлид"; "is_valid")]
+    #[test_case("hasValue" => "хэз вэлью"; "has_value")]
+    #[test_case("onClick" => "он клик"; "on_click")]
+    #[test_case("onChange" => "он чейндж"; "on_change")]
+    #[test_case("handleSubmit" => "хендл сабмит"; "handle_submit")]
+    #[test_case("fetchData" => "фетч дата"; "fetch_data")]
+    #[test_case("parseJSON" => "парс джейсон"; "parse_json")]
+    #[test_case("toString" => "ту стринг"; "to_string")]
+    #[test_case("getUserDataFromServer" => "гет юзер дата фром сервер"; "get_user_data_from_server")]
+    #[test_case("calculateTotalPrice" => "калькулейт тотал прайс"; "calculate_total_price")]
+    #[test_case("isUserAuthenticated" => "из юзер аутентикейтед"; "is_user_authenticated")]
+    #[test_case("parseHTMLContent" => "парс эйч ти эм эл контент"; "parse_html_content")]
+    #[test_case("getAPIResponse" => "гет эй пи ай респонс"; "get_api_response")]
+    #[test_case("loadJSONData" => "лоуд джейсон дата"; "load_json_data")]
+    #[test_case("createURLPath" => "криейт ю ар эл пас"; "create_url_path")]
+    #[test_case("getUser2Data" => "гет юзер два дата"; "get_user2_data")]
+    #[test_case("item1Name" => "айтем один нейм"; "item1_name")]
+    #[test_case("UserService" => "юзер сервис"; "pascal_user_service")]
+    #[test_case("DataRepository" => "дата репозитори"; "pascal_data_repository")]
+    #[test_case("HttpClient" => "эйч ти ти пи клиент"; "pascal_http_client")]
+    #[test_case("ApiController" => "эй пи ай контроллер"; "pascal_api_controller")]
+    #[test_case("DatabaseConnection" => "датабейз коннекшн"; "pascal_database_connection")]
+    #[test_case("EventHandler" => "ивент хендлер"; "pascal_event_handler")]
+    #[test_case("FileManager" => "файл менеджер"; "pascal_file_manager")]
+    #[test_case("ConfigLoader" => "конфиг лоудер"; "pascal_config_loader")]
+    fn camel_case(input: &str) -> String {
+        normalizer().normalize_camel_case(input)
     }
 
-    #[test]
-    fn camel_my_variable() {
-        assert_eq!(
-            normalizer().normalize_camel_case("myVariable"),
-            "май вэриабл"
-        );
+    // --- SnakeCase / SCREAMING_SNAKE_CASE (normalize_snake_case) ---
+
+    #[test_case("get_user_data" => "гет юзер дата"; "get_user_data")]
+    #[test_case("my_variable" => "май вэриабл"; "my_variable")]
+    #[test_case("is_valid" => "из вэлид"; "is_valid")]
+    #[test_case("has_value" => "хэз вэлью"; "has_value")]
+    #[test_case("on_click" => "он клик"; "on_click")]
+    #[test_case("handle_submit" => "хендл сабмит"; "handle_submit")]
+    #[test_case("fetch_data" => "фетч дата"; "fetch_data")]
+    #[test_case("parse_json" => "парс джейсон"; "parse_json")]
+    #[test_case("get_user_data_from_server" => "гет юзер дата фром сервер"; "get_user_data_from_server")]
+    #[test_case("calculate_total_price" => "калькулейт тотал прайс"; "calculate_total_price")]
+    #[test_case("user_2_data" => "юзер два дата"; "user_2_data")]
+    #[test_case("item_1_name" => "айтем один нейм"; "item_1_name")]
+    #[test_case("__init__" => "инит"; "dunder_init")]
+    #[test_case("__str__" => "стр"; "dunder_str")]
+    #[test_case("__repr__" => "репр"; "dunder_repr")]
+    #[test_case("__len__" => "лен"; "dunder_len")]
+    #[test_case("_private_method" => "прайвит метод"; "private_method")]
+    #[test_case("__private_attr" => "прайвит аттр"; "private_attr")]
+    #[test_case("MAX_VALUE" => "макс вэлью"; "screaming_max_value")]
+    #[test_case("DEFAULT_TIMEOUT" => "дефолт таймаут"; "screaming_default_timeout")]
+    #[test_case("API_BASE_URL" => "эй пи ай бейз ю ар эл"; "screaming_api_base_url")]
+    fn snake_case(input: &str) -> String {
+        normalizer().normalize_snake_case(input)
     }
 
-    #[test]
-    fn camel_is_valid() {
-        assert_eq!(normalizer().normalize_camel_case("isValid"), "из вэлид");
-    }
+    // --- KebabCase (normalize_kebab_case) ---
 
-    #[test]
-    fn camel_has_value() {
-        assert_eq!(normalizer().normalize_camel_case("hasValue"), "хэз вэлью");
-    }
-
-    #[test]
-    fn camel_on_click() {
-        assert_eq!(normalizer().normalize_camel_case("onClick"), "он клик");
-    }
-
-    #[test]
-    fn camel_on_change() {
-        assert_eq!(normalizer().normalize_camel_case("onChange"), "он чейндж");
-    }
-
-    #[test]
-    fn camel_handle_submit() {
-        assert_eq!(
-            normalizer().normalize_camel_case("handleSubmit"),
-            "хендл сабмит"
-        );
-    }
-
-    #[test]
-    fn camel_fetch_data() {
-        assert_eq!(normalizer().normalize_camel_case("fetchData"), "фетч дата");
-    }
-
-    #[test]
-    fn camel_parse_json() {
-        assert_eq!(
-            normalizer().normalize_camel_case("parseJSON"),
-            "парс джейсон"
-        );
-    }
-
-    #[test]
-    fn camel_to_string() {
-        assert_eq!(normalizer().normalize_camel_case("toString"), "ту стринг");
-    }
-
-    #[test]
-    fn camel_get_user_data_from_server() {
-        assert_eq!(
-            normalizer().normalize_camel_case("getUserDataFromServer"),
-            "гет юзер дата фром сервер"
-        );
-    }
-
-    #[test]
-    fn camel_calculate_total_price() {
-        assert_eq!(
-            normalizer().normalize_camel_case("calculateTotalPrice"),
-            "калькулейт тотал прайс"
-        );
-    }
-
-    #[test]
-    fn camel_is_user_authenticated() {
-        assert_eq!(
-            normalizer().normalize_camel_case("isUserAuthenticated"),
-            "из юзер аутентикейтед"
-        );
-    }
-
-    #[test]
-    fn camel_parse_html_content() {
-        assert_eq!(
-            normalizer().normalize_camel_case("parseHTMLContent"),
-            "парс эйч ти эм эл контент"
-        );
-    }
-
-    #[test]
-    fn camel_get_api_response() {
-        assert_eq!(
-            normalizer().normalize_camel_case("getAPIResponse"),
-            "гет эй пи ай респонс"
-        );
-    }
-
-    #[test]
-    fn camel_load_json_data() {
-        assert_eq!(
-            normalizer().normalize_camel_case("loadJSONData"),
-            "лоуд джейсон дата"
-        );
-    }
-
-    #[test]
-    fn camel_create_url_path() {
-        assert_eq!(
-            normalizer().normalize_camel_case("createURLPath"),
-            "криейт ю ар эл пас"
-        );
-    }
-
-    #[test]
-    fn camel_get_user2_data() {
-        assert_eq!(
-            normalizer().normalize_camel_case("getUser2Data"),
-            "гет юзер два дата"
-        );
-    }
-
-    #[test]
-    fn camel_item1_name() {
-        assert_eq!(
-            normalizer().normalize_camel_case("item1Name"),
-            "айтем один нейм"
-        );
-    }
-
-    // --- PascalCase ---
-
-    #[test]
-    fn pascal_user_service() {
-        assert_eq!(
-            normalizer().normalize_camel_case("UserService"),
-            "юзер сервис"
-        );
-    }
-
-    #[test]
-    fn pascal_data_repository() {
-        assert_eq!(
-            normalizer().normalize_camel_case("DataRepository"),
-            "дата репозитори"
-        );
-    }
-
-    #[test]
-    fn pascal_http_client() {
-        assert_eq!(
-            normalizer().normalize_camel_case("HttpClient"),
-            "эйч ти ти пи клиент"
-        );
-    }
-
-    #[test]
-    fn pascal_api_controller() {
-        assert_eq!(
-            normalizer().normalize_camel_case("ApiController"),
-            "эй пи ай контроллер"
-        );
-    }
-
-    #[test]
-    fn pascal_database_connection() {
-        assert_eq!(
-            normalizer().normalize_camel_case("DatabaseConnection"),
-            "датабейз коннекшн"
-        );
-    }
-
-    #[test]
-    fn pascal_event_handler() {
-        assert_eq!(
-            normalizer().normalize_camel_case("EventHandler"),
-            "ивент хендлер"
-        );
-    }
-
-    #[test]
-    fn pascal_file_manager() {
-        assert_eq!(
-            normalizer().normalize_camel_case("FileManager"),
-            "файл менеджер"
-        );
-    }
-
-    #[test]
-    fn pascal_config_loader() {
-        assert_eq!(
-            normalizer().normalize_camel_case("ConfigLoader"),
-            "конфиг лоудер"
-        );
-    }
-
-    // --- SnakeCase ---
-
-    #[test]
-    fn snake_get_user_data() {
-        assert_eq!(
-            normalizer().normalize_snake_case("get_user_data"),
-            "гет юзер дата"
-        );
-    }
-
-    #[test]
-    fn snake_my_variable() {
-        assert_eq!(
-            normalizer().normalize_snake_case("my_variable"),
-            "май вэриабл"
-        );
-    }
-
-    #[test]
-    fn snake_is_valid() {
-        assert_eq!(normalizer().normalize_snake_case("is_valid"), "из вэлид");
-    }
-
-    #[test]
-    fn snake_has_value() {
-        assert_eq!(normalizer().normalize_snake_case("has_value"), "хэз вэлью");
-    }
-
-    #[test]
-    fn snake_on_click() {
-        assert_eq!(normalizer().normalize_snake_case("on_click"), "он клик");
-    }
-
-    #[test]
-    fn snake_handle_submit() {
-        assert_eq!(
-            normalizer().normalize_snake_case("handle_submit"),
-            "хендл сабмит"
-        );
-    }
-
-    #[test]
-    fn snake_fetch_data() {
-        assert_eq!(normalizer().normalize_snake_case("fetch_data"), "фетч дата");
-    }
-
-    #[test]
-    fn snake_parse_json() {
-        assert_eq!(
-            normalizer().normalize_snake_case("parse_json"),
-            "парс джейсон"
-        );
-    }
-
-    #[test]
-    fn snake_get_user_data_from_server() {
-        assert_eq!(
-            normalizer().normalize_snake_case("get_user_data_from_server"),
-            "гет юзер дата фром сервер"
-        );
-    }
-
-    #[test]
-    fn snake_calculate_total_price() {
-        assert_eq!(
-            normalizer().normalize_snake_case("calculate_total_price"),
-            "калькулейт тотал прайс"
-        );
-    }
-
-    #[test]
-    fn snake_user_2_data() {
-        assert_eq!(
-            normalizer().normalize_snake_case("user_2_data"),
-            "юзер два дата"
-        );
-    }
-
-    #[test]
-    fn snake_item_1_name() {
-        assert_eq!(
-            normalizer().normalize_snake_case("item_1_name"),
-            "айтем один нейм"
-        );
-    }
-
-    #[test]
-    fn snake_dunder_init() {
-        assert_eq!(normalizer().normalize_snake_case("__init__"), "инит");
-    }
-
-    #[test]
-    fn snake_dunder_str() {
-        assert_eq!(normalizer().normalize_snake_case("__str__"), "стр");
-    }
-
-    #[test]
-    fn snake_dunder_repr() {
-        assert_eq!(normalizer().normalize_snake_case("__repr__"), "репр");
-    }
-
-    #[test]
-    fn snake_dunder_len() {
-        assert_eq!(normalizer().normalize_snake_case("__len__"), "лен");
-    }
-
-    #[test]
-    fn snake_private_method() {
-        assert_eq!(
-            normalizer().normalize_snake_case("_private_method"),
-            "прайвит метод"
-        );
-    }
-
-    #[test]
-    fn snake_private_attr() {
-        assert_eq!(
-            normalizer().normalize_snake_case("__private_attr"),
-            "прайвит аттр"
-        );
-    }
-
-    // --- KebabCase ---
-
-    #[test]
-    fn kebab_my_component() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("my-component"),
-            "май компонент"
-        );
-    }
-
-    #[test]
-    fn kebab_button_primary() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("button-primary"),
-            "баттон праймари"
-        );
-    }
-
-    #[test]
-    fn kebab_nav_bar() {
-        assert_eq!(normalizer().normalize_kebab_case("nav-bar"), "нав бар");
-    }
-
-    #[test]
-    fn kebab_side_menu() {
-        assert_eq!(normalizer().normalize_kebab_case("side-menu"), "сайд меню");
-    }
-
-    #[test]
-    fn kebab_header_logo() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("header-logo"),
-            "хедер лого"
-        );
-    }
-
-    #[test]
-    fn kebab_footer_links() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("footer-links"),
-            "футер линкс"
-        );
-    }
-
-    #[test]
-    fn kebab_output_dir() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("output-dir"),
-            "аутпут дир"
-        );
-    }
-
-    #[test]
-    fn kebab_config_file() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("config-file"),
-            "конфиг файл"
-        );
-    }
-
-    #[test]
-    fn kebab_no_cache() {
-        assert_eq!(normalizer().normalize_kebab_case("no-cache"), "ноу кэш");
-    }
-
-    #[test]
-    fn kebab_dry_run() {
-        assert_eq!(normalizer().normalize_kebab_case("dry-run"), "драй ран");
-    }
-
-    #[test]
-    fn kebab_my_awesome_package() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("my-awesome-package"),
-            "май авесом пакет"
-        );
-    }
-
-    #[test]
-    fn kebab_react_dom() {
-        assert_eq!(normalizer().normalize_kebab_case("react-dom"), "риакт дом");
-    }
-
-    #[test]
-    fn kebab_vue_router() {
-        assert_eq!(
-            normalizer().normalize_kebab_case("vue-router"),
-            "вью роутер"
-        );
-    }
-
-    // --- SCREAMING_SNAKE_CASE (MixedIdentifiers) ---
-
-    #[test]
-    fn screaming_max_value() {
-        assert_eq!(normalizer().normalize_snake_case("MAX_VALUE"), "макс вэлью");
-    }
-
-    #[test]
-    fn screaming_default_timeout() {
-        assert_eq!(
-            normalizer().normalize_snake_case("DEFAULT_TIMEOUT"),
-            "дефолт таймаут"
-        );
-    }
-
-    #[test]
-    fn screaming_api_base_url() {
-        assert_eq!(
-            normalizer().normalize_snake_case("API_BASE_URL"),
-            "эй пи ай бейз ю ар эл"
-        );
+    #[test_case("my-component" => "май компонент"; "my_component")]
+    #[test_case("button-primary" => "баттон праймари"; "button_primary")]
+    #[test_case("nav-bar" => "нав бар"; "nav_bar")]
+    #[test_case("side-menu" => "сайд меню"; "side_menu")]
+    #[test_case("header-logo" => "хедер лого"; "header_logo")]
+    #[test_case("footer-links" => "футер линкс"; "footer_links")]
+    #[test_case("output-dir" => "аутпут дир"; "output_dir")]
+    #[test_case("config-file" => "конфиг файл"; "config_file")]
+    #[test_case("no-cache" => "ноу кэш"; "no_cache")]
+    #[test_case("dry-run" => "драй ран"; "dry_run")]
+    #[test_case("my-awesome-package" => "май авесом пакет"; "my_awesome_package")]
+    #[test_case("react-dom" => "риакт дом"; "react_dom")]
+    #[test_case("vue-router" => "вью роутер"; "vue_router")]
+    fn kebab_case(input: &str) -> String {
+        normalizer().normalize_kebab_case(input)
     }
 }

--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -464,6 +464,7 @@ fn number_to_russian(n: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     fn brief_handler() -> CodeBlockHandler {
         CodeBlockHandler::with_mode(CodeBlockMode::Brief)
@@ -473,156 +474,54 @@ mod tests {
         CodeBlockHandler::with_mode(CodeBlockMode::Full)
     }
 
-    // ── TestCodeBlockBriefMode (14 cases) ──────────────────────────────
+    // ── Brief mode language descriptions (merges former TestCodeBlockBriefMode
+    // and TestLanguageNames — brief_description() ignores `code` entirely, so
+    // both groups exercised the same function keyed only on `language`; the
+    // 5 overlapping codes [python, javascript, typescript, bash, yaml] were
+    // genuine duplicates, now asserted once each with the (stronger) exact
+    // sentence instead of the former `.contains()` check) ──────────────────
 
-    #[test]
-    fn brief_python() {
-        assert_eq!(
-            brief_handler().process_block("print('hello')", Some("python")),
-            "далее следует пример кода на пайтон"
-        );
-    }
-
-    #[test]
-    fn brief_javascript() {
-        assert_eq!(
-            brief_handler().process_block("const x = 1;", Some("javascript")),
-            "далее следует пример кода на джаваскрипт"
-        );
-    }
-
-    #[test]
-    fn brief_typescript() {
-        assert_eq!(
-            brief_handler().process_block("let y: string;", Some("typescript")),
-            "далее следует пример кода на тайпскрипт"
-        );
-    }
-
-    #[test]
-    fn brief_bash() {
-        assert_eq!(
-            brief_handler().process_block("echo hi", Some("bash")),
-            "далее следует пример кода на баш"
-        );
-    }
-
-    #[test]
-    fn brief_sql() {
-        assert_eq!(
-            brief_handler().process_block("SELECT 1", Some("sql")),
-            "далее следует пример кода на эс кью эл"
-        );
-    }
-
-    #[test]
-    fn brief_json() {
-        assert_eq!(
-            brief_handler().process_block("{}", Some("json")),
-            "далее следует пример кода на джейсон"
-        );
-    }
-
-    #[test]
-    fn brief_yaml() {
-        assert_eq!(
-            brief_handler().process_block("key: val", Some("yaml")),
-            "далее следует пример кода на ямл"
-        );
-    }
-
-    #[test]
-    fn brief_html() {
-        assert_eq!(
-            brief_handler().process_block("<p>hi</p>", Some("html")),
-            "далее следует пример кода на эйч ти эм эл"
-        );
-    }
-
-    #[test]
-    fn brief_css() {
-        assert_eq!(
-            brief_handler().process_block("body{}", Some("css")),
-            "далее следует пример кода на си эс эс"
-        );
-    }
-
-    #[test]
-    fn brief_go() {
-        assert_eq!(
-            brief_handler().process_block("func main(){}", Some("go")),
-            "далее следует пример кода на го"
-        );
-    }
-
-    #[test]
-    fn brief_rust() {
-        assert_eq!(
-            brief_handler().process_block("fn main(){}", Some("rust")),
-            "далее следует пример кода на раст"
-        );
-    }
-
-    #[test]
-    fn brief_java() {
-        assert_eq!(
-            brief_handler().process_block("class A{}", Some("java")),
-            "далее следует пример кода на джава"
-        );
-    }
-
-    #[test]
-    fn brief_no_language() {
-        assert_eq!(
-            brief_handler().process_block("x = 1", None),
-            "далее следует блок кода"
-        );
-    }
-
-    #[test]
-    fn brief_empty_language() {
-        assert_eq!(
-            brief_handler().process_block("x = 1", Some("")),
-            "далее следует блок кода"
-        );
+    #[test_case(Some("python") => "далее следует пример кода на пайтон"; "python")]
+    #[test_case(Some("py") => "далее следует пример кода на пайтон"; "py")]
+    #[test_case(Some("javascript") => "далее следует пример кода на джаваскрипт"; "javascript")]
+    #[test_case(Some("js") => "далее следует пример кода на джаваскрипт"; "js")]
+    #[test_case(Some("typescript") => "далее следует пример кода на тайпскрипт"; "typescript")]
+    #[test_case(Some("ts") => "далее следует пример кода на тайпскрипт"; "ts")]
+    #[test_case(Some("bash") => "далее следует пример кода на баш"; "bash")]
+    #[test_case(Some("sh") => "далее следует пример кода на шелл"; "sh")]
+    #[test_case(Some("shell") => "далее следует пример кода на шелл"; "shell")]
+    #[test_case(Some("sql") => "далее следует пример кода на эс кью эл"; "sql")]
+    #[test_case(Some("json") => "далее следует пример кода на джейсон"; "json")]
+    #[test_case(Some("yaml") => "далее следует пример кода на ямл"; "yaml")]
+    #[test_case(Some("yml") => "далее следует пример кода на ямл"; "yml")]
+    #[test_case(Some("html") => "далее следует пример кода на эйч ти эм эл"; "html")]
+    #[test_case(Some("css") => "далее следует пример кода на си эс эс"; "css")]
+    #[test_case(Some("go") => "далее следует пример кода на го"; "go")]
+    #[test_case(Some("rust") => "далее следует пример кода на раст"; "rust")]
+    #[test_case(Some("java") => "далее следует пример кода на джава"; "java")]
+    #[test_case(Some("md") => "далее следует пример кода на маркдаун"; "md")]
+    #[test_case(Some("markdown") => "далее следует пример кода на маркдаун"; "markdown")]
+    #[test_case(Some("cpp") => "далее следует пример кода на си плюс плюс"; "cpp")]
+    #[test_case(Some("c++") => "далее следует пример кода на си плюс плюс"; "cpp_symbol")]
+    #[test_case(Some("cs") => "далее следует пример кода на си шарп"; "cs")]
+    #[test_case(Some("csharp") => "далее следует пример кода на си шарп"; "csharp")]
+    #[test_case(Some("dockerfile") => "далее следует пример кода на докерфайл"; "dockerfile")]
+    #[test_case(Some("makefile") => "далее следует пример кода на мейкфайл"; "makefile")]
+    #[test_case(None => "далее следует блок кода"; "no_language")]
+    #[test_case(Some("") => "далее следует блок кода"; "empty_language")]
+    fn brief_language(language: Option<&str>) -> String {
+        brief_handler().process_block("", language)
     }
 
     // ── TestCodeBlockFullMode (3 cases) ────────────────────────────────
 
-    #[test]
-    fn full_python_def_hello() {
-        let result =
-            full_handler().process_block("def hello():\n    print('world')", Some("python"));
+    #[test_case("def hello():\n    print('world')", Some("python"), &["деф", "хелло", "принт", "ворлд"]; "python_def_hello")]
+    #[test_case("const x = 42;", Some("javascript"), &["конст", "икс", "сорок два"]; "js_const_x")]
+    #[test_case("getUserData(userId)", None, &["гет юзер дата", "юзер ай ди"]; "function_call")]
+    fn full_mode(code: &str, language: Option<&str>, expected_substrings: &[&str]) {
+        let result = full_handler().process_block(code, language);
         let lower = result.to_lowercase();
-        for expected in &["деф", "хелло", "принт", "ворлд"] {
-            assert!(
-                lower.contains(expected),
-                "expected {:?} in {:?}",
-                expected,
-                result
-            );
-        }
-    }
-
-    #[test]
-    fn full_js_const_x() {
-        let result = full_handler().process_block("const x = 42;", Some("javascript"));
-        let lower = result.to_lowercase();
-        for expected in &["конст", "икс", "сорок два"] {
-            assert!(
-                lower.contains(expected),
-                "expected {:?} in {:?}",
-                expected,
-                result
-            );
-        }
-    }
-
-    #[test]
-    fn full_function_call() {
-        let result = full_handler().process_block("getUserData(userId)", None);
-        let lower = result.to_lowercase();
-        for expected in &["гет юзер дата", "юзер ай ди"] {
+        for expected in expected_substrings {
             assert!(
                 lower.contains(expected),
                 "expected {:?} in {:?}",
@@ -634,18 +533,12 @@ mod tests {
 
     // ── TestModeSwitch (4 cases) ────────────────────────────────────────
 
-    #[test]
-    fn mode_switch_to_brief() {
-        let mut h = CodeBlockHandler::with_mode(CodeBlockMode::Full);
-        h.set_mode(CodeBlockMode::Brief);
-        assert_eq!(h.mode(), CodeBlockMode::Brief);
-    }
-
-    #[test]
-    fn mode_switch_to_full() {
-        let mut h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
-        h.set_mode(CodeBlockMode::Full);
-        assert_eq!(h.mode(), CodeBlockMode::Full);
+    #[test_case(CodeBlockMode::Full, CodeBlockMode::Brief; "to_brief")]
+    #[test_case(CodeBlockMode::Brief, CodeBlockMode::Full; "to_full")]
+    fn mode_switch(initial: CodeBlockMode, set_to: CodeBlockMode) {
+        let mut h = CodeBlockHandler::with_mode(initial);
+        h.set_mode(set_to);
+        assert_eq!(h.mode(), set_to);
     }
 
     #[test]
@@ -669,142 +562,6 @@ mod tests {
             "expected full-mode output, got: {:?}",
             result
         );
-    }
-
-    // ── TestLanguageNames (19 cases) ────────────────────────────────────
-
-    #[test]
-    fn lang_py() {
-        assert!(brief_handler()
-            .process_block("", Some("py"))
-            .contains("пайтон"));
-    }
-
-    #[test]
-    fn lang_python() {
-        assert!(brief_handler()
-            .process_block("", Some("python"))
-            .contains("пайтон"));
-    }
-
-    #[test]
-    fn lang_js() {
-        assert!(brief_handler()
-            .process_block("", Some("js"))
-            .contains("джаваскрипт"));
-    }
-
-    #[test]
-    fn lang_javascript() {
-        assert!(brief_handler()
-            .process_block("", Some("javascript"))
-            .contains("джаваскрипт"));
-    }
-
-    #[test]
-    fn lang_ts() {
-        assert!(brief_handler()
-            .process_block("", Some("ts"))
-            .contains("тайпскрипт"));
-    }
-
-    #[test]
-    fn lang_typescript() {
-        assert!(brief_handler()
-            .process_block("", Some("typescript"))
-            .contains("тайпскрипт"));
-    }
-
-    #[test]
-    fn lang_sh() {
-        assert!(brief_handler()
-            .process_block("", Some("sh"))
-            .contains("шелл"));
-    }
-
-    #[test]
-    fn lang_bash() {
-        assert!(brief_handler()
-            .process_block("", Some("bash"))
-            .contains("баш"));
-    }
-
-    #[test]
-    fn lang_shell() {
-        assert!(brief_handler()
-            .process_block("", Some("shell"))
-            .contains("шелл"));
-    }
-
-    #[test]
-    fn lang_yml() {
-        assert!(brief_handler()
-            .process_block("", Some("yml"))
-            .contains("ямл"));
-    }
-
-    #[test]
-    fn lang_yaml() {
-        assert!(brief_handler()
-            .process_block("", Some("yaml"))
-            .contains("ямл"));
-    }
-
-    #[test]
-    fn lang_md() {
-        assert!(brief_handler()
-            .process_block("", Some("md"))
-            .contains("маркдаун"));
-    }
-
-    #[test]
-    fn lang_markdown() {
-        assert!(brief_handler()
-            .process_block("", Some("markdown"))
-            .contains("маркдаун"));
-    }
-
-    #[test]
-    fn lang_cpp() {
-        assert!(brief_handler()
-            .process_block("", Some("cpp"))
-            .contains("си плюс плюс"));
-    }
-
-    #[test]
-    fn lang_cpp_symbol() {
-        // "c++" contains '+' which is not a \w char, map it directly
-        assert!(brief_handler()
-            .process_block("", Some("c++"))
-            .contains("си плюс плюс"));
-    }
-
-    #[test]
-    fn lang_cs() {
-        assert!(brief_handler()
-            .process_block("", Some("cs"))
-            .contains("си шарп"));
-    }
-
-    #[test]
-    fn lang_csharp() {
-        assert!(brief_handler()
-            .process_block("", Some("csharp"))
-            .contains("си шарп"));
-    }
-
-    #[test]
-    fn lang_dockerfile() {
-        assert!(brief_handler()
-            .process_block("", Some("dockerfile"))
-            .contains("докерфайл"));
-    }
-
-    #[test]
-    fn lang_makefile() {
-        assert!(brief_handler()
-            .process_block("", Some("makefile"))
-            .contains("мейкфайл"));
     }
 
     // ── process() with TrackedText ──────────────────────────────────────

--- a/src-tauri/src/pipeline/normalizers/english.rs
+++ b/src-tauri/src/pipeline/normalizers/english.rs
@@ -446,6 +446,7 @@ pub fn transliterate_simple(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     fn normalizer() -> EnglishNormalizer {
         EnglishNormalizer::new()
@@ -453,315 +454,220 @@ mod tests {
 
     // ── IT_TERMS dictionary ───────────────────────────────────────────────────
 
-    #[test]
-    fn test_it_terms_git() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("feature", false), "фича");
-        assert_eq!(en.normalize("branch", false), "бранч");
-        assert_eq!(en.normalize("merge", false), "мёрдж");
-        assert_eq!(en.normalize("commit", false), "коммит");
-        assert_eq!(en.normalize("pull", false), "пулл");
-        assert_eq!(en.normalize("checkout", false), "чекаут");
-        assert_eq!(en.normalize("rebase", false), "рибейз");
-        assert_eq!(en.normalize("stash", false), "стэш");
+    #[test_case("feature" => "фича"; "feature")]
+    #[test_case("branch" => "бранч"; "branch")]
+    #[test_case("merge" => "мёрдж"; "merge")]
+    #[test_case("commit" => "коммит"; "commit")]
+    #[test_case("pull" => "пулл"; "pull")]
+    #[test_case("checkout" => "чекаут"; "checkout")]
+    #[test_case("rebase" => "рибейз"; "rebase")]
+    #[test_case("stash" => "стэш"; "stash")]
+    fn it_terms_git(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
-    #[test]
-    fn test_it_terms_dev_process() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("review", false), "ревью");
-        assert_eq!(en.normalize("deploy", false), "деплой");
-        assert_eq!(en.normalize("release", false), "релиз");
-        assert_eq!(en.normalize("debug", false), "дебаг");
-        assert_eq!(en.normalize("bug", false), "баг");
-        assert_eq!(en.normalize("refactor", false), "рефакторинг");
-        assert_eq!(en.normalize("scrum", false), "скрам");
-        assert_eq!(en.normalize("agile", false), "эджайл");
+    #[test_case("review" => "ревью"; "review")]
+    #[test_case("deploy" => "деплой"; "deploy")]
+    #[test_case("release" => "релиз"; "release")]
+    #[test_case("debug" => "дебаг"; "debug")]
+    #[test_case("bug" => "баг"; "bug")]
+    #[test_case("refactor" => "рефакторинг"; "refactor")]
+    #[test_case("scrum" => "скрам"; "scrum")]
+    #[test_case("agile" => "эджайл"; "agile")]
+    fn it_terms_dev_process(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
-    #[test]
-    fn test_it_terms_architecture() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("framework", false), "фреймворк");
-        assert_eq!(en.normalize("library", false), "лайбрари");
-        assert_eq!(en.normalize("package", false), "пакет");
-        assert_eq!(en.normalize("module", false), "модуль");
-        assert_eq!(en.normalize("function", false), "функция");
-        assert_eq!(en.normalize("method", false), "метод");
-        assert_eq!(en.normalize("class", false), "класс");
-        assert_eq!(en.normalize("object", false), "объект");
-        assert_eq!(en.normalize("interface", false), "интерфейс");
-        assert_eq!(en.normalize("callback", false), "коллбэк");
-        assert_eq!(en.normalize("promise", false), "промис");
-        assert_eq!(en.normalize("handler", false), "хендлер");
-        assert_eq!(en.normalize("listener", false), "листенер");
-        assert_eq!(en.normalize("middleware", false), "мидлвэр");
-        assert_eq!(en.normalize("endpoint", false), "эндпоинт");
-        assert_eq!(en.normalize("router", false), "роутер");
-        assert_eq!(en.normalize("controller", false), "контроллер");
-        assert_eq!(en.normalize("service", false), "сервис");
-        assert_eq!(en.normalize("repository", false), "репозиторий");
+    #[test_case("framework" => "фреймворк"; "framework")]
+    #[test_case("library" => "лайбрари"; "library")]
+    #[test_case("package" => "пакет"; "package")]
+    #[test_case("module" => "модуль"; "module")]
+    #[test_case("function" => "функция"; "function")]
+    #[test_case("method" => "метод"; "method")]
+    #[test_case("class" => "класс"; "class")]
+    #[test_case("object" => "объект"; "object")]
+    #[test_case("interface" => "интерфейс"; "interface")]
+    #[test_case("callback" => "коллбэк"; "callback")]
+    #[test_case("promise" => "промис"; "promise")]
+    #[test_case("handler" => "хендлер"; "handler")]
+    #[test_case("listener" => "листенер"; "listener")]
+    #[test_case("middleware" => "мидлвэр"; "middleware")]
+    #[test_case("endpoint" => "эндпоинт"; "endpoint")]
+    #[test_case("router" => "роутер"; "router")]
+    #[test_case("controller" => "контроллер"; "controller")]
+    #[test_case("service" => "сервис"; "service")]
+    #[test_case("repository" => "репозиторий"; "repository")]
+    fn it_terms_architecture(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
-    #[test]
-    fn test_it_terms_data() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("cache", false), "кэш");
-        assert_eq!(en.normalize("queue", false), "кью");
-        assert_eq!(en.normalize("array", false), "массив");
-        assert_eq!(en.normalize("string", false), "строка");
-        assert_eq!(en.normalize("boolean", false), "булеан");
-        assert_eq!(en.normalize("null", false), "налл");
-        assert_eq!(en.normalize("undefined", false), "андефайнд");
-        assert_eq!(en.normalize("default", false), "дефолт");
-        assert_eq!(en.normalize("index", false), "индекс");
-        assert_eq!(en.normalize("query", false), "квери");
+    #[test_case("cache" => "кэш"; "cache")]
+    #[test_case("queue" => "кью"; "queue")]
+    #[test_case("array" => "массив"; "array")]
+    #[test_case("string" => "строка"; "string")]
+    #[test_case("boolean" => "булеан"; "boolean")]
+    #[test_case("null" => "налл"; "null")]
+    #[test_case("undefined" => "андефайнд"; "undefined")]
+    #[test_case("default" => "дефолт"; "default")]
+    #[test_case("index" => "индекс"; "index")]
+    #[test_case("query" => "квери"; "query")]
+    fn it_terms_data(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
-    #[test]
-    fn test_it_terms_infrastructure() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("docker", false), "докер");
-        assert_eq!(en.normalize("container", false), "контейнер");
-        assert_eq!(en.normalize("kubernetes", false), "кубернетис");
-        assert_eq!(en.normalize("cluster", false), "кластер");
-        assert_eq!(en.normalize("node", false), "нода");
-        assert_eq!(en.normalize("pod", false), "под");
-        assert_eq!(en.normalize("nginx", false), "энджинкс");
-        assert_eq!(en.normalize("backup", false), "бэкап");
-        assert_eq!(en.normalize("client", false), "клиент");
+    #[test_case("docker" => "докер"; "docker")]
+    #[test_case("container" => "контейнер"; "container")]
+    #[test_case("kubernetes" => "кубернетис"; "kubernetes")]
+    #[test_case("cluster" => "кластер"; "cluster")]
+    #[test_case("node" => "нода"; "node")]
+    #[test_case("pod" => "под"; "pod")]
+    #[test_case("nginx" => "энджинкс"; "nginx")]
+    #[test_case("backup" => "бэкап"; "backup")]
+    #[test_case("client" => "клиент"; "client")]
+    fn it_terms_infrastructure(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
-    #[test]
-    fn test_it_terms_testing_and_build() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("test", false), "тест");
-        assert_eq!(en.normalize("mock", false), "мок");
-        assert_eq!(en.normalize("stub", false), "стаб");
-        assert_eq!(en.normalize("spec", false), "спек");
-        assert_eq!(en.normalize("build", false), "билд");
-        assert_eq!(en.normalize("bundle", false), "бандл");
-        assert_eq!(en.normalize("compile", false), "компайл");
-        assert_eq!(en.normalize("webpack", false), "вебпак");
+    #[test_case("test" => "тест"; "test")]
+    #[test_case("mock" => "мок"; "mock")]
+    #[test_case("stub" => "стаб"; "stub")]
+    #[test_case("spec" => "спек"; "spec")]
+    #[test_case("build" => "билд"; "build")]
+    #[test_case("bundle" => "бандл"; "bundle")]
+    #[test_case("compile" => "компайл"; "compile")]
+    #[test_case("webpack" => "вебпак"; "webpack")]
+    fn it_terms_testing_and_build(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
-    #[test]
-    fn test_it_terms_languages() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("python", false), "пайтон");
-        assert_eq!(en.normalize("typescript", false), "тайпскрипт");
-        assert_eq!(en.normalize("rust", false), "раст");
-        assert_eq!(en.normalize("golang", false), "голанг");
-        assert_eq!(en.normalize("kotlin", false), "котлин");
+    #[test_case("python" => "пайтон"; "python")]
+    #[test_case("typescript" => "тайпскрипт"; "typescript")]
+    #[test_case("rust" => "раст"; "rust")]
+    #[test_case("golang" => "голанг"; "golang")]
+    #[test_case("kotlin" => "котлин"; "kotlin")]
+    fn it_terms_languages(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
-    #[test]
-    fn test_it_terms_frameworks() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("react", false), "риакт");
-        assert_eq!(en.normalize("angular", false), "ангуляр");
-        assert_eq!(en.normalize("vue", false), "вью");
-        assert_eq!(en.normalize("svelte", false), "свелт");
-        assert_eq!(en.normalize("next", false), "некст");
-        assert_eq!(en.normalize("express", false), "экспресс");
-        assert_eq!(en.normalize("django", false), "джанго");
-        assert_eq!(en.normalize("flask", false), "фласк");
-        assert_eq!(en.normalize("fastapi", false), "фаст эй пи ай");
-        assert_eq!(en.normalize("laravel", false), "ларавел");
-        assert_eq!(en.normalize("redis", false), "редис");
-        assert_eq!(en.normalize("mongo", false), "монго");
-        assert_eq!(en.normalize("postgres", false), "постгрес");
-        assert_eq!(en.normalize("github", false), "гитхаб");
-        assert_eq!(en.normalize("jira", false), "джира");
-        assert_eq!(en.normalize("slack", false), "слэк");
-        assert_eq!(en.normalize("postman", false), "постман");
+    #[test_case("react" => "риакт"; "react")]
+    #[test_case("angular" => "ангуляр"; "angular")]
+    #[test_case("vue" => "вью"; "vue")]
+    #[test_case("svelte" => "свелт"; "svelte")]
+    #[test_case("next" => "некст"; "next")]
+    #[test_case("express" => "экспресс"; "express")]
+    #[test_case("django" => "джанго"; "django")]
+    #[test_case("flask" => "фласк"; "flask")]
+    #[test_case("fastapi" => "фаст эй пи ай"; "fastapi")]
+    #[test_case("laravel" => "ларавел"; "laravel")]
+    #[test_case("redis" => "редис"; "redis")]
+    #[test_case("mongo" => "монго"; "mongo")]
+    #[test_case("postgres" => "постгрес"; "postgres")]
+    #[test_case("github" => "гитхаб"; "github")]
+    #[test_case("jira" => "джира"; "jira")]
+    #[test_case("slack" => "слэк"; "slack")]
+    #[test_case("postman" => "постман"; "postman")]
+    fn it_terms_frameworks(word: &str) -> String {
+        normalizer().normalize(word, false)
+    }
+
+    #[test_case("c++" => "си плюс плюс"; "cpp")]
+    #[test_case("c#" => "си шарп"; "csharp")]
+    #[test_case("f#" => "эф шарп"; "fsharp")]
+    fn it_terms_special_syntax(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
     // ── Case insensitivity ────────────────────────────────────────────────────
 
-    #[test]
-    fn test_case_insensitivity() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("Feature", false), "фича");
-        assert_eq!(en.normalize("BRANCH", false), "бранч");
-        assert_eq!(en.normalize("Merge", false), "мёрдж");
-        assert_eq!(en.normalize("COMMIT", false), "коммит");
+    #[test_case("Feature" => "фича"; "feature")]
+    #[test_case("BRANCH" => "бранч"; "branch")]
+    #[test_case("Merge" => "мёрдж"; "merge")]
+    #[test_case("COMMIT" => "коммит"; "commit")]
+    #[test_case("Pull Request" => "пулл реквест"; "pull_request_phrase")]
+    #[test_case("CODE REVIEW" => "код ревью"; "code_review_phrase")]
+    fn case_insensitive(word: &str) -> String {
+        normalizer().normalize(word, false)
     }
 
     // ── Multi-word phrases ────────────────────────────────────────────────────
 
-    #[test]
-    fn test_multiword_phrases() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("pull request", false), "пулл реквест");
-        assert_eq!(en.normalize("merge request", false), "мёрдж реквест");
-        assert_eq!(en.normalize("code review", false), "код ревью");
-        assert_eq!(en.normalize("feature branch", false), "фича бранч");
-        assert_eq!(en.normalize("stack trace", false), "стэк трейс");
-        assert_eq!(en.normalize("daily standup", false), "дейли стендап");
-        assert_eq!(en.normalize("hot fix", false), "хот фикс");
-        assert_eq!(en.normalize("hot reload", false), "хот релоуд");
-        assert_eq!(en.normalize("live reload", false), "лайв релоуд");
-        assert_eq!(en.normalize("dry run", false), "драй ран");
-        assert_eq!(en.normalize("tech debt", false), "тек дет");
-        assert_eq!(en.normalize("code smell", false), "код смелл");
-        assert_eq!(en.normalize("best practice", false), "бест практис");
-        assert_eq!(en.normalize("use case", false), "юз кейс");
-        assert_eq!(en.normalize("edge case", false), "эдж кейс");
+    #[test_case("pull request" => "пулл реквест"; "pull_request")]
+    #[test_case("merge request" => "мёрдж реквест"; "merge_request")]
+    #[test_case("code review" => "код ревью"; "code_review")]
+    #[test_case("feature branch" => "фича бранч"; "feature_branch")]
+    #[test_case("stack trace" => "стэк трейс"; "stack_trace")]
+    #[test_case("daily standup" => "дейли стендап"; "daily_standup")]
+    #[test_case("hot fix" => "хот фикс"; "hot_fix")]
+    #[test_case("hot reload" => "хот релоуд"; "hot_reload")]
+    #[test_case("live reload" => "лайв релоуд"; "live_reload")]
+    #[test_case("dry run" => "драй ран"; "dry_run")]
+    #[test_case("tech debt" => "тек дет"; "tech_debt")]
+    #[test_case("code smell" => "код смелл"; "code_smell")]
+    #[test_case("best practice" => "бест практис"; "best_practice")]
+    #[test_case("use case" => "юз кейс"; "use_case")]
+    #[test_case("edge case" => "эдж кейс"; "edge_case")]
+    fn multiword_phrases(phrase: &str) -> String {
+        normalizer().normalize(phrase, false)
     }
 
-    #[test]
-    fn test_multiword_phrases_case_insensitive() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("Pull Request", false), "пулл реквест");
-        assert_eq!(en.normalize("CODE REVIEW", false), "код ревью");
+    // ── Transliteration (simple fallback), no duplicate elsewhere ────────────
+
+    #[test_case("ship" => "шип"; "ship")]
+    #[test_case("chip" => "чип"; "chip")]
+    #[test_case("sing" => "синг"; "sing")]
+    #[test_case("back" => "бак"; "back")]
+    #[test_case("phone" => "фоне"; "phone")]
+    #[test_case("see" => "си"; "see")]
+    #[test_case("moon" => "мун"; "moon")]
+    #[test_case("rain" => "рэйн"; "rain")]
+    #[test_case("boy" => "бой"; "boy")]
+    #[test_case("mp3" => "мп3"; "preserves_digits_mp3")]
+    #[test_case("v8" => "в8"; "preserves_digits_v8")]
+    #[test_case("" => ""; "empty")]
+    fn translit_only(word: &str) -> String {
+        transliterate_simple(word)
     }
 
-    // ── Transliteration (simple fallback) ────────────────────────────────────
+    // ── Transliteration fallback: dedup of two call paths ────────────────────
+    //
+    // The same (word, expected) pairs used to be asserted twice: once directly
+    // via `transliterate_simple`, once indirectly via `EnglishNormalizer::normalize`
+    // (these words are not in IT_TERMS, so normalize() falls back to
+    // transliterate_simple() internally). Both invariants are preserved here in
+    // a single table instead of two separate test groups.
 
-    #[test]
-    fn test_translit_push() {
-        // p→п, u→у, sh→ш
-        assert_eq!(transliterate_simple("push"), "пуш");
-    }
-
-    #[test]
-    fn test_translit_fix() {
-        // f→ф, i→и, x→кс
-        assert_eq!(transliterate_simple("fix"), "фикс");
-    }
-
-    #[test]
-    fn test_translit_sprint() {
-        // s→с, p→п, r→р, i→и, n→н, t→т
-        assert_eq!(transliterate_simple("sprint"), "спринт");
-    }
-
-    #[test]
-    fn test_translit_lint() {
-        // l→л, i→и, n→н, t→т
-        assert_eq!(transliterate_simple("lint"), "линт");
-    }
-
-    #[test]
-    fn test_translit_javascript() {
-        // j→дж, a→а, v→в, a→а, s→с, c→к, r→р, i→и, p→п, t→т
-        assert_eq!(transliterate_simple("javascript"), "джаваскрипт");
-    }
-
-    #[test]
-    fn test_translit_swift() {
-        // s→с, w→в, i→и, f→ф, t→т
-        assert_eq!(transliterate_simple("swift"), "свифт");
-    }
-
-    #[test]
-    fn test_translit_java() {
-        // j→дж, a→а, v→в, a→а
-        assert_eq!(transliterate_simple("java"), "джава");
-    }
-
-    #[test]
-    fn test_translit_ruby() {
-        // r→р, u→у, b→б, y→и
-        assert_eq!(transliterate_simple("ruby"), "руби");
-    }
-
-    #[test]
-    fn test_translit_scala() {
-        // s→с, c→к, a→а, l→л, a→а
-        assert_eq!(transliterate_simple("scala"), "скала");
-    }
-
-    #[test]
-    fn test_translit_spring() {
-        // s→с, p→п, r→р, i→и, ng→нг
-        assert_eq!(transliterate_simple("spring"), "спринг");
-    }
-
-    #[test]
-    fn test_translit_gitlab() {
-        // g→г, i→и, t→т, l→л, a→а, b→б
-        assert_eq!(transliterate_simple("gitlab"), "гитлаб");
-    }
-
-    #[test]
-    fn test_translit_figma() {
-        // f→ф, i→и, g→г, m→м, a→а
-        assert_eq!(transliterate_simple("figma"), "фигма");
-    }
-
-    #[test]
-    fn test_translit_kafka() {
-        // k→к, a→а, f→ф, k→к, a→а
-        assert_eq!(transliterate_simple("kafka"), "кафка");
-    }
-
-    #[test]
-    fn test_translit_server() {
-        // s→с, er→ер, v→в, er→ер
-        assert_eq!(transliterate_simple("server"), "сервер");
-    }
-
-    #[test]
-    fn test_translit_digraphs() {
-        // sh, ch, th, ph, ng, ck
-        assert_eq!(transliterate_simple("ship"), "шип");
-        assert_eq!(transliterate_simple("chip"), "чип");
-        assert_eq!(transliterate_simple("sing"), "синг");
-        assert_eq!(transliterate_simple("back"), "бак");
-        assert_eq!(transliterate_simple("phone"), "фоне");
-    }
-
-    #[test]
-    fn test_translit_vowel_digraphs() {
-        assert_eq!(transliterate_simple("see"), "си");
-        assert_eq!(transliterate_simple("moon"), "мун");
-        assert_eq!(transliterate_simple("rain"), "рэйн");
-        assert_eq!(transliterate_simple("boy"), "бой");
-    }
-
-    #[test]
-    fn test_translit_preserves_digits() {
-        // Non-alpha characters pass through verbatim; alpha chars transliterate
-        assert_eq!(transliterate_simple("mp3"), "мп3");
-        assert_eq!(transliterate_simple("v8"), "в8");
-    }
-
-    #[test]
-    fn test_translit_empty() {
-        assert_eq!(transliterate_simple(""), "");
+    #[test_case("push", "пуш"; "push")]
+    #[test_case("fix", "фикс"; "fix")]
+    #[test_case("sprint", "спринт"; "sprint")]
+    #[test_case("lint", "линт"; "lint")]
+    #[test_case("javascript", "джаваскрипт"; "javascript")]
+    #[test_case("swift", "свифт"; "swift")]
+    #[test_case("java", "джава"; "java")]
+    #[test_case("ruby", "руби"; "ruby")]
+    #[test_case("scala", "скала"; "scala")]
+    #[test_case("spring", "спринг"; "spring")]
+    #[test_case("gitlab", "гитлаб"; "gitlab")]
+    #[test_case("figma", "фигма"; "figma")]
+    #[test_case("kafka", "кафка"; "kafka")]
+    #[test_case("server", "сервер"; "server")]
+    fn translit_fallback_matches_normalize(word: &str, expected: &str) {
+        assert_eq!(transliterate_simple(word), expected);
+        assert_eq!(normalizer().normalize(word, false), expected);
     }
 
     // ── Custom terms ──────────────────────────────────────────────────────────
 
-    #[test]
-    fn test_custom_terms_override_it_terms() {
+    #[test_case("api", "апи", &["api", "API"]; "override_it_terms")]
+    #[test_case("foobar", "фубар", &["foobar"]; "new_word")]
+    #[test_case("MyTerm", "майтёрм", &["myterm", "MYTERM"]; "case_insensitive_key")]
+    fn custom_terms(key: &str, value: &str, queries: &[&str]) {
         let mut en = normalizer();
         let mut custom = HashMap::new();
-        custom.insert("api".to_string(), "апи".to_string());
+        custom.insert(key.to_string(), value.to_string());
         en.add_custom_terms(&custom);
-        assert_eq!(en.normalize("api", false), "апи");
-        assert_eq!(en.normalize("API", false), "апи");
-    }
-
-    #[test]
-    fn test_custom_terms_new_word() {
-        let mut en = normalizer();
-        let mut custom = HashMap::new();
-        custom.insert("foobar".to_string(), "фубар".to_string());
-        en.add_custom_terms(&custom);
-        assert_eq!(en.normalize("foobar", false), "фубар");
-    }
-
-    #[test]
-    fn test_custom_terms_case_insensitive_key() {
-        let mut en = normalizer();
-        let mut custom = HashMap::new();
-        custom.insert("MyTerm".to_string(), "майтёрм".to_string());
-        en.add_custom_terms(&custom);
-        assert_eq!(en.normalize("myterm", false), "майтёрм");
-        assert_eq!(en.normalize("MYTERM", false), "майтёрм");
+        for q in queries {
+            assert_eq!(en.normalize(q, false), value);
+        }
     }
 
     // ── Unknown word tracking ─────────────────────────────────────────────────
@@ -815,99 +721,5 @@ mod tests {
     fn test_empty_string() {
         let mut en = normalizer();
         assert_eq!(en.normalize("", false), "");
-    }
-
-    #[test]
-    fn test_it_terms_with_plus_signs() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("c++", false), "си плюс плюс");
-        assert_eq!(en.normalize("c#", false), "си шарп");
-        assert_eq!(en.normalize("f#", false), "эф шарп");
-    }
-
-    // ── Programming languages resolved via transliteration ───────────────────
-
-    #[test]
-    fn test_normalize_javascript_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("javascript", false), "джаваскрипт");
-    }
-
-    #[test]
-    fn test_normalize_swift_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("swift", false), "свифт");
-    }
-
-    #[test]
-    fn test_normalize_java_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("java", false), "джава");
-    }
-
-    #[test]
-    fn test_normalize_ruby_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("ruby", false), "руби");
-    }
-
-    #[test]
-    fn test_normalize_scala_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("scala", false), "скала");
-    }
-
-    #[test]
-    fn test_normalize_spring_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("spring", false), "спринг");
-    }
-
-    #[test]
-    fn test_normalize_gitlab_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("gitlab", false), "гитлаб");
-    }
-
-    #[test]
-    fn test_normalize_figma_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("figma", false), "фигма");
-    }
-
-    #[test]
-    fn test_normalize_kafka_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("kafka", false), "кафка");
-    }
-
-    #[test]
-    fn test_normalize_server_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("server", false), "сервер");
-    }
-
-    #[test]
-    fn test_normalize_push_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("push", false), "пуш");
-    }
-
-    #[test]
-    fn test_normalize_fix_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("fix", false), "фикс");
-    }
-
-    #[test]
-    fn test_normalize_sprint_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("sprint", false), "спринт");
-    }
-
-    #[test]
-    fn test_normalize_lint_via_translit() {
-        let mut en = normalizer();
-        assert_eq!(en.normalize("lint", false), "линт");
     }
 }

--- a/src-tauri/src/pipeline/normalizers/urls.rs
+++ b/src-tauri/src/pipeline/normalizers/urls.rs
@@ -480,6 +480,7 @@ mod tests {
     use super::super::english::EnglishNormalizer;
     use super::super::numbers::NumberNormalizer;
     use super::*;
+    use test_case::test_case;
 
     fn mk_normalizer() -> (EnglishNormalizer, NumberNormalizer) {
         (EnglishNormalizer::new(), NumberNormalizer::new())
@@ -495,563 +496,124 @@ mod tests {
         URLPathNormalizer::new(en, nn)
     }
 
-    // ---- TestURLNormalization ----
+    // ---- URL normalization ----
 
-    #[test]
-    fn test_url_https_example_com() {
+    #[test_case("https://example.com" => "эйч ти ти пи эс двоеточие слэш слэш example точка ком"; "https_example_com")]
+    #[test_case("http://test.org" => "эйч ти ти пи двоеточие слэш слэш test точка орг"; "http_test_org")]
+    #[test_case("https://github.com/user/repo" => "эйч ти ти пи эс двоеточие слэш слэш github точка ком слэш user слэш repo"; "with_path")]
+    #[test_case("https://docs.python.org/3.11/tutorial" => "эйч ти ти пи эс двоеточие слэш слэш docs точка python точка орг слэш три точка одиннадцать слэш tutorial"; "python_docs_version_path")]
+    #[test_case("https://example.com/file.html" => "эйч ти ти пи эс двоеточие слэш слэш example точка ком слэш file точка html"; "with_file_extension")]
+    #[test_case("https://api.github.com/repos" => "эйч ти ти пи эс двоеточие слэш слэш api точка github точка ком слэш repos"; "subdomain")]
+    #[test_case("http://localhost:8080" => "эйч ти ти пи двоеточие слэш слэш localhost двоеточие восемь тысяч восемьдесят"; "with_port_8080")]
+    #[test_case("http://localhost:3000/api" => "эйч ти ти пи двоеточие слэш слэш localhost двоеточие три тысячи слэш api"; "with_port_3000_and_path")]
+    fn url_normalization(input: &str) -> String {
         let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("https://example.com"),
-            "эйч ти ти пи эс двоеточие слэш слэш example точка ком"
-        );
+        norm_no_en(&nn).normalize_url(input)
     }
 
-    #[test]
-    fn test_url_http_test_org() {
+    // ---- Common TLDs ----
+
+    #[test_case("https://example.com", "ком"; "com")]
+    #[test_case("https://example.org", "орг"; "org")]
+    #[test_case("https://example.net", "нет"; "net")]
+    #[test_case("https://example.ru", "ру"; "ru")]
+    #[test_case("https://example.io", "ай оу"; "io")]
+    #[test_case("https://example.dev", "дев"; "dev")]
+    #[test_case("https://example.app", "апп"; "app")]
+    #[test_case("https://example.ai", "эй ай"; "ai")]
+    #[test_case("https://example.co", "ко"; "co")]
+    #[test_case("https://example.me", "ми"; "me")]
+    fn tld(url: &str, expected: &str) {
         let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("http://test.org"),
-            "эйч ти ти пи двоеточие слэш слэш test точка орг"
-        );
+        assert!(norm_no_en(&nn).normalize_url(url).contains(expected));
     }
 
-    #[test]
-    fn test_url_with_path() {
+    // ---- Protocols ----
+
+    #[test_case("https://example.com", "эйч ти ти пи эс"; "https")]
+    #[test_case("http://example.com", "эйч ти ти пи"; "http")]
+    #[test_case("ftp://files.example.com", "эф ти пи"; "ftp")]
+    #[test_case("ssh://server.example.com", "эс эс эйч"; "ssh")]
+    #[test_case("git://github.com/repo.git", "гит"; "git")]
+    #[test_case("file:///home/user/doc.txt", "файл"; "file")]
+    fn protocol(url: &str, expected_prefix: &str) {
         let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("https://github.com/user/repo"),
-            "эйч ти ти пи эс двоеточие слэш слэш github точка ком слэш user слэш repo"
-        );
+        assert!(norm_no_en(&nn)
+            .normalize_url(url)
+            .starts_with(expected_prefix));
     }
 
-    #[test]
-    fn test_url_python_docs_version_path() {
+    // ---- Email normalization ----
+
+    #[test_case("user@example.com" => "user собака example точка ком"; "simple")]
+    #[test_case("test@mail.ru" => "test собака mail точка ру"; "ru_tld")]
+    #[test_case("john.doe@company.org" => "john точка doe собака company точка орг"; "dot_in_local")]
+    #[test_case("admin@localhost" => "admin собака localhost"; "no_tld")]
+    #[test_case("support@sub.domain.com" => "support собака sub точка domain точка ком"; "subdomain")]
+    #[test_case("name_123@test.io" => "name андерскор сто двадцать три собака test точка ай оу"; "with_numbers_and_underscore")]
+    #[test_case("info-team@company.co" => "info дефис team собака company точка ко"; "with_hyphen")]
+    fn email(input: &str) -> String {
         let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("https://docs.python.org/3.11/tutorial"),
-            "эйч ти ти пи эс двоеточие слэш слэш docs точка python точка орг слэш три точка одиннадцать слэш tutorial"
-        );
+        norm_no_en(&nn).normalize_email(input)
     }
 
-    #[test]
-    fn test_url_with_file_extension() {
+    // ---- IP address normalization ----
+
+    #[test_case("192.168.1.1" => "сто девяносто два точка сто шестьдесят восемь точка один точка один"; "192_168_1_1")]
+    #[test_case("127.0.0.1" => "сто двадцать семь точка ноль точка ноль точка один"; "127_0_0_1")]
+    #[test_case("10.0.0.1" => "десять точка ноль точка ноль точка один"; "10_0_0_1")]
+    #[test_case("255.255.255.0" => "двести пятьдесят пять точка двести пятьдесят пять точка двести пятьдесят пять точка ноль"; "255_255_255_0")]
+    #[test_case("8.8.8.8" => "восемь точка восемь точка восемь точка восемь"; "8_8_8_8")]
+    #[test_case("172.16.0.1" => "сто семьдесят два точка шестнадцать точка ноль точка один"; "172_16_0_1")]
+    fn ip(input: &str) -> String {
         let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("https://example.com/file.html"),
-            "эйч ти ти пи эс двоеточие слэш слэш example точка ком слэш file точка html"
-        );
+        norm_no_en(&nn).normalize_ip(input)
     }
 
-    #[test]
-    fn test_url_subdomain() {
+    // ---- File path normalization + file extensions (both exercise normalize_filepath) ----
+
+    #[test_case("/home/user/file.txt" => "слэш home слэш user слэш file точка txt"; "unix_home_user_file_txt")]
+    #[test_case("/etc/nginx/nginx.conf" => "слэш etc слэш nginx слэш nginx точка conf"; "nginx_conf")]
+    #[test_case("/var/log/syslog" => "слэш var слэш log слэш syslog"; "var_log_syslog")]
+    #[test_case("~/Documents/report.pdf" => "тильда слэш Documents слэш report точка pdf"; "tilde_documents")]
+    #[test_case("~/.config/settings.json" => "тильда слэш точка config слэш settings точка json"; "tilde_config_hidden")]
+    #[test_case("./src/main.py" => "точка слэш src слэш main точка py"; "relative_dot_slash")]
+    #[test_case("../config/app.yaml" => "точка точка слэш config слэш app точка yaml"; "relative_parent")]
+    #[test_case("C:\\Users\\Admin\\file.txt" => "си двоеточие бэкслэш Users бэкслэш Admin бэкслэш file точка txt"; "windows_c")]
+    #[test_case("D:\\Projects\\code\\main.py" => "ди двоеточие бэкслэш Projects бэкслэш code бэкслэш main точка py"; "windows_d")]
+    #[test_case("main.py" => "main точка py"; "main_py")]
+    #[test_case("index.js" => "index точка js"; "index_js")]
+    #[test_case("styles.css" => "styles точка css"; "styles_css")]
+    #[test_case("config.yaml" => "config точка yaml"; "config_yaml")]
+    #[test_case("data.json" => "data точка json"; "data_json")]
+    #[test_case("README.md" => "README точка md"; "readme_md")]
+    #[test_case("Dockerfile" => "Dockerfile"; "dockerfile_no_ext")]
+    #[test_case("docker-compose.yml" => "docker дефис compose точка yml"; "docker_compose_yml")]
+    #[test_case(".gitignore" => "точка gitignore"; "gitignore")]
+    #[test_case(".env" => "точка env"; "dot_env")]
+    #[test_case("test.spec.ts" => "test точка spec точка ts"; "test_spec_ts")]
+    fn filepath(input: &str) -> String {
         let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("https://api.github.com/repos"),
-            "эйч ти ти пи эс двоеточие слэш слэш api точка github точка ком слэш repos"
-        );
+        norm_no_en(&nn).normalize_filepath(input)
     }
 
-    #[test]
-    fn test_url_with_port_8080() {
+    // ---- Complex URLs (multiple expected substrings) ----
+
+    #[test_case("https://example.com/search?q=test", &["example", "search", "q", "test"]; "query_params")]
+    #[test_case("https://docs.example.com/guide#installation", &["docs", "guide", "installation"]; "fragment")]
+    #[test_case("https://api.example.com/v1/users/123/posts", &["api", "v1", "users", "posts"]; "multiple_path_segments")]
+    fn complex_url(url: &str, parts: &[&str]) {
         let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("http://localhost:8080"),
-            "эйч ти ти пи двоеточие слэш слэш localhost двоеточие восемь тысяч восемьдесят"
-        );
-    }
-
-    #[test]
-    fn test_url_with_port_3000_and_path() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_url("http://localhost:3000/api"),
-            "эйч ти ти пи двоеточие слэш слэш localhost двоеточие три тысячи слэш api"
-        );
-    }
-
-    // ---- TestCommonTLDs ----
-
-    #[test]
-    fn test_tld_com() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.com").contains("ком"));
-    }
-
-    #[test]
-    fn test_tld_org() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.org").contains("орг"));
-    }
-
-    #[test]
-    fn test_tld_net() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.net").contains("нет"));
-    }
-
-    #[test]
-    fn test_tld_ru() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.ru").contains("ру"));
-    }
-
-    #[test]
-    fn test_tld_io() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.io").contains("ай оу"));
-    }
-
-    #[test]
-    fn test_tld_dev() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.dev").contains("дев"));
-    }
-
-    #[test]
-    fn test_tld_app() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.app").contains("апп"));
-    }
-
-    #[test]
-    fn test_tld_ai() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.ai").contains("эй ай"));
-    }
-
-    #[test]
-    fn test_tld_co() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.co").contains("ко"));
-    }
-
-    #[test]
-    fn test_tld_me() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n.normalize_url("https://example.me").contains("ми"));
-    }
-
-    // ---- TestProtocols ----
-
-    #[test]
-    fn test_protocol_https() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n
-            .normalize_url("https://example.com")
-            .starts_with("эйч ти ти пи эс"));
-    }
-
-    #[test]
-    fn test_protocol_http() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n
-            .normalize_url("http://example.com")
-            .starts_with("эйч ти ти пи"));
-    }
-
-    #[test]
-    fn test_protocol_ftp() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n
-            .normalize_url("ftp://files.example.com")
-            .starts_with("эф ти пи"));
-    }
-
-    #[test]
-    fn test_protocol_ssh() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n
-            .normalize_url("ssh://server.example.com")
-            .starts_with("эс эс эйч"));
-    }
-
-    #[test]
-    fn test_protocol_git() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n
-            .normalize_url("git://github.com/repo.git")
-            .starts_with("гит"));
-    }
-
-    #[test]
-    fn test_protocol_file() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert!(n
-            .normalize_url("file:///home/user/doc.txt")
-            .starts_with("файл"));
-    }
-
-    // ---- TestEmailNormalization ----
-
-    #[test]
-    fn test_email_simple() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_email("user@example.com"),
-            "user собака example точка ком"
-        );
-    }
-
-    #[test]
-    fn test_email_ru_tld() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_email("test@mail.ru"),
-            "test собака mail точка ру"
-        );
-    }
-
-    #[test]
-    fn test_email_dot_in_local() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_email("john.doe@company.org"),
-            "john точка doe собака company точка орг"
-        );
-    }
-
-    #[test]
-    fn test_email_no_tld() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_email("admin@localhost"),
-            "admin собака localhost"
-        );
-    }
-
-    #[test]
-    fn test_email_subdomain() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_email("support@sub.domain.com"),
-            "support собака sub точка domain точка ком"
-        );
-    }
-
-    #[test]
-    fn test_email_with_numbers_and_underscore() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_email("name_123@test.io"),
-            "name андерскор сто двадцать три собака test точка ай оу"
-        );
-    }
-
-    #[test]
-    fn test_email_with_hyphen() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_email("info-team@company.co"),
-            "info дефис team собака company точка ко"
-        );
-    }
-
-    // ---- TestIPAddressNormalization ----
-
-    #[test]
-    fn test_ip_192_168_1_1() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_ip("192.168.1.1"),
-            "сто девяносто два точка сто шестьдесят восемь точка один точка один"
-        );
-    }
-
-    #[test]
-    fn test_ip_127_0_0_1() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_ip("127.0.0.1"),
-            "сто двадцать семь точка ноль точка ноль точка один"
-        );
-    }
-
-    #[test]
-    fn test_ip_10_0_0_1() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_ip("10.0.0.1"),
-            "десять точка ноль точка ноль точка один"
-        );
-    }
-
-    #[test]
-    fn test_ip_255_255_255_0() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_ip("255.255.255.0"),
-            "двести пятьдесят пять точка двести пятьдесят пять точка двести пятьдесят пять точка ноль"
-        );
-    }
-
-    #[test]
-    fn test_ip_8_8_8_8() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_ip("8.8.8.8"),
-            "восемь точка восемь точка восемь точка восемь"
-        );
-    }
-
-    #[test]
-    fn test_ip_172_16_0_1() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_ip("172.16.0.1"),
-            "сто семьдесят два точка шестнадцать точка ноль точка один"
-        );
-    }
-
-    // ---- TestFilePathNormalization ----
-
-    #[test]
-    fn test_path_unix_home_user_file_txt() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("/home/user/file.txt"),
-            "слэш home слэш user слэш file точка txt"
-        );
-    }
-
-    #[test]
-    fn test_path_nginx_conf() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("/etc/nginx/nginx.conf"),
-            "слэш etc слэш nginx слэш nginx точка conf"
-        );
-    }
-
-    #[test]
-    fn test_path_var_log_syslog() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("/var/log/syslog"),
-            "слэш var слэш log слэш syslog"
-        );
-    }
-
-    #[test]
-    fn test_path_tilde_documents() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("~/Documents/report.pdf"),
-            "тильда слэш Documents слэш report точка pdf"
-        );
-    }
-
-    #[test]
-    fn test_path_tilde_config_hidden() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("~/.config/settings.json"),
-            "тильда слэш точка config слэш settings точка json"
-        );
-    }
-
-    #[test]
-    fn test_path_relative_dot_slash() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("./src/main.py"),
-            "точка слэш src слэш main точка py"
-        );
-    }
-
-    #[test]
-    fn test_path_relative_parent() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("../config/app.yaml"),
-            "точка точка слэш config слэш app точка yaml"
-        );
-    }
-
-    #[test]
-    fn test_path_windows_c() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("C:\\Users\\Admin\\file.txt"),
-            "си двоеточие бэкслэш Users бэкслэш Admin бэкслэш file точка txt"
-        );
-    }
-
-    #[test]
-    fn test_path_windows_d() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("D:\\Projects\\code\\main.py"),
-            "ди двоеточие бэкслэш Projects бэкслэш code бэкслэш main точка py"
-        );
-    }
-
-    // ---- TestFileExtensions ----
-
-    #[test]
-    fn test_filename_main_py() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath("main.py"), "main точка py");
-    }
-
-    #[test]
-    fn test_filename_index_js() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath("index.js"), "index точка js");
-    }
-
-    #[test]
-    fn test_filename_styles_css() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath("styles.css"), "styles точка css");
-    }
-
-    #[test]
-    fn test_filename_config_yaml() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath("config.yaml"), "config точка yaml");
-    }
-
-    #[test]
-    fn test_filename_data_json() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath("data.json"), "data точка json");
-    }
-
-    #[test]
-    fn test_filename_readme_md() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath("README.md"), "README точка md");
-    }
-
-    #[test]
-    fn test_filename_dockerfile_no_ext() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath("Dockerfile"), "Dockerfile");
-    }
-
-    #[test]
-    fn test_filename_docker_compose_yml() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("docker-compose.yml"),
-            "docker дефис compose точка yml"
-        );
-    }
-
-    #[test]
-    fn test_filename_gitignore() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath(".gitignore"), "точка gitignore");
-    }
-
-    #[test]
-    fn test_filename_dot_env() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(n.normalize_filepath(".env"), "точка env");
-    }
-
-    #[test]
-    fn test_filename_test_spec_ts() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        assert_eq!(
-            n.normalize_filepath("test.spec.ts"),
-            "test точка spec точка ts"
-        );
-    }
-
-    // ---- TestComplexURLs ----
-
-    #[test]
-    fn test_complex_url_query_params() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        let result = n.normalize_url("https://example.com/search?q=test");
-        for part in &["example", "search", "q", "test"] {
+        let result = norm_no_en(&nn).normalize_url(url);
+        for part in parts {
             assert!(result.contains(part), "missing '{}' in '{}'", part, result);
         }
     }
 
-    #[test]
-    fn test_complex_url_fragment() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        let result = n.normalize_url("https://docs.example.com/guide#installation");
-        for part in &["docs", "guide", "installation"] {
-            assert!(result.contains(part), "missing '{}' in '{}'", part, result);
-        }
-    }
+    // ---- With EnglishNormalizer (transliteration enabled) ----
 
     #[test]
-    fn test_complex_url_multiple_path_segments() {
-        let (_, nn) = mk_normalizer();
-        let n = norm_no_en(&nn);
-        let result = n.normalize_url("https://api.example.com/v1/users/123/posts");
-        for part in &["api", "v1", "users", "posts"] {
-            assert!(result.contains(part), "missing '{}' in '{}'", part, result);
-        }
-    }
-
-    // ---- Test with EnglishNormalizer (transliteration enabled) ----
-
-    #[test]
-    fn test_url_with_english_normalizer_transliterates() {
+    fn url_with_english_normalizer_transliterates() {
         let (en, nn) = mk_normalizer();
         let n = norm(&en, &nn);
         let result = n.normalize_url("https://github.com/user/repo");


### PR DESCRIPTION
## Summary

Part of epic "Оздоровление тестов RuVox", task S6c. Converts the remaining
pipeline normalizer test suites (`code.rs`, `urls.rs`, `english.rs`,
`code_blocks.rs`) to the `#[test_case]`-table pattern established in
`numbers.rs` (S6a), and removes two sources of duplicate coverage flagged
by the test-suite audit. Production code is untouched — the diff is scoped
entirely to `#[cfg(test)] mod tests` blocks.

## Reconciliation table (test count before -> after)

| File | Before (#[test] fns) | After (test executions) | Delta | Notes |
|---|---|---|---|---|
| `code.rs` | 61 | 61 | 0 | Pure restructuring, no duplicates |
| `urls.rs` | 61 | 61 | 0 | Pure restructuring, no duplicates |
| `english.rs` | 53 | 143 | -14 assertion-pairs* | 14 duplicate transliteration pairs consolidated |
| `code_blocks.rs` | 44 | 39 | -5 | 5 duplicate language-code checks consolidated |

\* `english.rs`: "before" fn count (53) and "after" test-execution count
(143) aren't directly comparable because grouped multi-assert `#[test]`
functions were flattened into one row per assertion. The 143 rows are 1:1
with all *retained* (word, expected) pairs; the only removed pairs are the
14 explicitly listed below (each removed pair kept both of its original
assertions, just consolidated into a single table row — see below).

Verified mechanically: a script (run locally, not committed) extracted the
multiset of string literals from the `#[cfg(test)]` block of each file, in
both `origin/main` and this branch, and diffed the counts. Every string
whose count decreased is accounted for by one of the reasons below — no
unexplained losses.

## `english.rs`: transliteration-pair dedup (requirement #2)

The audit flagged two test groups asserting the *same* 14 (word, expected)
pairs via two different call paths:

- `test_translit_push`, `test_translit_fix`, `test_translit_sprint`,
  `test_translit_lint`, `test_translit_javascript`, `test_translit_swift`,
  `test_translit_java`, `test_translit_ruby`, `test_translit_scala`,
  `test_translit_spring`, `test_translit_gitlab`, `test_translit_figma`,
  `test_translit_kafka`, `test_translit_server` — asserted directly via
  `transliterate_simple(word)`.
- `test_normalize_push_via_translit`, `test_normalize_fix_via_translit`,
  `test_normalize_sprint_via_translit`, `test_normalize_lint_via_translit`,
  `test_normalize_javascript_via_translit`, `test_normalize_swift_via_translit`,
  `test_normalize_java_via_translit`, `test_normalize_ruby_via_translit`,
  `test_normalize_scala_via_translit`, `test_normalize_spring_via_translit`,
  `test_normalize_gitlab_via_translit`, `test_normalize_figma_via_translit`,
  `test_normalize_kafka_via_translit`, `test_normalize_server_via_translit`
  — asserted the identical 14 pairs via `EnglishNormalizer::normalize(word, false)`.

Both sets were checking exactly the same 14 pairs (identical, no
divergence), so nothing needed to be "merged without losing anything" —
they were honest duplicates. Removed duplicate pairs (word -> expected),
each now covered by a single row in `translit_fallback_matches_normalize`
that asserts **both** invariants (`transliterate_simple` and
`normalize`) in one function body, so no coverage is lost, only the
redundant second test declaration:

```
push -> пуш
fix -> фикс
sprint -> спринт
lint -> линт
javascript -> джаваскрипт
swift -> свифт
java -> джава
ruby -> руби
scala -> скала
spring -> спринг
gitlab -> гитлаб
figma -> фигма
kafka -> кафка
server -> сервер
```

## `code_blocks.rs`: lang_*/brief_* overlap removal (requirement #3)

`CodeBlockHandler::brief_description()` ignores its `code` parameter
entirely — brief-mode output depends only on `language`. That means
`TestCodeBlockBriefMode` (12 real languages, exact-sentence assertions via
realistic code content) and `TestLanguageNames` (19 language codes,
`.contains()` assertions via empty code content) were, in 5 cases, testing
the exact same (language, expected) pair twice through two different
assertion styles:

| Language code | Old brief_* test | Old lang_* test |
|---|---|---|
| `python` | `brief_python` (exact) | `lang_python` (contains) |
| `javascript` | `brief_javascript` (exact) | `lang_javascript` (contains) |
| `typescript` | `brief_typescript` (exact) | `lang_typescript` (contains) |
| `bash` | `brief_bash` (exact) | `lang_bash` (contains) |
| `yaml` | `brief_yaml` (exact) | `lang_yaml` (contains) |

Both groups are merged into a single `brief_language` table over the union
of 26 distinct language codes (12 from brief_* + 19 from lang_* minus the 5
overlaps, plus the 2 `None`/`Some("")` edge cases), using `process_block("",
Some(lang))` since the code content was proven irrelevant. Every row now
asserts the **exact** expected sentence — strictly stronger than the
former `.contains()` checks used by the 14 non-overlapping lang_* codes
(`py`, `js`, `ts`, `sh`, `shell`, `yml`, `md`, `markdown`, `cpp`, `c++`,
`cs`, `csharp`, `dockerfile`, `makefile`), so this consolidation both
removes duplication and strengthens assertions. No unique language code was
lost — all 26 codes plus both edge cases are still covered.

`TestCodeBlockFullMode` (3 cases) and the two `mode_switch_to_brief` /
`mode_switch_to_full` cases were also converted to tables (`full_mode`,
`mode_switch`) since they're simple input/expected-substring or
input/output pairs. `mode_default_is_brief`, `mode_switch_via_process`, and
the four `process_*` tests using `TrackedText` were left untouched as
unique/stateful tests, per the task's scope.

## Gates (all green, run in the nix devshell, foreground)

- `cargo fmt --manifest-path src-tauri/Cargo.toml` — clean (reformatted
  `urls.rs` minorly on first run, included in this PR)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — clean, no warnings
- `cargo test --manifest-path src-tauri/Cargo.toml` — 779 passed, 0 failed