### PR TITLE
test: extend test_case table convention to audio, commands and player modules

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -194,6 +194,12 @@ fn build_opus_tags() -> Vec<u8> {
 mod tests {
     use super::*;
     use crate::storage::test_util::write_sine_wav;
+    use test_case::test_case;
+
+    /// Rates enumerated as per-rate `#[test_case]` rows below. Kept in sync with
+    /// the production `SUPPORTED_SAMPLE_RATES` constant by
+    /// `test_case_rates_match_supported_sample_rates`.
+    const TEST_CASE_RATES: [u32; 5] = [8_000, 12_000, 16_000, 24_000, 48_000];
 
     /// Read the `input_sample_rate` field out of an encoded Ogg-Opus file's
     /// OpusHead packet. The packet is: "OggS" page header (27+ bytes) then
@@ -217,35 +223,54 @@ mod tests {
 
     /// Every Opus-native sample rate (RFC 6716 §2, `SUPPORTED_SAMPLE_RATES`)
     /// must round-trip through the encoder: a non-empty Ogg stream whose
-    /// OpusHead records the input rate. Table-driven so the 5 rates share one
-    /// assertion path instead of one copy-pasted test per rate.
+    /// OpusHead records the input rate. One `#[test_case]` per rate so a
+    /// failing rate is a named case, not a loop iteration swallowed by the
+    /// first `assert`.
+    #[test_case(8_000; "8kHz")]
+    #[test_case(12_000; "12kHz")]
+    #[test_case(16_000; "16kHz")]
+    #[test_case(24_000; "24kHz")]
+    #[test_case(48_000; "48kHz")]
+    fn encode_wav_produces_valid_opus_at_supported_rate(rate: u32) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wav_path = dir.path().join("in.wav");
+        let opus_path = dir.path().join("out.opus");
+
+        write_sine_wav(&wav_path, rate, 440.0, 0.25);
+        encode_wav_to_opus(&wav_path, &opus_path)
+            .unwrap_or_else(|e| panic!("encode failed at {rate} Hz: {e}"));
+
+        // 1 s at 32 kbps VOIP yields >1700 bytes even at 8/12 kHz; the
+        // pre-refactor 48 kHz test asserted > 1000, keep that bar so a
+        // header-only or truncated stream can't slip through.
+        let bytes = std::fs::read(&opus_path).expect("read opus");
+        assert!(
+            bytes.len() > 1000,
+            "opus too small at {rate} Hz: {}",
+            bytes.len()
+        );
+
+        let head_rate = read_opus_head_rate(&opus_path);
+        assert_eq!(
+            head_rate, rate,
+            "OpusHead input_sample_rate mismatch at {rate} Hz"
+        );
+    }
+
+    /// Compile-/run-time guard: the literal rates enumerated as `#[test_case]`
+    /// rows above must equal the production `SUPPORTED_SAMPLE_RATES` set, so a
+    /// newly supported rate cannot land without its own per-rate case.
     #[test]
-    fn encode_wav_produces_valid_opus_at_each_supported_rate() {
-        for rate in SUPPORTED_SAMPLE_RATES {
-            let dir = tempfile::tempdir().expect("tempdir");
-            let wav_path = dir.path().join("in.wav");
-            let opus_path = dir.path().join("out.opus");
-
-            write_sine_wav(&wav_path, rate, 440.0, 0.25);
-            encode_wav_to_opus(&wav_path, &opus_path)
-                .unwrap_or_else(|e| panic!("encode failed at {rate} Hz: {e}"));
-
-            // 1 s at 32 kbps VOIP yields >1700 bytes even at 8/12 kHz; the
-            // pre-refactor 48 kHz test asserted > 1000, keep that bar so a
-            // header-only or truncated stream can't slip through.
-            let bytes = std::fs::read(&opus_path).expect("read opus");
-            assert!(
-                bytes.len() > 1000,
-                "opus too small at {rate} Hz: {}",
-                bytes.len()
-            );
-
-            let head_rate = read_opus_head_rate(&opus_path);
-            assert_eq!(
-                head_rate, rate,
-                "OpusHead input_sample_rate mismatch at {rate} Hz"
-            );
-        }
+    fn test_case_rates_match_supported_sample_rates() {
+        let mut cases = TEST_CASE_RATES;
+        let mut supported = SUPPORTED_SAMPLE_RATES;
+        cases.sort_unstable();
+        supported.sort_unstable();
+        assert_eq!(
+            cases.as_slice(),
+            supported.as_slice(),
+            "add a #[test_case] row for every SUPPORTED_SAMPLE_RATES entry"
+        );
     }
 
     /// Rates outside the Opus-native set must be rejected up front.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1128,6 +1128,7 @@ mod synthesis_tests {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use test_case::test_case;
 
     // ── apply_config_patch ──────────────────────────────────────────────────
 
@@ -1367,39 +1368,27 @@ mod tests {
 
     // ── parse_entry_id ───────────────────────────────────────────────────────
 
-    #[test]
-    fn parse_entry_id_accepts_valid_uuid() {
-        let id = uuid::Uuid::new_v4();
-        let parsed = parse_entry_id(&id.to_string()).unwrap();
-        assert_eq!(parsed, id);
+    /// Well-formed UUID strings round-trip: `parse_entry_id` returns the same
+    /// UUID `Uuid::parse_str` would. Covers the nil UUID and a v4-shaped value.
+    #[test_case("00000000-0000-0000-0000-000000000000"; "nil")]
+    #[test_case("550e8400-e29b-41d4-a716-446655440000"; "v4")]
+    fn parse_entry_id_accepts_valid(input: &str) {
+        let parsed = parse_entry_id(input).unwrap();
+        assert_eq!(parsed, uuid::Uuid::parse_str(input).unwrap());
     }
 
-    #[test]
-    fn parse_entry_id_accepts_nil_uuid() {
-        let parsed = parse_entry_id("00000000-0000-0000-0000-000000000000").unwrap();
-        assert_eq!(parsed, uuid::Uuid::nil());
-    }
-
-    #[test]
-    fn parse_entry_id_rejects_empty_string() {
-        let err = parse_entry_id("").unwrap_err();
-        assert!(matches!(err, CommandError::NotFound { .. }));
-    }
-
-    #[test]
-    fn parse_entry_id_rejects_garbage() {
-        let err = parse_entry_id("not-a-uuid").unwrap_err();
+    /// Malformed ids are rejected as `CommandError::NotFound` whose message
+    /// (`invalid entry id '{s}': …`, per `parse_entry_id`) names the input.
+    /// Trailing whitespace is significant: the parser does not trim.
+    #[test_case(""; "empty")]
+    #[test_case("not-a-uuid"; "garbage")]
+    #[test_case("00000000-0000-0000-0000-000000000000 "; "trailing_whitespace")]
+    fn parse_entry_id_rejects(input: &str) {
+        let err = parse_entry_id(input).unwrap_err();
         assert!(matches!(err, CommandError::NotFound { .. }));
         if let CommandError::NotFound { message } = err {
             assert!(message.contains("invalid entry id"));
         }
-    }
-
-    #[test]
-    fn parse_entry_id_rejects_uuid_with_trailing_whitespace() {
-        let id = uuid::Uuid::new_v4();
-        let padded = format!("{id} ");
-        assert!(parse_entry_id(&padded).is_err());
     }
 
     // ── char_mapping_to_entries ──────────────────────────────────────────────
@@ -1446,57 +1435,50 @@ mod tests {
 
     // ── CommandError::from conversions ────────────────────────────────────────
 
-    #[test]
-    fn command_error_from_storage_not_found_maps_to_not_found_with_id() {
-        let id = uuid::Uuid::new_v4();
-        let err: CommandError = StorageError::NotFound(id).into();
-        let value = serde_json::to_value(&err).unwrap();
-        assert_eq!(
-            value,
-            json!({
-                "type": "not_found",
-                "message": format!("entry not found: {id}"),
-            })
-        );
-    }
-
-    #[test]
-    fn command_error_from_storage_other_variant_maps_to_storage_error() {
-        let source = StorageError::NoCacheDir;
-        let expected_message = source.to_string();
+    /// `From<StorageError>`: `NotFound` maps to the `not_found` type (with the
+    /// entry id carried into the message), every other variant to
+    /// `storage_error` with the source error's `Display` as the message.
+    #[test_case(
+        StorageError::NotFound(uuid::Uuid::nil()),
+        "not_found",
+        "entry not found: 00000000-0000-0000-0000-000000000000";
+        "not_found_carries_id"
+    )]
+    #[test_case(
+        StorageError::NoCacheDir,
+        "storage_error",
+        "cache dir unavailable: dirs::cache_dir() returned None";
+        "other_variant"
+    )]
+    fn command_error_from_storage(
+        source: StorageError,
+        expected_type: &str,
+        expected_message: &str,
+    ) {
         let err: CommandError = source.into();
         let value = serde_json::to_value(&err).unwrap();
         assert_eq!(
             value,
             json!({
-                "type": "storage_error",
+                "type": expected_type,
                 "message": expected_message,
             })
         );
     }
 
-    #[test]
-    fn command_error_from_tts_error_maps_to_synthesis_error() {
-        let source = TtsError::Died;
-        let expected_message = source.to_string();
-        let err: CommandError = source.into();
-        let value = serde_json::to_value(&err).unwrap();
-        assert_eq!(
-            value,
-            json!({
-                "type": "synthesis_error",
-                "message": expected_message,
-            })
-        );
-    }
-
-    #[test]
-    fn command_error_from_tts_ttsd_error_preserves_code_and_message() {
-        let source = TtsError::Ttsd {
+    /// `From<TtsError>`: every variant maps to `synthesis_error` carrying the
+    /// source error's `Display`. The literal `Ttsd` expectation pins that both
+    /// `code` and `message` survive into the wire message.
+    #[test_case(TtsError::Died, "ttsd subprocess has exited"; "died")]
+    #[test_case(
+        TtsError::Ttsd {
             code: "voice_not_installed".to_string(),
             message: "voice xenia missing".to_string(),
-        };
-        let expected_message = source.to_string();
+        },
+        "ttsd error [voice_not_installed]: voice xenia missing";
+        "ttsd_preserves_code_and_message"
+    )]
+    fn command_error_from_tts(source: TtsError, expected_message: &str) {
         let err: CommandError = source.into();
         let value = serde_json::to_value(&err).unwrap();
         assert_eq!(
@@ -1506,41 +1488,29 @@ mod tests {
                 "message": expected_message,
             })
         );
-        assert!(expected_message.contains("voice_not_installed"));
-        assert!(expected_message.contains("voice xenia missing"));
     }
 
     // ── serde: CleanupMode / ClearCacheArgs ───────────────────────────────────
 
-    #[test]
-    fn cleanup_mode_deserializes_size_limit_variant() {
-        let mode: CleanupMode =
-            serde_json::from_value(json!({ "mode": "size_limit", "target_mb": 250 })).unwrap();
-        match mode {
-            CleanupMode::SizeLimit { target_mb } => assert_eq!(target_mb, 250),
-            CleanupMode::All => panic!("expected SizeLimit"),
+    /// Accepted `CleanupMode` payloads deserialize to the right variant:
+    /// `size_limit` carries `target_mb` (mapped to `Some`), `all` has no
+    /// payload (mapped to `None`).
+    #[test_case(json!({ "mode": "size_limit", "target_mb": 250 }) => Some(250); "size_limit")]
+    #[test_case(json!({ "mode": "all" }) => None; "all")]
+    fn cleanup_mode_deserializes(value: serde_json::Value) -> Option<u32> {
+        match serde_json::from_value::<CleanupMode>(value).unwrap() {
+            CleanupMode::SizeLimit { target_mb } => Some(target_mb),
+            CleanupMode::All => None,
         }
     }
 
-    #[test]
-    fn cleanup_mode_deserializes_all_variant() {
-        let mode: CleanupMode = serde_json::from_value(json!({ "mode": "all" })).unwrap();
-        assert!(matches!(mode, CleanupMode::All));
-    }
-
-    #[test]
-    fn cleanup_mode_rejects_pascal_case_variant_name() {
-        // `rename_all = "snake_case"` on the `mode` tag: the Rust variant
-        // name `SizeLimit` must NOT be accepted on the wire.
-        let result: Result<CleanupMode, _> =
-            serde_json::from_value(json!({ "mode": "SizeLimit", "target_mb": 250 }));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn cleanup_mode_rejects_unknown_tag() {
-        let result: Result<CleanupMode, _> = serde_json::from_value(json!({ "mode": "bogus" }));
-        assert!(result.is_err());
+    /// Malformed `mode` tags are rejected: the Rust variant name `SizeLimit`
+    /// (the tag is `rename_all = "snake_case"`) and any unknown tag are both
+    /// invalid on the wire.
+    #[test_case(json!({ "mode": "SizeLimit", "target_mb": 250 }); "pascal_case_variant_name")]
+    #[test_case(json!({ "mode": "bogus" }); "unknown_tag")]
+    fn cleanup_mode_rejects(value: serde_json::Value) {
+        assert!(serde_json::from_value::<CleanupMode>(value).is_err());
     }
 
     #[test]

--- a/src-tauri/src/player/mod.rs
+++ b/src-tauri/src/player/mod.rs
@@ -532,6 +532,7 @@ pub fn spawn_position_emitter<R: Runtime + 'static>(player: Arc<Player<R>>, app:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     /// Compile-time check: Player::new returns Result (does not panic at type
     /// level).  The body is never executed because we cannot build a real
@@ -541,53 +542,31 @@ mod tests {
     }
 
     /// Smoke: PlayerError variants format correctly.
-    #[test]
-    fn player_error_display() {
-        let e = PlayerError::Init("test init".to_string());
-        assert_eq!(e.to_string(), "mpv init failed: test init");
-
-        let e = PlayerError::Op("test op".to_string());
-        assert_eq!(e.to_string(), "mpv operation failed: test op");
-
-        let e = PlayerError::FileNotFound("/tmp/x.wav".to_string());
-        assert_eq!(e.to_string(), "file not found: /tmp/x.wav");
+    #[test_case(PlayerError::Init("test init".to_string()) => "mpv init failed: test init"; "init")]
+    #[test_case(PlayerError::Op("test op".to_string()) => "mpv operation failed: test op"; "op")]
+    #[test_case(PlayerError::FileNotFound("/tmp/x.wav".to_string()) => "file not found: /tmp/x.wav"; "file_not_found")]
+    fn player_error_display(err: PlayerError) -> String {
+        err.to_string()
     }
 
     // -- is_eof ------------------------------------------------------------
 
-    #[test]
-    fn is_eof_none_pos_with_duration_is_eof() {
-        // mpv unloaded the file / entered idle while a duration was known.
-        assert!(is_eof(None, Some(10.0)));
-    }
-
-    #[test]
-    fn is_eof_pos_at_or_past_threshold_is_eof() {
-        // At exactly duration − 0.2 and beyond.
-        assert!(is_eof(Some(9.8), Some(10.0)));
-        assert!(is_eof(Some(10.0), Some(10.0)));
-        assert!(is_eof(Some(11.0), Some(10.0)));
-    }
-
-    #[test]
-    fn is_eof_pos_before_threshold_is_not_eof() {
-        // Just short of duration − 0.2 keeps playing.
-        assert!(!is_eof(Some(9.79), Some(10.0)));
-        assert!(!is_eof(Some(0.0), Some(10.0)));
-    }
-
-    #[test]
-    fn is_eof_unknown_duration_is_never_eof() {
-        // Without a duration we cannot decide the file ended.
-        assert!(!is_eof(None, None));
-        assert!(!is_eof(Some(5.0), None));
-    }
-
-    #[test]
-    fn is_eof_zero_duration_is_not_eof() {
-        // d > 0.0 guard: a zero-length duration must not be treated as EOF
-        // for a real position poll.
-        assert!(!is_eof(Some(0.0), Some(0.0)));
+    /// `is_eof(pos, duration)` decides EOF from mpv's last position poll:
+    /// - unknown duration → never EOF (cannot tell the file ended);
+    /// - a zero-length duration is guarded off (`d > 0.0`);
+    /// - otherwise EOF once `pos` is `None` (file unloaded) or within 0.2 s of
+    ///   the end.
+    #[test_case(None, Some(10.0) => true; "none_pos_with_duration")]
+    #[test_case(Some(9.8), Some(10.0) => true; "at_threshold")]
+    #[test_case(Some(10.0), Some(10.0) => true; "at_duration")]
+    #[test_case(Some(11.0), Some(10.0) => true; "past_duration")]
+    #[test_case(Some(9.79), Some(10.0) => false; "just_before_threshold")]
+    #[test_case(Some(0.0), Some(10.0) => false; "start_of_file")]
+    #[test_case(None, None => false; "unknown_duration_no_pos")]
+    #[test_case(Some(5.0), None => false; "unknown_duration_with_pos")]
+    #[test_case(Some(0.0), Some(0.0) => false; "zero_duration")]
+    fn is_eof_cases(pos: Option<f64>, duration: Option<f64>) -> bool {
+        is_eof(pos, duration)
     }
 
     // -- seek_suppressed ---------------------------------------------------


### PR DESCRIPTION
R3 of the test-refactor epic: extend the `#[test_case]` table-test convention (dev-dep `test-case = 3.3.1`, style modeled on `src-tauri/src/pipeline/normalizers/numbers.rs`) to test modules outside `pipeline/`. Test-only change — no production code touched. Coverage is 1:1; expectations unchanged (two deviations noted below).

## Converted

| Module | Group | Before | After |
|---|---|---|---|
| `src/audio/mod.rs` | `encode_wav_produces_valid_opus_*` | 1 test, internal `for` over 5 rates | 5 named `#[test_case]` rows + 1 guard test |
| `src/commands/mod.rs` | `parse_entry_id_*` | 5 tests | 5 rows (2 accept + 3 reject) |
| `src/commands/mod.rs` | `command_error_from_*` | 4 tests | 4 rows (2 tables) |
| `src/commands/mod.rs` | `cleanup_mode_*` | 4 tests | 4 rows (accept/reject tables) |
| `src/player/mod.rs` | `player_error_display` | 1 test, 3 assertions | 3 rows |
| `src/player/mod.rs` | `is_eof_*` | 5 tests, 9 assertions | 9 rows |

`#[test_case]` attributes need literal rates, but the loop iterated the production `SUPPORTED_SAMPLE_RATES` constant — so the audio table gets a compile-time-listed `TEST_CASE_RATES` plus a guard test (`test_case_rates_match_supported_sample_rates`) asserting the sorted lists are equal. A newly supported rate cannot land without its own per-rate case.

## Deliberately not converted

- `commands`: `apply_config_patch_*` (already table-driven with exhaustive destructuring — out of scope per task), `char_mapping_to_entries_*` (2 heterogeneous tests), `clear_cache_args_*` (2 tests with different assertion shapes), `set_speed`/`set_volume` contract tests (documentation-pin tests, no input table).
- `player`: `seek_suppressed_*` (4 tests) — inputs are `Instant::now()` arithmetic computed per test, not literals a `test_case` row can express; `_assert_new_returns_result` (compile-time check).
- `tts/switcher.rs`: `parse_kind` accept group has only 2 cases (below the >= 3 threshold); the `apply_config_*` tests are async with `TempDir`s and a mock emitter (setup-heavy, not input->expectation rows).
- `tts/mod.rs`: serde tests are heterogeneous — each asserts a different field shape of the JSON (`warmup`/`shutdown` share a shape but are only 2 cases; `synthesize`/response tests each check different structures).

## Case-count verification

Test counts per module (`cargo test --lib -- --list`, before = counted `#[test]`/`#[tokio::test]` attributes at `origin/main` inside `mod tests`):

| Module | Before | After | Delta |
|---|---|---|---|
| `audio::tests` | 5 | 10 | +5: 1 looped test split into 5 named cases, +1 rate-sync guard |
| `commands::tests` | 22 | 22 | 0 |
| `player::tests` | 10 | 16 | +6: multi-assert tests split into named rows |
| `tts::tests` | 8 | 8 | untouched |
| `tts::switcher::tests` | 5 | 5 | untouched |

Multisets of (input, expected) pairs were compared mechanically (script diffing `git show origin/main:<file>` vs HEAD extractions): audio rates 5=5, `parse_entry_id` 5=5, `CommandError::from` 4=4, `CleanupMode` serde 4=4, `player_error_display` 3=3, `is_eof` 9=9 — all match.

Two intentional deviations from strict 1:1, both strengthenings:
- `parse_entry_id` accept rows use fixed UUID literals instead of `Uuid::new_v4()`; the merged reject table asserts `NotFound` + message for all rows (before, the empty-string row checked only the variant and the trailing-whitespace row only `is_err()`).
- `command_error_from_*` expected messages are pinned as string literals instead of `source.to_string()`; the previous `contains(code)`/`contains(message)` assertions for the `Ttsd` case are implied by the exact-equality pin.

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 813 unit + integration tests, 0 failed
