### PR TITLE
ci: fix punycode/url.parse deprecation warnings from actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## Summary
- `actions/setup-node@v5` printed `node:punycode` (DEP0040) and `url.parse()` (DEP0169) deprecation warnings on every run, via a bundled `node-fetch@2` dependency chain.
- Both are fixed upstream in `actions/setup-node` v6.2.0 by bumping `@actions/cache` to v5.0.1 (actions/setup-node#1364, #1370). Bumped `actions/setup-node@v5` → `@v6`.
- Left the equivalent `Swatinem/rust-cache` punycode warning alone: it's an open, unresolved upstream issue (Swatinem/rust-cache#331) with no released fix, so there's nothing to genuinely fix yet — not suppressing it artificially.

## Test plan
- [ ] CI run on this PR is green
- [ ] `TypeScript (typecheck + vitest)` job logs no longer show DEP0040/DEP0169 warnings from `actions/setup-node`