### PR TITLE
refactor(ttsd): remove dead re-exports and duplicated validation

### DIFF
--- a/ttsd/tests/test_main_unit.py
+++ b/ttsd/tests/test_main_unit.py
@@ -237,20 +237,16 @@ def test_main_invalid_json_returns_bad_input(monkeypatch, use_engine):
     assert responses[0]["error"] == "bad_input"
 
 
-def test_main_unknown_cmd(monkeypatch, use_engine):
+def test_main_unknown_cmd_rejected_as_bad_input(monkeypatch, use_engine):
+    # RequestAdapter's discriminated union rejects an unknown cmd during
+    # validation, so it surfaces as bad_input without ever reaching the
+    # defensive else-branch in the dispatch loop.
     use_engine(FakeEngine())
-
-    # RequestAdapter's discriminated union cannot produce an unknown cmd, so we
-    # stub validate_json to return a request object with an out-of-range cmd,
-    # which is the only way to reach the else-branch.
-    fake_adapter = SimpleNamespace(validate_json=lambda line: SimpleNamespace(cmd="bogus"))
-    monkeypatch.setattr(ttsd_main, "RequestAdapter", fake_adapter)
-    stdin = io.StringIO('{"cmd": "bogus"}\n')
+    stdin = io.StringIO('{"cmd": "bogus"}\n{"cmd": "shutdown"}\n')
     rc, responses = _run_main(monkeypatch, stdin)
     assert rc == 0
     assert responses[0]["ok"] is False
     assert responses[0]["error"] == "bad_input"
-    assert "unknown cmd: bogus" in responses[0]["message"]
 
 
 class _RaisingStdin:

--- a/ttsd/tests/test_silero.py
+++ b/ttsd/tests/test_silero.py
@@ -46,19 +46,6 @@ def test_silero_second_load_is_noop():
     assert engine._model is model_before
 
 
-@pytest.mark.slow
-def test_silero_empty_text_raises(tmp_path):
-    engine = _import_silero_engine()()
-    engine.load()
-    with pytest.raises(ValueError, match="empty"):
-        engine.synthesize(
-            text="   ",
-            speaker="xenia",
-            sample_rate=48000,
-            out_wav=tmp_path / "empty.wav",
-        )
-
-
 def _assert_covers_source(text: str, chunks: list[tuple[str, int]]) -> None:
     """Every chunk must sit at its declared start position, stay within
     MAX_CHUNK_SIZE, and the gaps between (and after) chunks must be

--- a/ttsd/ttsd/main.py
+++ b/ttsd/ttsd/main.py
@@ -120,6 +120,11 @@ def main() -> int:
                 _write_response(_handle_shutdown())
                 return 0
             else:
+                # Unreachable today: RequestAdapter's discriminated union rejects
+                # any unknown cmd during validate_json above. Kept as a defensive
+                # fallback so that adding a new request type to the union without a
+                # matching handler surfaces a bad_input response instead of a silent
+                # no-op that would hang the Rust side waiting for a reply.
                 _write_response(
                     ErrResponse(error="bad_input", message=f"unknown cmd: {req.cmd}")  # type: ignore[union-attr]
                 )

--- a/ttsd/ttsd/silero.py
+++ b/ttsd/ttsd/silero.py
@@ -9,21 +9,11 @@ import numpy as np
 import torch
 from scipy.io import wavfile
 
-from ttsd.chunking import MAX_CHUNK_SIZE, sanitize_for_silero, split_into_chunks
+from ttsd.chunking import sanitize_for_silero, split_into_chunks
 from ttsd.protocol import WordTimestamp
 from ttsd.timestamps import estimate_timestamps_chunked
 
 logger = logging.getLogger("ttsd.silero")
-
-# MAX_CHUNK_SIZE / split_into_chunks / sanitize_for_silero now live in ttsd.chunking
-# (torch-free) and are re-exported here for backwards compatibility.
-__all__ = [
-    "MAX_CHUNK_SIZE",
-    "SileroEngine",
-    "SynthesisOutput",
-    "sanitize_for_silero",
-    "split_into_chunks",
-]
 
 
 @dataclass
@@ -76,9 +66,9 @@ class SileroEngine:
 
         assert self._model is not None
 
-        if not text.strip():
-            raise ValueError("text must not be empty")
-
+        # Empty/whitespace-only text is rejected upstream by the protocol layer
+        # (main._handle_synthesize returns a bad_input ErrResponse); the engine
+        # trusts that invariant instead of re-validating it here.
         chunks = split_into_chunks(text)
         logger.debug("Synthesizing %d chars in %d chunks", len(text), len(chunks))
 


### PR DESCRIPTION
## R2 — ttsd (Silero sidecar) cleanup

Refactoring-only pass on the Python sidecar per the PR #59 review. **No change to the JSON protocol behavior.**

### 1. Remove backwards-compatibility re-export in `silero.py`
`MAX_CHUNK_SIZE` / `split_into_chunks` / `sanitize_for_silero` were moved to the torch-free `ttsd.chunking` module and re-exported from `silero.py` "just in case". There are no external consumers: a repo-wide grep shows every importer (production code and tests) already pulls them from `ttsd.chunking`, and the Rust backend only speaks the JSON protocol. Dropped the `__all__` re-export block and the now-unused `MAX_CHUNK_SIZE` import.

### 2. Unknown-`cmd` else-branch in `main.py` — decision: **keep as documented defensive fallback**
`RequestAdapter`'s discriminated union rejects any unknown `cmd` during `validate_json`, so the `else` branch of the dispatch loop is unreachable today. The existing test could only reach it by monkeypatching `RequestAdapter` to fabricate an impossible request — testing framework internals, not real behavior.

Rationale for keeping the branch: if a new request type is later added to the union without a matching handler, a missing `else` would make the loop silently write no response, hanging the Rust side which blocks waiting for a reply. The defensive `else` turns that programming error into a `bad_input` response instead. Added a comment explaining this, and replaced the brittle monkeypatch test with `test_main_unknown_cmd_rejected_as_bad_input`, which asserts the real behavior (unknown cmd rejected at validation). The unreachable line is intentionally left uncovered.

### 3. Deduplicate empty-text validation — decision: **single protocol-level check in `main.py`**
The empty-text invariant was checked twice: `main._handle_synthesize` (returns a `bad_input` ErrResponse) and `silero.synthesize` (raised `ValueError`). Kept the protocol-layer check in `main` as the single source of truth (protocol errors are `main`'s responsibility) and replaced the engine-level re-validation with a comment documenting the precondition. Removed the now-redundant slow engine test `test_silero_empty_text_raises`; coverage of the surviving check point is retained by `test_handle_synthesize_empty_text`.

### Gates
- `ruff check .` — clean.
- `pytest -m 'not slow'` — 64 passed, 4 deselected.
- **slow** set not run: it requires `torch.hub.load` (Silero model download over the network), which is unavailable in the sandbox.