### PR TITLE
ci: bump actions/cache to v6 in OpenSpec job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Locate pnpm store
         id: pnpm-store
         run: echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-store.outputs.dir }}
           key: ${{ runner.os }}-pnpm-store-openspec


### PR DESCRIPTION
Bump `actions/cache` from v4 to v6 in the `OpenSpec (validate specs)` CI job to silence the Node.js 20 deprecation warning.\n\n```\nactions/cache@v4 → actions/cache@v6\n```