### PR TITLE
test(pipeline): replace weak contains asserts with exact assertions

### DIFF
--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -604,7 +604,7 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        // TODO: keep `.contains()` here until the duplicate-block bug is fixed.
+        // TODO(#84): keep `.contains()` here until the duplicate-block bug is fixed.
         // Actual output is "\nдалее следует пример кода на пайтон\n\nдалее
         // следует пример кода на пайтон" — BOTH blocks come out brief, even
         // though the first is preceded by a `full` directive. Cause:

--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -515,20 +515,11 @@ mod tests {
 
     // ── TestCodeBlockFullMode (3 cases) ────────────────────────────────
 
-    #[test_case("def hello():\n    print('world')", Some("python"), &["деф", "хелло", "принт", "ворлд"]; "python_def_hello")]
-    #[test_case("const x = 42;", Some("javascript"), &["конст", "икс", "сорок два"]; "js_const_x")]
-    #[test_case("getUserData(userId)", None, &["гет юзер дата", "юзер ай ди"]; "function_call")]
-    fn full_mode(code: &str, language: Option<&str>, expected_substrings: &[&str]) {
-        let result = full_handler().process_block(code, language);
-        let lower = result.to_lowercase();
-        for expected in expected_substrings {
-            assert!(
-                lower.contains(expected),
-                "expected {:?} in {:?}",
-                expected,
-                result
-            );
-        }
+    #[test_case("def hello():\n    print('world')", Some("python") => "деф хелло открывающая скобка закрывающая скобка двоеточие принт открывающая скобка ворлд закрывающая скобка"; "python_def_hello")]
+    #[test_case("const x = 42;", Some("javascript") => "конст икс равно сорок два точка с запятой"; "js_const_x")]
+    #[test_case("getUserData(userId)", None => "гет юзер дата открывающая скобка юзер ай ди закрывающая скобка"; "function_call")]
+    fn full_mode(code: &str, language: Option<&str>) -> String {
+        full_handler().process_block(code, language)
     }
 
     // ── TestModeSwitch (4 cases) ────────────────────────────────────────
@@ -556,12 +547,10 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        // Brief would give "далее следует пример кода на пайтон"; Full should contain "принт".
-        assert!(
-            result.contains("принт"),
-            "expected full-mode output, got: {:?}",
-            result
-        );
+        // Brief would give "далее следует пример кода на пайтон"; the `full`
+        // directive upgrades the block to Full, so the code is read verbatim.
+        // Leading "\n" is where the removed directive line used to be.
+        assert_eq!(result, "\nпринт открывающая скобка хи закрывающая скобка");
     }
 
     // ── process() with TrackedText ──────────────────────────────────────
@@ -573,15 +562,10 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        assert!(
-            result.contains("далее следует пример кода на пайтон"),
-            "got: {:?}",
-            result
-        );
-        assert!(
-            !result.contains("```"),
-            "backticks should be gone, got: {:?}",
-            result
+        // Exact form also proves the backticks are gone (no "```" substring).
+        assert_eq!(
+            result,
+            "Смотри:\nдалее следует пример кода на пайтон\nКонец."
         );
     }
 
@@ -592,11 +576,7 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        assert!(
-            result.contains("Тут мермэйд диаграмма"),
-            "got: {:?}",
-            result
-        );
+        assert_eq!(result, "Диаграмма:\nТут мермэйд диаграмма\nКонец.");
     }
 
     #[test]
@@ -606,16 +586,11 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        // Full mode should contain "принт" and "ворлд"
-        assert!(
-            result.contains("принт"),
-            "expected full mode, got: {:?}",
-            result
-        );
-        assert!(
-            result.contains("ворлд"),
-            "expected full mode, got: {:?}",
-            result
+        // Full-mode reading of print('world'); the leading "\n" is where the
+        // removed directive line used to be.
+        assert_eq!(
+            result,
+            "\nпринт открывающая скобка ворлд закрывающая скобка"
         );
     }
 
