### PR TITLE
refactor(pipeline): consolidate phase 9 date/time normalization

### DIFF
--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -334,27 +334,15 @@ impl TTSPipeline {
         // substrings inside them are not re-matched here.
         {
             let num = &self.number_normalizer;
-            // normalize_date returns its input unchanged on an invalid
-            // month/day/year, so out-of-range matches become no-ops.
-            tracked.sub(re_date_iso(), |caps| {
-                num.normalize_date(caps.get(0).unwrap().as_str())
-            });
-            tracked.sub(re_date_dot(), |caps| {
-                num.normalize_date(caps.get(0).unwrap().as_str())
-            });
+            // normalize_date and normalize_time return their input unchanged on an
+            // invalid calendar/clock value, so out-of-range matches become no-ops
+            // and leave the region and its digits for the number phase.
+            let normalize_date =
+                |caps: &regex::Captures| num.normalize_date(caps.get(0).unwrap().as_str());
+            tracked.sub(re_date_iso(), normalize_date);
+            tracked.sub(re_date_dot(), normalize_date);
             tracked.sub(re_time(), |caps| {
-                let full = caps.get(0).unwrap().as_str();
-                let h: i64 = caps.get(1).unwrap().as_str().parse().unwrap_or(-1);
-                let m: i64 = caps.get(2).unwrap().as_str().parse().unwrap_or(-1);
-                let s: i64 = caps
-                    .get(3)
-                    .map(|g| g.as_str().parse().unwrap_or(-1))
-                    .unwrap_or(0);
-                if (0..=23).contains(&h) && (0..=59).contains(&m) && (0..=59).contains(&s) {
-                    num.normalize_time(full)
-                } else {
-                    full.to_string()
-                }
+                num.normalize_time(caps.get(0).unwrap().as_str())
             });
         }
 
@@ -709,6 +697,15 @@ mod tests {
         let mut p = TTSPipeline::new();
         let input = "Привет мир";
         assert_eq!(p.process(input), "Привет мир");
+    }
+
+    #[test]
+    fn pipeline_invalid_time_falls_through_to_numbers() {
+        // Invariant: normalize_time returns an out-of-range clock value unchanged,
+        // so the time phase is a no-op and does not consume the region. TrackedText
+        // skips no-op replacements, leaving the digits for the number phase to read.
+        let mut p = TTSPipeline::new();
+        assert_eq!(p.process("В 25:00 встреча"), "В двадцать пять:ноль встреча");
     }
 
     #[test]

--- a/src-tauri/src/pipeline/normalizers/numbers.rs
+++ b/src-tauri/src/pipeline/normalizers/numbers.rs
@@ -962,7 +962,17 @@ impl NumberNormalizer {
     }
 
     /// Convert time string (HH:MM or HH:MM:SS) to Russian words.
+    ///
+    /// Returns the input unchanged when it is not a valid clock time (unparseable
+    /// or an out-of-range hour/minute/second component), mirroring `normalize_date`.
+    /// This keeps the range guard co-located with the parsing so the function is
+    /// self-contained: called in isolation it will not narrate "25:00", and inside
+    /// the pipeline the no-op leaves the region and its digits for the number phase.
     pub fn normalize_time(&self, time_str: &str) -> String {
+        const MAX_HOUR: i64 = 23;
+        const MAX_MINUTE: i64 = 59;
+        const MAX_SECOND: i64 = 59;
+
         let parts: Vec<&str> = time_str.split(':').collect();
         if parts.len() < 2 {
             return time_str.to_string();
@@ -984,6 +994,13 @@ impl NumberNormalizer {
         } else {
             0
         };
+
+        if !((0..=MAX_HOUR).contains(&hours)
+            && (0..=MAX_MINUTE).contains(&minutes)
+            && (0..=MAX_SECOND).contains(&seconds))
+        {
+            return time_str.to_string();
+        }
 
         let mut result_parts: Vec<String> = Vec::new();
 
@@ -1171,6 +1188,16 @@ mod tests {
     #[test_case("23:59" => "двадцать три часа пятьдесят девять минут"; "23_59")]
     #[test_case("10:30:15" => "десять часов тридцать минут пятнадцать секунд"; "with_seconds")]
     #[test_case("08:00:00" => "восемь часов"; "eight_zeros")]
+    // Out-of-range components are returned unchanged: the range guard lives inside
+    // normalize_time, so in the pipeline the no-op leaves digits for the number phase.
+    #[test_case("25:00" => "25:00"; "hour_out_of_range")]
+    #[test_case("99:00" => "99:00"; "hour_way_out_of_range")]
+    #[test_case("14:99" => "14:99"; "minute_out_of_range")]
+    #[test_case("25:99" => "25:99"; "hour_and_minute_out_of_range")]
+    #[test_case("14:30:99" => "14:30:99"; "second_out_of_range")]
+    #[test_case("14:30:60" => "14:30:60"; "second_boundary_60")]
+    #[test_case("24:00" => "24:00"; "hour_boundary_24")]
+    #[test_case("12:60" => "12:60"; "minute_boundary_60")]
     fn time(input: &str) -> String {
         nn().normalize_time(input)
     }


### PR DESCRIPTION
## Summary

Refactor-only cleanup of Phase 9 (dates/times) of the normalization pipeline. **No behaviour change** — all existing tests and golden fixtures stay green without touching any expectation.

Addresses the review points from #67 on `src-tauri/src/pipeline/mod.rs` (Phase 9) and `src-tauri/src/pipeline/normalizers/numbers.rs` (`normalize_time` / `normalize_date`).

## Changes, point by point

1. **Range validation moved inside `normalize_time`.** The clock-range guard (hours `0..=23`, minutes/seconds `0..=59`) lived in the pipeline closure, so `normalize_time` called in isolation would have narrated `"25:00"`. It now returns its input unchanged on an out-of-range component, mirroring `normalize_date`'s behaviour on invalid calendar values.

2. **Double parse removed.** The closure previously parsed the `h`/`m`/`s` capture groups and `normalize_time` then re-parsed via `split(':')`. With validation moved in, the closure collapses to a single `num.normalize_time(full)` call, matching the sibling date/range/percentage closures.

3. **Defensive `.parse().unwrap_or(-1)` gone.** Removed as a direct consequence of (2).

4. **Merged the duplicated `re_date_iso` / `re_date_dot` closures** into one reused closure (`let normalize_date = |caps| ...; tracked.sub(re_date_iso(), normalize_date); tracked.sub(re_date_dot(), normalize_date);`). Kept both `sub` calls explicit (the two regexes are genuinely different patterns) while eliminating the copy-pasted body.

5. **Named constants** `MAX_HOUR` / `MAX_MINUTE` / `MAX_SECOND` introduced in `normalize_time` in place of inline `23` / `59` literals.

## Invariant preserved

`TrackedText::sub` skips no-op replacements (`new_text == old_text`). The refactor preserves the invariant that an out-of-range time does not consume its region — the digits still reach the number phase. Covered by a new pipeline test: `"В 25:00 встреча"` → `"В двадцать пять:ноль встреча"`.

## Tests added

- Negative table-driven (`#[test_case]`) cases for `normalize_time`: `25:00`, `99:00`, `14:99`, `25:99`, `14:30:99`, plus boundary values `24:00`, `12:60`, `14:30:60` — all expected to return the input unchanged.
- `pipeline_invalid_time_falls_through_to_numbers` asserting the fall-through invariant.

No existing test or fixture was modified — they are the proof of unchanged behaviour.

## Gates

- `cargo fmt --check`: clean
- `cargo clippy --all-targets -D warnings`: clean
- `cargo test` (incl. `--test golden`): 811 + golden passing