### PR TITLE
ci: bump GitHub Actions to node24 runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Slim .#ruvox does not pull in ttsd at the derivation level
         run: |
           set -euo pipefail
-          drvs=$(nix derivation show .#ruvox | jq -r 'to_entries[0].value.inputDrvs | keys[]')
+          drvs=$(nix derivation show .#ruvox | jq -r '(if has("derivations") then .derivations else . end) | to_entries[0].value | (.inputDrvs // .inputs.drvs) | keys[]')
           echo "$drvs" | grep -i ttsd && {
             echo "::error::slim .#ruvox derivation pulls in ttsd; this defeats the withSilero=false default"
             exit 1
@@ -129,7 +129,7 @@ jobs:
       - name: Full .#ruvox-with-silero does pull in ttsd
         run: |
           set -euo pipefail
-          drvs=$(nix derivation show .#ruvox-with-silero | jq -r 'to_entries[0].value.inputDrvs | keys[]')
+          drvs=$(nix derivation show .#ruvox-with-silero | jq -r '(if has("derivations") then .derivations else . end) | to_entries[0].value | (.inputDrvs // .inputs.drvs) | keys[]')
           echo "$drvs" | grep -qi ttsd || {
             echo "::error::full .#ruvox-with-silero derivation does not pull in ttsd"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       ttsd: ${{ steps.filter.outputs.ttsd }}
       nix: ${{ steps.filter.outputs.nix }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -47,7 +47,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Tauri system dependencies
         run: |
           sudo apt-get update
@@ -71,11 +71,11 @@ jobs:
     if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -90,11 +90,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - working-directory: ttsd
@@ -111,8 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes


### PR DESCRIPTION
## Summary
- GitHub Actions runners deprecated Node.js 20; several actions used in `.github/workflows/ci.yml` were being forced onto Node 24 with a deprecation warning.
- Bumped each affected action to the first major version that ships a `node24` runtime: `actions/checkout` v4→v5, `dorny/paths-filter` v3→v4, `actions/setup-node` v4→v5, `pnpm/action-setup` v4→v6, `astral-sh/setup-uv` v5→v7, `actions/setup-python` v5→v6, `cachix/install-nix-action` v30→v31.
- Checked each major-version changelog for breaking changes relevant to our usage (none apply: no `packageManager` field in package.json, no `python-version`/`server-url` inputs on setup-uv).

## Test plan
- [ ] CI run on this PR is green with no "Node.js 20 is deprecated" warnings in any job