@@ -629,7 +604,17 @@ mod tests {
         let h = CodeBlockHandler::with_mode(CodeBlockMode::Brief);
         h.process(&mut tracked);
         let result = tracked.text();
-        // Second block should be brief
+        // TODO: keep `.contains()` here until the duplicate-block bug is fixed.
+        // Actual output is "\nдалее следует пример кода на пайтон\n\nдалее
+        // следует пример кода на пайтон" — BOTH blocks come out brief, even
+        // though the first is preceded by a `full` directive. Cause:
+        // CodeBlockHandler::process() replaces blocks via literal
+        // TrackedText::replace(), which substitutes ALL occurrences, so two
+        // byte-identical code blocks both receive the replacement computed
+        // for whichever block is processed first (the second, brief one).
+        // With distinct block contents the modes are applied correctly.
+        // Pinning the buggy output with assert_eq! would freeze the wrong
+        // behaviour; only the second (brief) block is asserted here.
         assert!(
             result.contains("далее следует пример кода на пайтон"),
             "got: {:?}",

--- a/src-tauri/src/pipeline/normalizers/urls.rs
+++ b/src-tauri/src/pipeline/normalizers/urls.rs
@@ -513,19 +513,19 @@ mod tests {
 
     // ---- Common TLDs ----
 
-    #[test_case("https://example.com", "ком"; "com")]
-    #[test_case("https://example.org", "орг"; "org")]
-    #[test_case("https://example.net", "нет"; "net")]
-    #[test_case("https://example.ru", "ру"; "ru")]
-    #[test_case("https://example.io", "ай оу"; "io")]
-    #[test_case("https://example.dev", "дев"; "dev")]
-    #[test_case("https://example.app", "апп"; "app")]
-    #[test_case("https://example.ai", "эй ай"; "ai")]
-    #[test_case("https://example.co", "ко"; "co")]
-    #[test_case("https://example.me", "ми"; "me")]
-    fn tld(url: &str, expected: &str) {
+    #[test_case("https://example.com" => "эйч ти ти пи эс двоеточие слэш слэш example точка ком"; "com")]
+    #[test_case("https://example.org" => "эйч ти ти пи эс двоеточие слэш слэш example точка орг"; "org")]
+    #[test_case("https://example.net" => "эйч ти ти пи эс двоеточие слэш слэш example точка нет"; "net")]
+    #[test_case("https://example.ru" => "эйч ти ти пи эс двоеточие слэш слэш example точка ру"; "ru")]
+    #[test_case("https://example.io" => "эйч ти ти пи эс двоеточие слэш слэш example точка ай оу"; "io")]
+    #[test_case("https://example.dev" => "эйч ти ти пи эс двоеточие слэш слэш example точка дев"; "dev")]
+    #[test_case("https://example.app" => "эйч ти ти пи эс двоеточие слэш слэш example точка апп"; "app")]
+    #[test_case("https://example.ai" => "эйч ти ти пи эс двоеточие слэш слэш example точка эй ай"; "ai")]
+    #[test_case("https://example.co" => "эйч ти ти пи эс двоеточие слэш слэш example точка ко"; "co")]
+    #[test_case("https://example.me" => "эйч ти ти пи эс двоеточие слэш слэш example точка ми"; "me")]
+    fn tld(url: &str) -> String {
         let (_, nn) = mk_normalizer();
-        assert!(norm_no_en(&nn).normalize_url(url).contains(expected));
+        norm_no_en(&nn).normalize_url(url)
     }
 
     // ---- Protocols ----
@@ -597,17 +597,18 @@ mod tests {
         norm_no_en(&nn).normalize_filepath(input)
     }
 
-    // ---- Complex URLs (multiple expected substrings) ----
+    // ---- Complex URLs (query, fragment, multi-segment paths) ----
+    //
+    // English words and bare digit segments (e.g. "123") pass through
+    // verbatim here by design: later pipeline phases (English/number
+    // normalizers) pick them up.
 
-    #[test_case("https://example.com/search?q=test", &["example", "search", "q", "test"]; "query_params")]
-    #[test_case("https://docs.example.com/guide#installation", &["docs", "guide", "installation"]; "fragment")]
-    #[test_case("https://api.example.com/v1/users/123/posts", &["api", "v1", "users", "posts"]; "multiple_path_segments")]
-    fn complex_url(url: &str, parts: &[&str]) {
+    #[test_case("https://example.com/search?q=test" => "эйч ти ти пи эс двоеточие слэш слэш example точка ком слэш search вопросительный знак q равно test"; "query_params")]
+    #[test_case("https://docs.example.com/guide#installation" => "эйч ти ти пи эс двоеточие слэш слэш docs точка example точка ком слэш guide решётка installation"; "fragment")]
+    #[test_case("https://api.example.com/v1/users/123/posts" => "эйч ти ти пи эс двоеточие слэш слэш api точка example точка ком слэш v1 слэш users слэш 123 слэш posts"; "multiple_path_segments")]
+    fn complex_url(url: &str) -> String {
         let (_, nn) = mk_normalizer();
-        let result = norm_no_en(&nn).normalize_url(url);
-        for part in parts {
-            assert!(result.contains(part), "missing '{}' in '{}'", part, result);
-        }
+        norm_no_en(&nn).normalize_url(url)
     }
 
     // ---- With EnglishNormalizer (transliteration enabled) ----
@@ -617,9 +618,11 @@ mod tests {
         let (en, nn) = mk_normalizer();
         let n = norm(&en, &nn);
         let result = n.normalize_url("https://github.com/user/repo");
-        // With English normalizer, host parts should be transliterated.
-        // "github" → "гисуб" (transliteration), TLD "com" → "ком"
-        assert!(result.starts_with("эйч ти ти пи эс"));
-        assert!(result.contains("ком"));
+        // With the English normalizer enabled every English segment is
+        // transliterated: github → гитхаб, user → юзер, repo → репо.
+        assert_eq!(
+            result,
+            "эйч ти ти пи эс двоеточие слэш слэш гитхаб точка ком слэш юзер слэш репо"
+        );
     }
 }


### PR DESCRIPTION
## Summary

R4 of the refactoring epic: replace weak `.contains()` assertions with exact assertions in the `code_blocks` and `urls` normalizer tests. Test-only change; no production code touched.

Method: for every assertion the full actual output was captured, manually reviewed as Russian TTS text, and only then pinned exactly.

## Replacements (12)

### `src-tauri/src/pipeline/normalizers/code_blocks.rs` (9 contains removed)

1. `full_mode::python_def_hello` — substring loop (4 substrings) replaced with exact `test_case` return value: `"деф хелло открывающая скобка закрывающая скобка двоеточие принт открывающая скобка ворлд закрывающая скобка"`
2. `full_mode::js_const_x` — exact: `"конст икс равно сорок два точка с запятой"`
3. `full_mode::function_call` — exact: `"гет юзер дата открывающая скобка юзер ай ди закрывающая скобка"`
4. `mode_switch_via_process` — exact `assert_eq` on the full processed text (leading `\n` is where the removed directive line was)
5. `process_brief_replaces_fenced_block` — 2 contains (positive + no-backticks) replaced with one exact `assert_eq`; the exact form subsumes the backtick check
6. `process_mermaid_replaced_with_marker` — exact: `"Диаграмма:\nТут мермэйд диаграмма\nКонец."`
7. + 8. `process_mode_directive_switches_to_full` — 2 contains (`принт`, `ворлд`) replaced with one exact `assert_eq`
9. `process_mode_directive_brief_after_full` — **kept as `.contains()` with a TODO** (see finding below)

### `src-tauri/src/pipeline/normalizers/urls.rs` (3 contains removed)

10. `tld` (10 cases) — converted to `test_case` return-value style with full normalized URL strings
11. `complex_url` (3 cases) — substring loops replaced with full exact strings
12. `url_with_english_normalizer_transliterates` — exact `assert_eq`; also fixes a stale comment claiming `github` transliterates to `"гисуб"` (actual output: `"гитхаб"`)

The `full_mode` outputs were short enough that full literals were practical, so no structural splitting was needed.

## Finding: duplicate-block mode-directive bug

`process_mode_directive_brief_after_full` exposes a real bug, so its assert was deliberately left as `contains` with a TODO instead of pinning the wrong output:

- Input: two byte-identical ` ```python ` blocks, the first preceded by `<!-- ruvox-code: full -->`, the second by `<!-- ruvox-code: brief -->`.
- Expected: first block read in full mode, second brief.
- Actual: **both** come out brief (`"\nдалее следует пример кода на пайтон\n\nдалее следует пример кода на пайтон"`).
- Cause: `CodeBlockHandler::process()` applies replacements via literal `TrackedText::replace()`, which substitutes **all** occurrences, so identical blocks all receive the replacement computed for whichever block is processed first (the last one, due to reverse iteration). Verified that with distinct block contents the per-block modes are applied correctly. A fix could use `TrackedText::replace_byte_range()` instead.

## Notes

- `complex_url` outputs keep English words and the bare digit segment `123` verbatim — this is by design (`norm_no_en`; later English/number pipeline phases handle them), documented in a comment.

## Gates

- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 811 passed, 0 failed