### PR TITLE
feat(tts): make cancel_synthesis actually stop synthesis

### DIFF
--- a/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/design.md
+++ b/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/design.md
@@ -1,0 +1,107 @@
+# Design: Real synthesis cancellation
+
+## Current mechanics (why cancel is a lie)
+
+Each entry synthesis runs as its own tokio task (`spawn_synthesis`,
+`src-tauri/src/commands/mod.rs:368-430`): normalize → `mark_processing` →
+`synthesize_audio` → finalize (WAV→Opus, timestamps) →
+`mark_ready_and_emit` → optional autoplay. Requests to ttsd are serialized
+through an mpsc channel (capacity 1) consumed by a single `driver_task`
+(`src-tauri/src/tts/mod.rs:308-352`); the implicit queue is the set of
+tasks waiting on `send()` or on their oneshot reply. `cancel_synthesis`
+(mod.rs:660-664) only writes status `pending`; the task keeps running, and
+`mark_ready_and_emit` (mod.rs:328-350) applies the late result without
+checking the current status — the cancelled entry silently becomes `ready`
+again.
+
+## Chosen design: abort + stale guard + targeted kill
+
+### Layer 1 — stale-completion guard (the issue's minimum)
+
+`mark_ready_and_emit`, `set_entry_error`, and the autoplay step re-read the
+entry's status and proceed only if it is still `processing`. Otherwise the
+late result is dropped: any audio/timestamp files just written for the
+entry are deleted, no `entry_updated`→`ready` event is emitted, no
+autoplay. This also hardens `regenerate_entry` races, not just cancel.
+
+### Layer 2 — abort registry
+
+`AppState` gains `synthesis_tasks: Mutex<HashMap<EntryId, AbortHandle>>`,
+populated in `spawn_synthesis` and cleared when the task finishes (any
+outcome). `cancel_synthesis` aborts the task and sets the entry back to
+`pending`. Tasks aborted while queued (before their request reaches ttsd)
+stop immediately with zero subprocess impact. Aborting a task whose request
+is already written to ttsd's stdin leaves an orphaned response in the pipe;
+that is protocol-safe: the driver reads exactly one line per request and
+the dead oneshot receiver is already handled (`req.reply.send(result)`
+ignores the error, `src-tauri/src/tts/mod.rs:331`).
+
+### Layer 3 — kill the subprocess when the cancelled entry reached the TTS stage
+
+`AppState` also tracks which entries have entered the `tts.synthesize()`
+await (`synthesize_entered: Mutex<HashSet<EntryId>>`, set just before the
+call, cleared after). When `cancel_synthesis` aborts such an entry, it
+additionally calls a new `TtsSupervisor::kill_current()`: the current
+`Arc<TtsSubprocess>` slot is cleared, `kill_on_drop` terminates the
+process, and the next request triggers the existing `ensure_respawned`
+(BACKOFFS = 1s/3s/5s, up to 3 attempts, `supervisor.rs:41-45`) with its
+background warmup and `model_loading`/`model_loaded` events. Requests from
+*other* entries that were in flight or queued are retried transparently by
+the existing `with_retry` loop (`supervisor.rs:95-114`).
+
+Known collateral, accepted: if the cancelled entry had entered
+`synthesize()` but was still waiting for the channel slot while *another*
+entry's request was in flight, the kill also interrupts that other request;
+it is then retried (restart + warmup + re-synthesis). Cancellation is a
+rare, explicit user action, and the issue explicitly accepts this class of
+collateral for the simple option.
+
+## Rejected alternatives
+
+- **Cooperative protocol cancel (`cmd:"cancel"`)** — requires a reader
+  thread in ttsd (its main loop is a blocking `for raw_line in sys.stdin`,
+  `ttsd/ttsd/main.py:106`), chunk-level cancel checks in `silero.py`, a
+  writer/reader split in `driver_task`, and request ids for out-of-order
+  replies. That is a redesign of the strict request-response protocol, and
+  it contradicts the `ttsd-protocol` requirement "Serialized Request
+  Concurrency" (exactly one request in flight). The only gain over the
+  hybrid is avoiding the restart of a *different* entry's in-flight request
+  — not worth the volume and risk.
+- **Naive always-kill** (kill ttsd on every cancel, no abort registry) —
+  restarts the model even when the cancelled entry never reached ttsd
+  (warmup costs seconds); the abort registry avoids that in the common
+  queued case.
+- **Guard only** (the issue's stated minimum) — stops the silent `ready`
+  resurrection but leaves a cancelled Silero synthesis burning CPU for tens
+  of seconds, which is the core complaint of #88.
+
+## Touch points
+
+- `src-tauri/src/commands/mod.rs` — guards in `mark_ready_and_emit` /
+  `set_entry_error` / autoplay (with file cleanup); registry population in
+  `spawn_synthesis`; new `cancel_synthesis` logic (abort + conditional
+  kill); unregister on task completion.
+- `src-tauri/src/state.rs` — `synthesis_tasks` and `synthesize_entered`
+  fields.
+- `src-tauri/src/tts/mod.rs` — active kill support: `TtsSubprocess::kill_now()`
+  signals the driver via a watch channel; the driver (on `tokio::select!`)
+  SIGKILLs the child even mid-request and answers the in-flight request with
+  `TtsError::Died`. (Passive slot clearing is not sufficient: the driver owns
+  the `Child` and blocks awaiting the response, so `kill_on_drop` would only
+  fire after the synthesis runs out — exactly the CPU burn #88 removes.)
+- `src-tauri/src/tts/supervisor.rs` — new `kill_current()` forwarding to
+  `kill_now()`; the respawn itself goes through the existing
+  `ensure_respawned` path (single-flight, backoff, `ttsd_restarting`,
+  warmup).
+- No Python / protocol changes.
+
+## Tests
+
+- Unit/integration: stale-guard behavior (completion after cancel does not
+  flip status, files removed) — extract the guard decision into a pure
+  function over entry status if that keeps it testable without Tauri
+  `State`.
+- `tests/supervisor.rs`-style integration with the existing mock ttsd:
+  `kill_current` drops the process, the next request respawns it and
+  succeeds (retry path intact).
+- ttsd pytest: untouched.

--- a/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/proposal.md
+++ b/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: Real synthesis cancellation (#88)
+
+## Summary
+
+Today `cancel_synthesis` is a cancellation in name only: it flips the entry
+back to `pending` while the in-flight ttsd request runs to completion, and
+the completion handler then silently resurrects the entry to `ready` with
+fresh audio. For long Silero syntheses this wastes tens of seconds of CPU
+and produces exactly the result the user asked to discard.
+
+Make cancellation real, in three layers:
+
+1. **Stale-completion guard.** The completion and error paths
+   (`mark_ready_and_emit`, `set_entry_error`, autoplay) only apply their
+   result when the entry is still `processing`. A completion arriving for an
+   entry that is no longer `processing` is discarded together with its
+   freshly written audio files.
+2. **Abort queued work.** `AppState` keeps a registry of
+   `entry_id → tokio::task::AbortHandle` for spawned synthesis tasks.
+   `cancel_synthesis` aborts the task, so entries that never reached ttsd
+   stop immediately without touching the subprocess.
+3. **Kill in-flight work.** An entry that already entered the TTS stage is
+   tracked; cancelling it additionally drops the current ttsd subprocess
+   (`kill_on_drop`), freeing the CPU immediately. The supervisor's existing
+   auto-restart (3 attempts, 1/3/5 s backoff) brings a fresh instance up,
+   and other queued/in-flight requests are retried by the existing
+   `with_retry` logic.
+
+## Capabilities
+
+- `ipc-commands` (modified) — the `cancel_synthesis` command contract
+- `queue-lifecycle` (modified) — status transitions on cancel, stale
+  completion handling
+- `ttsd-protocol` (modified) — restart may also be triggered by cancellation
+
+## Non-goals
+
+- No ttsd protocol changes: no `cancel` request, no reader thread, no
+  request ids (the cooperative-cancel redesign was evaluated and rejected —
+  see design.md).
+- Piper in-process synthesis is not interruptible mid-call; for Piper the
+  abort + stale guard applies (the blocking call runs out, its result is
+  discarded). True mid-inference Piper cancellation is out of scope.
+- No changes to the retry/backoff policy itself.
+
+## Approach
+
+See design.md for the rejected alternatives (protocol-level cooperative
+cancel; naive always-kill) and the exact touch points.

--- a/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/specs/ipc-commands/spec.md
+++ b/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/specs/ipc-commands/spec.md
@@ -1,0 +1,85 @@
+# Delta: ipc-commands
+
+## MODIFIED Requirements
+
+### Requirement: Synthesis Cancellation Command
+
+The system SHALL provide `cancel_synthesis(id)` which actually stops the
+entry's synthesis work and sets the entry status back to `pending`, emitting
+`entry_updated`. Cancellation SHALL abort the entry's spawned synthesis task
+via a per-entry abort registry. If the cancelled entry had already entered
+the TTS stage, the system SHALL additionally terminate the current ttsd
+subprocess; recovery then follows the ttsd-protocol auto-restart procedure,
+and requests belonging to other entries are retried transparently. A late
+completion or failure belonging to a cancelled entry SHALL be discarded: the
+entry MUST NOT flip to `ready` or `error`, any audio/timestamp files written
+by the late completion SHALL be removed, no further `entry_updated` for that
+completion is emitted, and no autoplay starts. A missing entry fails with
+`not_found`.
+
+#### Scenario: cancel a queued synthesis
+
+- GIVEN an entry with status `processing` whose request has not yet reached
+  ttsd
+- WHEN `cancel_synthesis` is invoked
+- THEN the synthesis task is aborted, the entry status becomes `pending`,
+  `entry_updated` is emitted, and the ttsd subprocess keeps running (no
+  restart)
+
+#### Scenario: cancel an in-flight synthesis
+
+- GIVEN an entry with status `processing` whose request is being synthesized
+  by ttsd
+- WHEN `cancel_synthesis` is invoked
+- THEN the synthesis task is aborted, the ttsd subprocess is terminated, the
+  supervisor restarts it per the auto-restart procedure, and the entry
+  status becomes `pending`
+
+#### Scenario: late completion is discarded
+
+- GIVEN an entry that was cancelled back to `pending` while its request was
+  in flight
+- WHEN the orphaned request completes
+- THEN the entry remains `pending`, the generated audio/timestamp files are
+  removed, no `entry_updated` with `ready` is emitted, and no autoplay
+  starts
+
+#### Scenario: cancel a missing entry
+
+- GIVEN no entry with the given id
+- WHEN `cancel_synthesis` is invoked
+- THEN the command fails with `not_found`
+
+### Requirement: Entry Lifecycle Events
+
+The backend SHALL emit `entry_updated` with payload `{ entry: TextEntry }`
+whenever an entry is created or any of its fields change: on ingestion
+(`pending`), when synthesis starts (`processing`, `normalized_text` set), when
+synthesis completes (`ready`, audio/timestamps paths and `duration_sec` set),
+when synthesis fails (`error`, `error_message` set), after `delete_audio`,
+`regenerate_entry`, `cancel_synthesis`, and after `clear_cache` for each reset
+entry. A discarded late completion (after cancellation) SHALL NOT emit
+`entry_updated` with `ready` or `error`. The backend SHALL emit
+`entry_removed` with payload `{ id }` when an entry is removed from history
+by a bulk operation; the frontend MUST drop the entry from local state
+without expecting any `entry_updated` follow-up.
+
+#### Scenario: synthesis progress is reflected via entry_updated
+
+- GIVEN a newly ingested entry
+- WHEN background synthesis runs to completion
+- THEN the frontend receives `entry_updated` with `pending`, then
+  `processing`, then `ready` carrying the audio path and duration
+
+#### Scenario: no ready event after cancellation
+
+- GIVEN an entry cancelled back to `pending`
+- WHEN its orphaned synthesis completes
+- THEN no `entry_updated` carrying `ready` is emitted for that completion
+
+#### Scenario: bulk removal notification
+
+- GIVEN `clear_cache` removed an entry from history
+- WHEN the `entry_removed` event arrives
+- THEN the payload is `{ id: "<uuid>" }` and no `entry_updated` follows for
+  that entry

--- a/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/specs/queue-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/specs/queue-lifecycle/spec.md
@@ -1,0 +1,55 @@
+# Delta: queue-lifecycle
+
+## MODIFIED Requirements
+
+### Requirement: Entry status lifecycle
+
+The system SHALL move each entry through the statuses `pending` ->
+`processing` -> `ready` during background synthesis: the entry is persisted
+as `pending`, switched to `processing` once normalization completes, and to
+`ready` once the audio file, word timestamps, and `duration_sec` are stored.
+On any synthesis failure the system SHALL set the status to `error` and store
+a user-visible message in `error_message`. After each status change the
+system SHALL emit an `entry_updated` event. When the entry was added with
+`play_when_ready = true`, the system SHALL start playback automatically once
+the entry reaches `ready`; auto-play failures MUST NOT flip the entry into
+`error`. The `playing` status is transient only — the storage layer
+normalizes `playing` back to `ready` on save. `cancel_synthesis` SHALL move
+an entry from `processing` back to `pending`; a synthesis completion or
+failure arriving for an entry that is no longer `processing` SHALL be
+discarded without changing its status (see the Synthesis Cancellation
+Command requirement in `ipc-commands`).
+
+#### Scenario: Successful synthesis
+
+- GIVEN a newly added entry with status `pending`
+- WHEN normalization and TTS synthesis complete successfully
+- THEN the entry status becomes `ready`, `audio_path`, `timestamps_path` and
+  `duration_sec` are populated, and an `entry_updated` event is emitted
+
+#### Scenario: Synthesis failure
+
+- GIVEN an entry in status `processing`
+- WHEN the TTS engine fails
+- THEN the entry status becomes `error`, `error_message` is set, and a
+  `tts_error` event is emitted
+
+#### Scenario: Read-now add
+
+- GIVEN an entry added with `play_when_ready = true`
+- WHEN the entry reaches status `ready`
+- THEN playback of the entry's audio starts automatically
+
+#### Scenario: Cancellation returns the entry to pending
+
+- GIVEN an entry in status `processing`
+- WHEN `cancel_synthesis` runs
+- THEN the entry status becomes `pending` and the entry can be regenerated
+  later
+
+#### Scenario: Stale completion does not change status
+
+- GIVEN an entry that left `processing` (cancelled back to `pending`)
+- WHEN its late synthesis completion or failure arrives
+- THEN the entry status is left unchanged and the late result's files are
+  removed

--- a/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/specs/ttsd-protocol/spec.md
+++ b/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/specs/ttsd-protocol/spec.md
@@ -1,0 +1,56 @@
+# Delta: ttsd-protocol
+
+## MODIFIED Requirements
+
+### Requirement: Auto-Restart on Subprocess Death
+
+The `TtsSupervisor` SHALL detect a dead ttsd when a request fails with
+`TtsError::Died` (only `Died` triggers respawn — protocol errors and timeouts
+propagate as-is) or when the subprocess was explicitly terminated by
+`cancel_synthesis` for an in-flight entry (see the Synthesis Cancellation
+Command requirement in `ipc-commands`). On detection it SHALL:
+
+1. Log a warning and emit `ttsd_restarting` (`{}`).
+2. Make the respawn single-flight (concurrent callers share one respawn).
+3. Try to spawn a fresh ttsd up to 3 times with backoff delays of 1 s, 3 s, 5 s.
+4. After a successful respawn, run `warmup` in the background re-emitting
+   `model_loading` → `model_loaded` / `model_error`, and retry the failed
+   request against the new handle.
+5. After all attempts fail, emit `tts_fatal { message }` and surface the spawn
+   error to the caller; the next request SHALL trigger a fresh respawn attempt
+   so the system can still recover later.
+
+An in-flight request sent to the crashed or terminated process fails; after
+an explicit kill for cancellation, in-flight and queued requests belonging
+to OTHER entries SHALL be retried transparently via the existing retry loop,
+while the cancelled entry's own request is not retried (its task is
+aborted). Pending entries whose requests ultimately fail go to the `error`
+state via the normal command-error path.
+
+#### Scenario: transparent respawn and retry
+
+- GIVEN a ttsd that crashed mid-session
+- WHEN the next request hits `TtsError::Died`
+- THEN `ttsd_restarting` is emitted, a new process is spawned within the
+  backoff schedule, warmup replays the model lifecycle events, and the
+  request is retried against the new process
+
+#### Scenario: respawn after cancellation kill
+
+- GIVEN a ttsd terminated by `cancel_synthesis` for an in-flight entry
+- WHEN the next request arrives
+- THEN a fresh ttsd is spawned per the same backoff/warmup procedure and
+  other entries' requests proceed against the new process
+
+#### Scenario: respawn exhausted
+
+- GIVEN a supervisor whose spawn attempts all fail
+- WHEN the third attempt fails
+- THEN `tts_fatal` is emitted with the error message and the caller receives
+  the spawn error
+
+#### Scenario: protocol errors do not trigger respawn
+
+- GIVEN a live ttsd that responds with an error (e.g. `bad_input`)
+- WHEN the request completes with that error
+- THEN no respawn is attempted and no `ttsd_restarting` event is emitted

--- a/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/tasks.md
+++ b/openspec/changes/archive/2026-07-25-real-synthesis-cancellation/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Real synthesis cancellation
+
+## Implementation
+
+- [x] `src-tauri/src/state.rs`: add `synthesis_tasks:
+  Mutex<HashMap<EntryId, AbortHandle>>` and `synthesize_entered:
+  Mutex<HashSet<EntryId>>` to `AppState`.
+- [x] `src-tauri/src/commands/mod.rs` `spawn_synthesis`: register the task's
+  `AbortHandle`; mark the entry in `synthesize_entered` around the
+  `tts.synthesize()` await; unregister both on any task outcome.
+- [x] `src-tauri/src/commands/mod.rs`: stale-completion guard in
+  `mark_ready_and_emit`, `set_entry_error`, and the autoplay step — proceed
+  only if the entry is still `processing`; otherwise delete the freshly
+  written audio/timestamp files and skip events/autoplay. Extract the guard
+  decision into a testable pure function if that avoids Tauri `State` in
+  tests.
+- [x] `src-tauri/src/commands/mod.rs` `cancel_synthesis`: abort the task via
+  the registry, set the entry to `pending`, emit `entry_updated`; if the
+  entry was in `synthesize_entered`, call `TtsSupervisor::kill_current()`.
+- [x] `src-tauri/src/tts/supervisor.rs`: add `kill_current()` — clear the
+  current subprocess slot so `kill_on_drop` terminates ttsd; the next
+  request respawns via the existing `ensure_respawned` path (with
+  `ttsd_restarting` and warmup events).
+
+## Tests
+
+- [x] Guard unit tests: a late completion/failure for a non-`processing`
+  entry changes no status and removes the late files.
+- [x] `cancel_synthesis` unit tests: missing entry → `not_found`; cancel
+  sets `pending` and aborts the registered task.
+- [x] Integration test next to `src-tauri/tests/supervisor.rs` (mock ttsd):
+  `kill_current` drops the process and the next request transparently
+  respawns + succeeds.
+
+## Validation
+
+- [x] `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml` green.
+- [x] `nix develop -c just lint` green.
+- [x] `nix develop -c pnpm dlx @fission-ai/openspec@1.6.0 validate
+  real-synthesis-cancellation --strict` green.

--- a/openspec/specs/ipc-commands/spec.md
+++ b/openspec/specs/ipc-commands/spec.md
@@ -9,9 +9,7 @@ Tauri events the backend emits to the frontend via `listen("event_name", handler
 This covers command signatures, typed error format, shared data types, and event
 payloads as currently implemented. The backend-to-Python protocol is specified
 separately in `ttsd-protocol`.
-
 ## Requirements
-
 ### Requirement: Command Error Format
 
 All fallible Tauri commands SHALL return errors as a typed JSON object
@@ -219,16 +217,51 @@ rejected with `synthesis_error` to avoid racing the in-flight task.
 
 ### Requirement: Synthesis Cancellation Command
 
-The system SHALL provide `cancel_synthesis(id)` which sets the entry status
-back to `pending` and emits `entry_updated`. The current implementation does
-NOT abort an in-flight TTS request — the TTS supervisor serializes all requests
-through a single channel, so a running synthesis continues to completion; only
-the entry status is reset. A missing entry fails with `not_found`.
+The system SHALL provide `cancel_synthesis(id)` which actually stops the
+entry's synthesis work and sets the entry status back to `pending`, emitting
+`entry_updated`. Cancellation SHALL abort the entry's spawned synthesis task
+via a per-entry abort registry. If the cancelled entry had already entered
+the TTS stage, the system SHALL additionally terminate the current ttsd
+subprocess; recovery then follows the ttsd-protocol auto-restart procedure,
+and requests belonging to other entries are retried transparently. A late
+completion or failure belonging to a cancelled entry SHALL be discarded: the
+entry MUST NOT flip to `ready` or `error`, any audio/timestamp files written
+by the late completion SHALL be removed, no further `entry_updated` for that
+completion is emitted, and no autoplay starts. A missing entry fails with
+`not_found`.
 
 #### Scenario: cancel a queued synthesis
-- GIVEN an entry with status `processing`
+
+- GIVEN an entry with status `processing` whose request has not yet reached
+  ttsd
 - WHEN `cancel_synthesis` is invoked
-- THEN the entry status becomes `pending` and `entry_updated` is emitted
+- THEN the synthesis task is aborted, the entry status becomes `pending`,
+  `entry_updated` is emitted, and the ttsd subprocess keeps running (no
+  restart)
+
+#### Scenario: cancel an in-flight synthesis
+
+- GIVEN an entry with status `processing` whose request is being synthesized
+  by ttsd
+- WHEN `cancel_synthesis` is invoked
+- THEN the synthesis task is aborted, the ttsd subprocess is terminated, the
+  supervisor restarts it per the auto-restart procedure, and the entry
+  status becomes `pending`
+
+#### Scenario: late completion is discarded
+
+- GIVEN an entry that was cancelled back to `pending` while its request was
+  in flight
+- WHEN the orphaned request completes
+- THEN the entry remains `pending`, the generated audio/timestamp files are
+  removed, no `entry_updated` with `ready` is emitted, and no autoplay
+  starts
+
+#### Scenario: cancel a missing entry
+
+- GIVEN no entry with the given id
+- WHEN `cancel_synthesis` is invoked
+- THEN the command fails with `not_found`
 
 ### Requirement: Playback Control Commands
 
@@ -376,19 +409,31 @@ whenever an entry is created or any of its fields change: on ingestion
 synthesis completes (`ready`, audio/timestamps paths and `duration_sec` set),
 when synthesis fails (`error`, `error_message` set), after `delete_audio`,
 `regenerate_entry`, `cancel_synthesis`, and after `clear_cache` for each reset
-entry. The backend SHALL emit `entry_removed` with payload `{ id }` when an
-entry is removed from history by a bulk operation; the frontend MUST drop the
-entry from local state without expecting any `entry_updated` follow-up.
+entry. A discarded late completion (after cancellation) SHALL NOT emit
+`entry_updated` with `ready` or `error`. The backend SHALL emit
+`entry_removed` with payload `{ id }` when an entry is removed from history
+by a bulk operation; the frontend MUST drop the entry from local state
+without expecting any `entry_updated` follow-up.
 
 #### Scenario: synthesis progress is reflected via entry_updated
+
 - GIVEN a newly ingested entry
 - WHEN background synthesis runs to completion
-- THEN the frontend receives `entry_updated` with `pending`, then `processing`, then `ready` carrying the audio path and duration
+- THEN the frontend receives `entry_updated` with `pending`, then
+  `processing`, then `ready` carrying the audio path and duration
+
+#### Scenario: no ready event after cancellation
+
+- GIVEN an entry cancelled back to `pending`
+- WHEN its orphaned synthesis completes
+- THEN no `entry_updated` carrying `ready` is emitted for that completion
 
 #### Scenario: bulk removal notification
+
 - GIVEN `clear_cache` removed an entry from history
 - WHEN the `entry_removed` event arrives
-- THEN the payload is `{ id: "<uuid>" }` and no `entry_updated` follows for that entry
+- THEN the payload is `{ id: "<uuid>" }` and no `entry_updated` follows for
+  that entry
 
 ### Requirement: Synthesis Failure Event
 
@@ -462,3 +507,4 @@ During `download_piper_voice` the backend SHALL emit:
 - GIVEN a voice that is not installed
 - WHEN `download_piper_voice` runs
 - THEN `voice_download_started` fires first, `voice_download_progress` events carry cumulative byte counts per file, and a terminal `voice_download_finished` with `ok: true` completes the sequence
+

--- a/openspec/specs/queue-lifecycle/spec.md
+++ b/openspec/specs/queue-lifecycle/spec.md
@@ -6,9 +6,7 @@ Covers how text entries enter the queue (clipboard add flow, with or without
 the normalization preview dialog), how their synthesis status progresses, and
 how the queue is presented in the UI: entry list rendering, sorting, search,
 per-entry actions, deletion, and the resizable queue panel.
-
 ## Requirements
-
 ### Requirement: Clipboard add flow
 
 The system SHALL read text from the system clipboard when the user activates
@@ -51,7 +49,11 @@ system SHALL emit an `entry_updated` event. When the entry was added with
 `play_when_ready = true`, the system SHALL start playback automatically once
 the entry reaches `ready`; auto-play failures MUST NOT flip the entry into
 `error`. The `playing` status is transient only — the storage layer
-normalizes `playing` back to `ready` on save.
+normalizes `playing` back to `ready` on save. `cancel_synthesis` SHALL move
+an entry from `processing` back to `pending`; a synthesis completion or
+failure arriving for an entry that is no longer `processing` SHALL be
+discarded without changing its status (see the Synthesis Cancellation
+Command requirement in `ipc-commands`).
 
 #### Scenario: Successful synthesis
 
@@ -72,6 +74,20 @@ normalizes `playing` back to `ready` on save.
 - GIVEN an entry added with `play_when_ready = true`
 - WHEN the entry reaches status `ready`
 - THEN playback of the entry's audio starts automatically
+
+#### Scenario: Cancellation returns the entry to pending
+
+- GIVEN an entry in status `processing`
+- WHEN `cancel_synthesis` runs
+- THEN the entry status becomes `pending` and the entry can be regenerated
+  later
+
+#### Scenario: Stale completion does not change status
+
+- GIVEN an entry that left `processing` (cancelled back to `pending`)
+- WHEN its late synthesis completion or failure arrives
+- THEN the entry status is left unchanged and the late result's files are
+  removed
 
 ### Requirement: Queue list rendering
 
@@ -165,3 +181,4 @@ border, clamping the width between 180 px and 70% of the window width.
 - WHEN the user drags the right border of the navbar
 - THEN the navbar width follows the pointer, never going below 180 px or
   above 70% of the window width
+

--- a/openspec/specs/ttsd-protocol/spec.md
+++ b/openspec/specs/ttsd-protocol/spec.md
@@ -9,9 +9,7 @@ startup behavior, request serialization, and the supervisor's auto-restart
 policy. Implemented by `src-tauri/src/tts/mod.rs` and
 `src-tauri/src/tts/supervisor.rs` on the Rust side, and by `ttsd/ttsd/protocol.py`
 and `ttsd/ttsd/main.py` on the Python side.
-
 ## Requirements
-
 ### Requirement: NDJSON Transport and Framing
 
 Communication SHALL use the subprocess's `stdin`/`stdout` with newline-delimited
@@ -248,7 +246,9 @@ failure. Synthesis requests submitted before a successful load fail with
 
 The `TtsSupervisor` SHALL detect a dead ttsd when a request fails with
 `TtsError::Died` (only `Died` triggers respawn — protocol errors and timeouts
-propagate as-is). On detection it SHALL:
+propagate as-is) or when the subprocess was explicitly terminated by
+`cancel_synthesis` for an in-flight entry (see the Synthesis Cancellation
+Command requirement in `ipc-commands`). On detection it SHALL:
 
 1. Log a warning and emit `ttsd_restarting` (`{}`).
 2. Make the respawn single-flight (concurrent callers share one respawn).
@@ -260,20 +260,38 @@ propagate as-is). On detection it SHALL:
    error to the caller; the next request SHALL trigger a fresh respawn attempt
    so the system can still recover later.
 
-An in-flight request sent to the crashed process fails; pending entries go to
-the `error` state via the normal command-error path.
+An in-flight request sent to the crashed or terminated process fails; after
+an explicit kill for cancellation, in-flight and queued requests belonging
+to OTHER entries SHALL be retried transparently via the existing retry loop,
+while the cancelled entry's own request is not retried (its task is
+aborted). Pending entries whose requests ultimately fail go to the `error`
+state via the normal command-error path.
 
 #### Scenario: transparent respawn and retry
+
 - GIVEN a ttsd that crashed mid-session
 - WHEN the next request hits `TtsError::Died`
-- THEN `ttsd_restarting` is emitted, a new process is spawned within the backoff schedule, warmup replays the model lifecycle events, and the request is retried against the new process
+- THEN `ttsd_restarting` is emitted, a new process is spawned within the
+  backoff schedule, warmup replays the model lifecycle events, and the
+  request is retried against the new process
+
+#### Scenario: respawn after cancellation kill
+
+- GIVEN a ttsd terminated by `cancel_synthesis` for an in-flight entry
+- WHEN the next request arrives
+- THEN a fresh ttsd is spawned per the same backoff/warmup procedure and
+  other entries' requests proceed against the new process
 
 #### Scenario: respawn exhausted
+
 - GIVEN a supervisor whose spawn attempts all fail
 - WHEN the third attempt fails
-- THEN `tts_fatal` is emitted with the error message and the caller receives the spawn error
+- THEN `tts_fatal` is emitted with the error message and the caller receives
+  the spawn error
 
 #### Scenario: protocol errors do not trigger respawn
+
 - GIVEN a live ttsd that responds with an error (e.g. `bad_input`)
 - WHEN the request completes with that error
 - THEN no respawn is attempted and no `ttsd_restarting` event is emitted
+

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@
 //! typed JSON objects (`{ "type": "...", "message": "..." }`) which the frontend
 //! can pattern-match on.
 
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -11,6 +12,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tauri::{AppHandle, Emitter, Runtime, State, Wry};
+use tokio::task::AbortHandle;
 use tracing::{info, warn};
 
 use crate::pipeline::tracked_text::CharMapping;
@@ -108,6 +110,8 @@ pub fn spawn_synthesis_pub<R: Runtime + 'static>(
     emitter: crate::tts::supervisor::Emitter,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<parking_lot::Mutex<crate::pipeline::TTSPipeline>>,
+    synthesis_tasks: Arc<Mutex<HashMap<EntryId, AbortHandle>>>,
+    synthesize_entered: Arc<Mutex<HashSet<EntryId>>>,
     entry_id: EntryId,
     play_when_ready: bool,
 ) {
@@ -119,6 +123,8 @@ pub fn spawn_synthesis_pub<R: Runtime + 'static>(
         emitter,
         player,
         pipeline,
+        synthesis_tasks,
+        synthesize_entered,
         entry_id,
         play_when_ready,
     );
@@ -204,11 +210,13 @@ fn mark_processing<R: Runtime>(
 /// [`crate::tts::piper::download::download_voice`] and retries once. The
 /// retry runs only on Piper because Silero is bundled — its Python venv
 /// already includes the model.
+#[allow(clippy::too_many_arguments)]
 async fn synthesize_audio(
     tts: &dyn TtsEngine,
     storage: &StorageService,
     piper_voices_dir: &std::path::Path,
     emitter: &crate::tts::supervisor::Emitter,
+    synthesize_entered: &Mutex<HashSet<EntryId>>,
     entry_id: &EntryId,
     normalized: String,
     mapping: &CharMapping,
@@ -234,6 +242,10 @@ async fn synthesize_audio(
         config.piper_voice.clone()
     };
 
+    // Track the entry as "inside the TTS stage" so `cancel_synthesis` knows
+    // the ttsd subprocess must be killed. If the task is aborted at this
+    // await, `cancel_synthesis` removes the marker itself.
+    synthesize_entered.lock().insert(*entry_id);
     let attempt = tts
         .synthesize(
             normalized.clone(),
@@ -243,6 +255,7 @@ async fn synthesize_audio(
             tts_char_mapping.clone(),
         )
         .await;
+    synthesize_entered.lock().remove(entry_id);
 
     let output = match attempt {
         Ok(o) => o,
@@ -253,15 +266,18 @@ async fn synthesize_audio(
             crate::tts::piper::download::download_voice(piper_voices_dir, &voice, emitter)
                 .await
                 .map_err(|e| SynthesisError::TtsFailed(e.to_string()))?;
-            tts.synthesize(
-                normalized,
-                voice,
-                config.sample_rate,
-                out_wav,
-                tts_char_mapping,
-            )
-            .await
-            .map_err(|e| SynthesisError::TtsFailed(e.to_string()))?
+            synthesize_entered.lock().insert(*entry_id);
+            let retry = tts
+                .synthesize(
+                    normalized,
+                    voice,
+                    config.sample_rate,
+                    out_wav,
+                    tts_char_mapping,
+                )
+                .await;
+            synthesize_entered.lock().remove(entry_id);
+            retry.map_err(|e| SynthesisError::TtsFailed(e.to_string()))?
         }
         Err(e) => return Err(SynthesisError::TtsFailed(e.to_string())),
     };
@@ -323,8 +339,80 @@ async fn finalize_audio_files(
     (ts_filename, audio_filename)
 }
 
-/// Phase 6: mark entry `Ready` with audio + timestamp paths and emit
-/// `entry_updated`. Vanishing entries (deleted mid-synthesis) silently abort.
+/// Stale-completion guard: a synthesis completion or failure applies only
+/// while the entry is still `processing`. A cancelled entry is already back
+/// at `pending`, so its late result must be discarded instead of
+/// resurrecting it to `ready` / `error`.
+fn completion_is_current(status: EntryStatus) -> bool {
+    status == EntryStatus::Processing
+}
+
+/// Best-effort removal of the audio/timestamp files a discarded late result
+/// wrote into the audio dir. Missing files are fine (e.g. the Opus transcode
+/// never ran on the failure path).
+fn discard_late_files<I: IntoIterator<Item = String>>(storage: &StorageService, names: I) {
+    let audio_dir = storage.cache_dir().join("audio");
+    for name in names {
+        let path = audio_dir.join(name);
+        match std::fs::remove_file(&path) {
+            Ok(()) => (),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => (),
+            Err(e) => warn!("failed to remove stale result file {}: {e}", path.display()),
+        }
+    }
+}
+
+/// Phase 6 core (no Tauri handles, so the stale guard is unit-testable):
+/// mark the entry `Ready` with audio + timestamp paths — but only if it is
+/// still `processing`. A late completion for a non-`processing` entry is
+/// discarded together with the files it just wrote. Returns `true` when the
+/// result was applied.
+fn apply_ready_if_current(
+    storage: &StorageService,
+    entry_id: &EntryId,
+    output: &SynthesizeOutput,
+    ts_filename: Option<String>,
+    audio_filename: &str,
+) -> bool {
+    let Some(mut entry) = storage.get_entry(entry_id) else {
+        // Vanished mid-synthesis (deleted) — drop the late files too.
+        discard_late_files(
+            storage,
+            [Some(audio_filename.to_string()), ts_filename]
+                .into_iter()
+                .flatten(),
+        );
+        return false;
+    };
+    if !completion_is_current(entry.status) {
+        info!(
+            "discarding stale completion for {entry_id} (status: {:?})",
+            entry.status
+        );
+        discard_late_files(
+            storage,
+            [Some(audio_filename.to_string()), ts_filename]
+                .into_iter()
+                .flatten(),
+        );
+        return false;
+    }
+
+    entry.status = EntryStatus::Ready;
+    entry.audio_path = Some(audio_filename.to_string());
+    entry.timestamps_path = ts_filename;
+    entry.duration_sec = Some(output.duration_sec);
+    entry.audio_generated_at = Some(chrono::Local::now().naive_local());
+
+    if let Err(e) = storage.update_entry(entry) {
+        warn!("failed to update entry to ready: {e}");
+    }
+    true
+}
+
+/// Phase 6: apply the synthesis result and, when it was applied, emit
+/// `entry_updated`. Returns whether the entry reached `ready` — the caller
+/// gates autoplay on it.
 fn mark_ready_and_emit<R: Runtime>(
     storage: &StorageService,
     app: &AppHandle<R>,
@@ -332,21 +420,15 @@ fn mark_ready_and_emit<R: Runtime>(
     output: &SynthesizeOutput,
     ts_filename: Option<String>,
     audio_filename: &str,
-) {
-    let Some(mut entry) = storage.get_entry(entry_id) else {
-        return;
-    };
-    entry.status = EntryStatus::Ready;
-    entry.audio_path = Some(audio_filename.to_string());
-    entry.timestamps_path = ts_filename;
-    entry.duration_sec = Some(output.duration_sec);
-    entry.audio_generated_at = Some(chrono::Local::now().naive_local());
-
-    if let Err(e) = storage.update_entry(entry.clone()) {
-        warn!("failed to update entry to ready: {e}");
+) -> bool {
+    let applied = apply_ready_if_current(storage, entry_id, output, ts_filename, audio_filename);
+    if applied {
+        if let Some(entry) = storage.get_entry(entry_id) {
+            emit_entry_updated(app, &entry);
+        }
+        info!("synthesis complete: entry_id={entry_id}");
     }
-    emit_entry_updated(app, &entry);
-    info!("synthesis complete: entry_id={entry_id}");
+    applied
 }
 
 /// Phase 7: kick off auto-play. Errors are logged and swallowed — failed
@@ -364,6 +446,11 @@ fn autoplay<R: Runtime>(
 }
 
 /// Run the full synthesis pipeline for `entry_id` in a background task.
+///
+/// The task's `AbortHandle` is registered in `synthesis_tasks` so
+/// `cancel_synthesis` can abort it; a detached reaper removes the task's
+/// registry entry once it terminates, taking care not to remove a newer
+/// task's handle for the same entry.
 #[allow(clippy::too_many_arguments)]
 fn spawn_synthesis<R: Runtime + 'static>(
     app: AppHandle<R>,
@@ -373,60 +460,153 @@ fn spawn_synthesis<R: Runtime + 'static>(
     emitter: crate::tts::supervisor::Emitter,
     player: Arc<crate::player::Player<R>>,
     pipeline: Arc<Mutex<TTSPipeline>>,
+    synthesis_tasks: Arc<Mutex<HashMap<EntryId, AbortHandle>>>,
+    synthesize_entered: Arc<Mutex<HashSet<EntryId>>>,
     entry_id: EntryId,
     play_when_ready: bool,
 ) {
-    tokio::spawn(async move {
-        let Some(entry) = storage.get_entry(&entry_id) else {
-            warn!("synthesis task: entry {entry_id} vanished before synthesis started");
-            return;
-        };
+    let entered_for_task = Arc::clone(&synthesize_entered);
+    let tasks_for_cleanup = Arc::clone(&synthesis_tasks);
+    let entered_for_cleanup = Arc::clone(&synthesize_entered);
+    let handle = tokio::spawn(async move {
+        async {
+            let Some(entry) = storage.get_entry(&entry_id) else {
+                warn!("synthesis task: entry {entry_id} vanished before synthesis started");
+                return;
+            };
 
-        let result: Result<(), SynthesisError> = async {
-            let (normalized, mapping) =
-                run_normalization(Arc::clone(&pipeline), entry.original_text.clone()).await?;
-            mark_processing(&storage, &app, &entry_id, &normalized);
-            let (output, out_wav_path, wav_filename) = synthesize_audio(
-                tts.as_ref(),
-                &storage,
-                &piper_voices_dir,
-                &emitter,
-                &entry_id,
-                normalized,
-                &mapping,
-            )
-            .await?;
-            let (ts_filename, audio_filename) =
-                finalize_audio_files(&storage, &entry_id, &output, out_wav_path, &wav_filename)
-                    .await;
-            mark_ready_and_emit(
-                &storage,
-                &app,
-                &entry_id,
-                &output,
-                ts_filename,
-                &audio_filename,
-            );
-            if play_when_ready {
-                let path = storage.cache_dir().join("audio").join(&audio_filename);
-                autoplay(&player, path, &entry_id);
+            let result: Result<(), SynthesisError> = async {
+                let (normalized, mapping) =
+                    run_normalization(Arc::clone(&pipeline), entry.original_text.clone()).await?;
+                mark_processing(&storage, &app, &entry_id, &normalized);
+                let (output, out_wav_path, wav_filename) = synthesize_audio(
+                    tts.as_ref(),
+                    &storage,
+                    &piper_voices_dir,
+                    &emitter,
+                    &entered_for_task,
+                    &entry_id,
+                    normalized,
+                    &mapping,
+                )
+                .await?;
+                let (ts_filename, audio_filename) =
+                    finalize_audio_files(&storage, &entry_id, &output, out_wav_path, &wav_filename)
+                        .await;
+                let applied = mark_ready_and_emit(
+                    &storage,
+                    &app,
+                    &entry_id,
+                    &output,
+                    ts_filename,
+                    &audio_filename,
+                );
+                if applied && play_when_ready {
+                    let path = storage.cache_dir().join("audio").join(&audio_filename);
+                    autoplay(&player, path, &entry_id);
+                }
+                Ok(())
             }
-            Ok(())
+            .await;
+
+            if let Err(err) = result {
+                let msg = err.user_message();
+                tracing::error!("synthesis failed for {entry_id}: {msg}");
+                // Normalization-stage failures arrive while the entry is
+                // legitimately still `pending` (mark_processing runs after
+                // normalization), so the stale guard only applies to
+                // TTS-stage failures.
+                let require_processing = matches!(err, SynthesisError::TtsFailed(_));
+                let applied = set_entry_error(&storage, &app, &entry_id, &msg, require_processing);
+                if applied {
+                    if let SynthesisError::TtsFailed(tts_msg) = err {
+                        let _ = app.emit(
+                            "tts_error",
+                            json!({ "entry_id": entry_id.to_string(), "message": tts_msg }),
+                        );
+                    }
+                }
+            }
         }
         .await;
+    });
 
-        if let Err(err) = result {
-            let msg = err.user_message();
-            tracing::error!("synthesis failed for {entry_id}: {msg}");
-            set_entry_error(&storage, &app, &entry_id, &msg);
-            if let SynthesisError::TtsFailed(tts_msg) = err {
-                let _ = app.emit(
-                    "tts_error",
-                    json!({ "entry_id": entry_id.to_string(), "message": tts_msg }),
-                );
+    // Registry cleanup runs in a reaper that awaits the task's JoinHandle:
+    // only then is the task's registered handle truly `is_finished()`, which
+    // lets the cleanup distinguish its own handle from a newer live one — a
+    // task spawned later for the same entry (e.g. by regenerate_entry) must
+    // stay cancellable. The reaper is detached (its JoinHandle dropped).
+    let abort_handle = handle.abort_handle();
+    drop(tokio::spawn(async move {
+        let result = handle.await;
+        cleanup_finished_handle(&tasks_for_cleanup, &entry_id);
+        // `synthesize_entered` is unmarked right after the synthesize await
+        // on the normal path and by `cancel_synthesis` on the abort path;
+        // only a panic can leave the entry marked, so only then clean up.
+        if let Err(e) = &result {
+            if e.is_panic() {
+                entered_for_cleanup.lock().remove(&entry_id);
             }
         }
-    });
+    }));
+
+    let already_finished = abort_handle.is_finished();
+    let mut tasks = synthesis_tasks.lock();
+    tasks.insert(entry_id, abort_handle);
+    if already_finished {
+        // The task already finished and its reaper already ran — don't
+        // leave a stale handle behind.
+        tasks.remove(&entry_id);
+    }
+}
+
+/// Remove `entry_id` from the abort registry only if the registered handle
+/// has already finished — i.e. it belongs to the completed task being
+/// cleaned up, not to a newer live task for the same entry.
+fn cleanup_finished_handle(tasks: &Mutex<HashMap<EntryId, AbortHandle>>, entry_id: &EntryId) {
+    let mut tasks = tasks.lock();
+    if tasks.get(entry_id).is_some_and(AbortHandle::is_finished) {
+        tasks.remove(entry_id);
+    }
+}
+
+/// Core of [`set_entry_error`] without Tauri handles: flip the entry to
+/// `error`. With `require_processing` the stale-completion guard applies —
+/// a failure arriving for an entry that left `processing` (e.g. cancelled
+/// back to `pending`) is discarded together with the files the late request
+/// may have written. Normalization-stage failures pass `false` because the
+/// entry is legitimately still `pending` before `mark_processing` runs.
+/// Returns `true` when the error was applied.
+fn apply_error_if_current(
+    storage: &StorageService,
+    entry_id: &EntryId,
+    message: &str,
+    require_processing: bool,
+) -> bool {
+    let Some(mut entry) = storage.get_entry(entry_id) else {
+        return false;
+    };
+    if require_processing && !completion_is_current(entry.status) {
+        info!(
+            "discarding stale failure for {entry_id} (status: {:?})",
+            entry.status
+        );
+        // The exact filename is unknown on the failure path (a dying ttsd
+        // may have left a partial WAV); remove every candidate.
+        discard_late_files(
+            storage,
+            [
+                format!("{entry_id}.wav"),
+                format!("{entry_id}.opus"),
+                format!("{entry_id}.timestamps.json"),
+            ],
+        );
+        return false;
+    }
+    entry.status = EntryStatus::Error;
+    entry.error_message = Some(message.to_string());
+    let _ = storage.update_entry(entry);
+    true
 }
 
 fn set_entry_error<R: Runtime>(
@@ -434,13 +614,15 @@ fn set_entry_error<R: Runtime>(
     app: &AppHandle<R>,
     entry_id: &EntryId,
     message: &str,
-) {
-    if let Some(mut entry) = storage.get_entry(entry_id) {
-        entry.status = EntryStatus::Error;
-        entry.error_message = Some(message.to_string());
-        let _ = storage.update_entry(entry.clone());
-        emit_entry_updated(app, &entry);
+    require_processing: bool,
+) -> bool {
+    let applied = apply_error_if_current(storage, entry_id, message, require_processing);
+    if applied {
+        if let Some(entry) = storage.get_entry(entry_id) {
+            emit_entry_updated(app, &entry);
+        }
     }
+    applied
 }
 
 // ── Commands ───────────────────────────────────────────────────────────────────
@@ -473,6 +655,8 @@ fn ingest_text(
         Arc::clone(&state.emitter),
         Arc::clone(&state.player),
         Arc::clone(&state.pipeline),
+        Arc::clone(&state.synthesis_tasks),
+        Arc::clone(&state.synthesize_entered),
         entry_id,
         play_when_ready,
     );
@@ -683,6 +867,8 @@ pub async fn regenerate_entry(
         Arc::clone(&state.emitter),
         Arc::clone(&state.player),
         Arc::clone(&state.pipeline),
+        Arc::clone(&state.synthesis_tasks),
+        Arc::clone(&state.synthesize_entered),
         uuid,
         false,
     );
@@ -690,22 +876,58 @@ pub async fn regenerate_entry(
     Ok(())
 }
 
-/// Cancel an in-progress or queued synthesis job.
-/// Currently marks entry as pending (mid-request abort is not supported since
-/// the TTS supervisor serialises all requests into a single channel).
+/// Core of [`cancel_synthesis`] without Tauri handles: abort the entry's
+/// synthesis task (if registered) and flip the entry back to `pending`.
+/// Returns the updated entry plus whether the task had entered the TTS
+/// stage — the caller kills ttsd only in that case.
+fn cancel_entry(
+    storage: &StorageService,
+    synthesis_tasks: &Mutex<HashMap<EntryId, AbortHandle>>,
+    synthesize_entered: &Mutex<HashSet<EntryId>>,
+    id: &str,
+) -> CmdResult<(TextEntry, bool)> {
+    let mut entry = require_entry(storage, id)?;
+    let uuid = entry.id;
+
+    // An aborted task is destroyed at its next yield point and never runs
+    // its own registry cleanup, so both keys are removed here. Aborting an
+    // already-finished (but not yet cleaned-up) handle is a no-op.
+    if let Some(handle) = synthesis_tasks.lock().remove(&uuid) {
+        handle.abort();
+    }
+    let entered_tts = synthesize_entered.lock().remove(&uuid);
+
+    entry.status = EntryStatus::Pending;
+    storage
+        .update_entry(entry.clone())
+        .map_err(CommandError::from)?;
+    Ok((entry, entered_tts))
+}
+
+/// Cancel an in-progress or queued synthesis job: abort the entry's
+/// synthesis task and flip the entry back to `pending`. If the task had
+/// already entered the TTS stage, the current ttsd subprocess is killed too
+/// (the supervisor transparently respawns it on the next request). A late
+/// completion belonging to the cancelled entry is discarded by the
+/// stale-completion guard in `apply_ready_if_current` /
+/// `apply_error_if_current`.
 #[tauri::command]
 pub async fn cancel_synthesis(
     app: AppHandle<Wry>,
     state: State<'_, AppState>,
     id: String,
 ) -> CmdResult<()> {
-    let mut entry = require_entry(&state.storage, &id)?;
+    let (entry, entered_tts) = cancel_entry(
+        &state.storage,
+        &state.synthesis_tasks,
+        &state.synthesize_entered,
+        &id,
+    )?;
 
-    entry.status = EntryStatus::Pending;
-    state
-        .storage
-        .update_entry(entry.clone())
-        .map_err(CommandError::from)?;
+    if entered_tts {
+        state.engine_switcher.kill_current_ttsd().await;
+    }
+
     emit_entry_updated(&app, &entry);
     Ok(())
 }
@@ -1142,6 +1364,245 @@ mod synthesis_tests {
             SynthesisError::TtsFailed("ttsd died".into()).user_message(),
             "ttsd died",
         );
+    }
+
+    // ── Stale-completion guard ───────────────────────────────────────────
+
+    /// The guard decision is pure: only `processing` lets a late result
+    /// through; every other status discards it.
+    #[test]
+    fn completion_guard_only_allows_processing() {
+        assert!(completion_is_current(EntryStatus::Processing));
+        for status in [
+            EntryStatus::Pending,
+            EntryStatus::Ready,
+            EntryStatus::Playing,
+            EntryStatus::Error,
+        ] {
+            assert!(!completion_is_current(status), "{status:?} must be stale");
+        }
+    }
+
+    fn fake_output() -> SynthesizeOutput {
+        SynthesizeOutput {
+            timestamps: Vec::new(),
+            duration_sec: 1.0,
+        }
+    }
+
+    fn set_status(storage: &StorageService, entry: &TextEntry, status: EntryStatus) {
+        let mut updated = entry.clone();
+        updated.status = status;
+        storage.update_entry(updated).unwrap();
+    }
+
+    /// A late completion for a non-`processing` entry changes no status and
+    /// removes the audio/timestamp files it just wrote.
+    #[test]
+    fn stale_ready_completion_is_discarded_with_files() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap(); // pending
+        let id = entry.id;
+        let audio_dir = storage.cache_dir().join("audio");
+        let audio_name = format!("{id}.opus");
+        let ts_name = format!("{id}.timestamps.json");
+        std::fs::write(audio_dir.join(&audio_name), b"opus").unwrap();
+        std::fs::write(audio_dir.join(&ts_name), b"{}").unwrap();
+
+        let applied = apply_ready_if_current(
+            &storage,
+            &id,
+            &fake_output(),
+            Some(ts_name.clone()),
+            &audio_name,
+        );
+
+        assert!(!applied);
+        let stored = storage.get_entry(&id).unwrap();
+        assert_eq!(stored.status, EntryStatus::Pending);
+        assert!(stored.audio_path.is_none());
+        assert!(stored.timestamps_path.is_none());
+        assert!(!audio_dir.join(&audio_name).exists());
+        assert!(!audio_dir.join(&ts_name).exists());
+    }
+
+    /// The happy path: a completion arriving while the entry is `processing`
+    /// applies and populates the ready fields.
+    #[test]
+    fn ready_completion_applies_while_processing() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap();
+        set_status(&storage, &entry, EntryStatus::Processing);
+        let id = entry.id;
+
+        let applied = apply_ready_if_current(
+            &storage,
+            &id,
+            &fake_output(),
+            Some(format!("{id}.timestamps.json")),
+            &format!("{id}.opus"),
+        );
+
+        assert!(applied);
+        let stored = storage.get_entry(&id).unwrap();
+        assert_eq!(stored.status, EntryStatus::Ready);
+        assert_eq!(
+            stored.audio_path.as_deref(),
+            Some(format!("{id}.opus").as_str())
+        );
+        assert_eq!(stored.duration_sec, Some(1.0));
+        assert!(stored.audio_generated_at.is_some());
+    }
+
+    /// A late TTS-stage failure for a non-`processing` entry changes no
+    /// status and removes the candidate files a dying ttsd may have written.
+    #[test]
+    fn stale_failure_is_discarded_with_candidate_files() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap(); // pending
+        let id = entry.id;
+        let wav = storage.cache_dir().join("audio").join(format!("{id}.wav"));
+        std::fs::write(&wav, b"partial").unwrap();
+
+        let applied = apply_error_if_current(&storage, &id, "ttsd died", true);
+
+        assert!(!applied);
+        let stored = storage.get_entry(&id).unwrap();
+        assert_eq!(stored.status, EntryStatus::Pending);
+        assert!(stored.error_message.is_none());
+        assert!(!wav.exists());
+    }
+
+    /// A TTS-stage failure while the entry is `processing` applies normally.
+    #[test]
+    fn tts_failure_applies_while_processing() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap();
+        set_status(&storage, &entry, EntryStatus::Processing);
+
+        let applied = apply_error_if_current(&storage, &entry.id, "ttsd died", true);
+
+        assert!(applied);
+        let stored = storage.get_entry(&entry.id).unwrap();
+        assert_eq!(stored.status, EntryStatus::Error);
+        assert_eq!(stored.error_message.as_deref(), Some("ttsd died"));
+    }
+
+    /// Normalization-stage failures arrive while the entry is legitimately
+    /// still `pending` — they must not be discarded by the guard.
+    #[test]
+    fn normalization_failure_applies_from_pending() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap(); // pending
+
+        let applied = apply_error_if_current(&storage, &entry.id, "empty", false);
+
+        assert!(applied);
+        let stored = storage.get_entry(&entry.id).unwrap();
+        assert_eq!(stored.status, EntryStatus::Error);
+        assert_eq!(stored.error_message.as_deref(), Some("empty"));
+    }
+
+    // ── cancel_entry ───────────────────────────────────────────────────────
+
+    /// Cancelling an unknown id fails with `not_found` and touches nothing.
+    #[test]
+    fn cancel_entry_unknown_id_is_not_found() {
+        let (storage, _dir) = make_service();
+        let tasks = Mutex::new(HashMap::new());
+        let entered = Mutex::new(HashSet::new());
+
+        let err = cancel_entry(
+            &storage,
+            &tasks,
+            &entered,
+            &uuid::Uuid::new_v4().to_string(),
+        )
+        .unwrap_err();
+        match err {
+            CommandError::NotFound { message } => assert!(message.contains("entry not found")),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    /// Cancel flips the entry to `pending`, removes both registry keys, and
+    /// the registered task is actually aborted.
+    #[tokio::test]
+    async fn cancel_entry_aborts_registered_task_and_sets_pending() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap();
+        set_status(&storage, &entry, EntryStatus::Processing);
+        let id = entry.id;
+
+        let tasks: Mutex<HashMap<EntryId, AbortHandle>> = Mutex::new(HashMap::new());
+        let entered: Mutex<HashSet<EntryId>> = Mutex::new(HashSet::new());
+        let sleeper = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        tasks.lock().insert(id, sleeper.abort_handle());
+        entered.lock().insert(id);
+
+        let (updated, entered_tts) =
+            cancel_entry(&storage, &tasks, &entered, &id.to_string()).unwrap();
+
+        assert_eq!(updated.status, EntryStatus::Pending);
+        assert!(entered_tts, "entry was marked as inside the TTS stage");
+        assert!(tasks.lock().is_empty());
+        assert!(entered.lock().is_empty());
+        assert_eq!(storage.get_entry(&id).unwrap().status, EntryStatus::Pending);
+
+        let join_err = sleeper.await.unwrap_err();
+        assert!(join_err.is_cancelled());
+    }
+
+    /// An entry that never reached the TTS stage reports `entered_tts =
+    /// false`, so the caller does not kill ttsd.
+    #[tokio::test]
+    async fn cancel_entry_without_tts_stage_reports_false() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap();
+        set_status(&storage, &entry, EntryStatus::Processing);
+        let id = entry.id;
+
+        let tasks: Mutex<HashMap<EntryId, AbortHandle>> = Mutex::new(HashMap::new());
+        let entered: Mutex<HashSet<EntryId>> = Mutex::new(HashSet::new());
+        let sleeper = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        tasks.lock().insert(id, sleeper.abort_handle());
+
+        let (_updated, entered_tts) =
+            cancel_entry(&storage, &tasks, &entered, &id.to_string()).unwrap();
+
+        assert!(!entered_tts);
+        let join_err = sleeper.await.unwrap_err();
+        assert!(join_err.is_cancelled());
+    }
+
+    /// Registry cleanup removes only finished handles: a live handle (a
+    /// newer task spawned for the same entry) must survive, otherwise the
+    /// newer task would become uncancellable.
+    #[tokio::test]
+    async fn cleanup_finished_handle_removes_only_finished_handles() {
+        let tasks: Mutex<HashMap<EntryId, AbortHandle>> = Mutex::new(HashMap::new());
+        let id = uuid::Uuid::new_v4();
+
+        // Finished handle (the completed task's own) → removed.
+        let done = tokio::spawn(async {});
+        let done_abort = done.abort_handle();
+        done.await.unwrap();
+        tasks.lock().insert(id, done_abort);
+        cleanup_finished_handle(&tasks, &id);
+        assert!(tasks.lock().is_empty());
+
+        // Live handle (a newer task for the same entry) → kept.
+        let live = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        tasks.lock().insert(id, live.abort_handle());
+        cleanup_finished_handle(&tasks, &id);
+        assert!(tasks.lock().contains_key(&id));
+        live.abort();
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod storage;
 pub mod tray;
 pub mod tts;
 
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -216,28 +217,32 @@ fn build_engine<R: Runtime>(
     let want_silero = config.engine == "silero";
     let silero_available = want_silero && tts::availability::probe(&ttsd_dir).silero.available;
 
-    let (initial_engine, initial_kind, initial_voice) = if silero_available {
+    let (initial_engine, initial_kind, initial_voice, initial_silero) = if silero_available {
         match try_build_silero(&ttsd_dir, Arc::clone(&emitter)) {
             Ok(sup) => {
-                let engine: Arc<dyn tts::TtsEngine> = sup;
-                (engine, tts::EngineKind::Silero, None)
+                let engine: Arc<dyn tts::TtsEngine> = sup.clone();
+                (engine, tts::EngineKind::Silero, None, Some(sup))
             }
             Err(e) => {
                 tracing::warn!("Silero probe passed but spawn failed ({e}); falling back to Piper");
-                build_piper_initial(&voices_dir, &config.piper_voice, &emitter)
+                let (engine, kind, voice) =
+                    build_piper_initial(&voices_dir, &config.piper_voice, &emitter);
+                (engine, kind, voice, None)
             }
         }
     } else {
         if want_silero {
             tracing::info!("Silero requested in config but unavailable; serving Piper this run");
         }
-        build_piper_initial(&voices_dir, &config.piper_voice, &emitter)
+        let (engine, kind, voice) = build_piper_initial(&voices_dir, &config.piper_voice, &emitter);
+        (engine, kind, voice, None)
     };
 
     let switcher = Arc::new(tts::EngineSwitcher::new(
         initial_engine,
         initial_kind,
         initial_voice,
+        initial_silero,
         voices_dir.clone(),
         ttsd_dir.clone(),
         Arc::clone(&emitter),
@@ -290,6 +295,8 @@ fn spawn_tray_handler<R: Runtime + 'static>(
     emitter: tts::supervisor::Emitter,
     player: Arc<Player<R>>,
     pipeline: Arc<Mutex<TTSPipeline>>,
+    synthesis_tasks: Arc<Mutex<HashMap<storage::schema::EntryId, tokio::task::AbortHandle>>>,
+    synthesize_entered: Arc<Mutex<HashSet<storage::schema::EntryId>>>,
     app: AppHandle<R>,
 ) -> tokio::sync::mpsc::Sender<TrayCmd> {
     let (tray_tx, mut tray_rx) = tokio::sync::mpsc::channel::<TrayCmd>(16);
@@ -338,6 +345,8 @@ fn spawn_tray_handler<R: Runtime + 'static>(
                 Arc::clone(&emitter),
                 Arc::clone(&player),
                 Arc::clone(&pipeline),
+                Arc::clone(&synthesis_tasks),
+                Arc::clone(&synthesize_entered),
                 entry_id,
                 cmd.play_when_ready,
             );
@@ -377,6 +386,8 @@ pub fn run() {
             }
 
             let pipeline = Arc::new(Mutex::new(TTSPipeline::new()));
+            let synthesis_tasks = Arc::new(Mutex::new(HashMap::new()));
+            let synthesize_entered = Arc::new(Mutex::new(HashSet::new()));
             let tray_tx = spawn_tray_handler(
                 Arc::clone(&storage),
                 Arc::clone(&tts),
@@ -384,6 +395,8 @@ pub fn run() {
                 Arc::clone(&emitter),
                 Arc::clone(&player),
                 Arc::clone(&pipeline),
+                Arc::clone(&synthesis_tasks),
+                Arc::clone(&synthesize_entered),
                 app.handle().clone(),
             );
 
@@ -398,6 +411,8 @@ pub fn run() {
                 pipeline,
                 tray_cmd_tx: Some(tray_tx),
                 user_quit: Arc::new(AtomicBool::new(false)),
+                synthesis_tasks,
+                synthesize_entered,
             });
 
             Ok(())

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,11 +1,14 @@
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use tokio::task::AbortHandle;
 
 use crate::pipeline::TTSPipeline;
 use crate::player::Player;
+use crate::storage::schema::EntryId;
 use crate::storage::service::StorageService;
 use crate::tray::TrayCmd;
 use crate::tts::supervisor::Emitter;
@@ -45,4 +48,12 @@ pub struct AppState {
     /// runtime distinguish a real quit from a window-close that should keep
     /// the app running in the tray.
     pub user_quit: Arc<AtomicBool>,
+    /// Abort handles of the spawned synthesis tasks, keyed by entry.
+    /// Populated by `spawn_synthesis` and removed when the task finishes
+    /// (any outcome) or when `cancel_synthesis` aborts it.
+    pub synthesis_tasks: Arc<Mutex<HashMap<EntryId, AbortHandle>>>,
+    /// Entries currently inside the `tts.synthesize()` await. Lets
+    /// `cancel_synthesis` decide whether the ttsd subprocess must be killed
+    /// (only entries that reached the TTS stage keep ttsd busy).
+    pub synthesize_entered: Arc<Mutex<HashSet<EntryId>>>,
 }

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -29,7 +29,7 @@ use serde_json::Value;
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::timeout;
 use tracing::{info, warn};
 
@@ -193,6 +193,8 @@ struct DriverRequest {
 /// The underlying driver task owns the subprocess and serializes all I/O.
 pub struct TtsSubprocess {
     sender: mpsc::Sender<DriverRequest>,
+    /// Kill signal for the driver task (see [`TtsSubprocess::kill_now`]).
+    kill_tx: watch::Sender<bool>,
 }
 
 impl TtsSubprocess {
@@ -212,9 +214,26 @@ impl TtsSubprocess {
         let child = cmd.spawn().map_err(TtsError::Spawn)?;
 
         let (tx, rx) = mpsc::channel::<DriverRequest>(1);
-        tokio::spawn(driver_task(child, rx));
+        let (kill_tx, kill_rx) = watch::channel(false);
+        tokio::spawn(driver_task(child, rx, kill_rx));
 
-        Ok(Self { sender: tx })
+        Ok(Self {
+            sender: tx,
+            kill_tx,
+        })
+    }
+
+    /// Forcibly terminate the ttsd subprocess (SIGKILL), even mid-request.
+    ///
+    /// The driver task kills the child and exits, so in-flight and queued
+    /// requests on this handle fail with [`TtsError::Died`] and the
+    /// supervisor's retry loop respawns transparently. No-op when the driver
+    /// is already gone (i.e. the process is already dead). Used by
+    /// [`supervisor::TtsSupervisor::kill_current`] for synthesis cancellation.
+    pub fn kill_now(&self) {
+        // Errors only when the driver (and its receiver) is already gone —
+        // the process is dead then, which is what the caller wants anyway.
+        let _ = self.kill_tx.send(true);
     }
 
     /// Send a raw request and wait for the response.
@@ -305,7 +324,19 @@ impl TtsSubprocess {
 // ---------------------------------------------------------------------------
 
 /// Owns the subprocess and its stdin/stdout. Serializes all requests one at a time.
-async fn driver_task(mut child: Child, mut rx: mpsc::Receiver<DriverRequest>) {
+///
+/// The task exits — making queued and future senders observe [`TtsError::Died`]
+/// so the supervisor can respawn — when:
+/// - all senders are dropped (normal teardown),
+/// - the child exits (observed via `child.wait()` between requests, or via a
+///   stdout EOF mid-request), or
+/// - a kill is requested through `kill_rx` ([`TtsSubprocess::kill_now`]),
+///   which SIGKILLs the child even while a request is in flight.
+async fn driver_task(
+    mut child: Child,
+    mut rx: mpsc::Receiver<DriverRequest>,
+    mut kill_rx: watch::Receiver<bool>,
+) {
     // stdin is held in an Option so it can be dropped (closing the pipe / sending EOF)
     // before we wait on the child during graceful shutdown.
     let mut stdin = Some(child.stdin.take().expect("stdin was piped"));
@@ -322,12 +353,49 @@ async fn driver_task(mut child: Child, mut rx: mpsc::Receiver<DriverRequest>) {
 
     let mut stdout_lines = BufReader::new(stdout).lines();
 
-    while let Some(req) = rx.recv().await {
+    loop {
+        let req = tokio::select! {
+            req = rx.recv() => match req {
+                Some(req) => req,
+                None => return,
+            },
+            // Kill requested while idle: SIGKILL the child and exit.
+            _ = kill_rx.changed() => {
+                info!(target: "ttsd", "kill requested — terminating subprocess");
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                return;
+            }
+            // Child exited between requests (no in-flight request to observe
+            // the EOF). Exit so the next request fails fast with Died instead
+            // of an unretryable stdin write error.
+            status = child.wait() => {
+                match status {
+                    Ok(status) => info!(target: "ttsd", "subprocess exited: {status}"),
+                    Err(e) => warn!(target: "ttsd", "wait() failed: {e}"),
+                }
+                return;
+            }
+        };
+
         let is_shutdown = matches!(&req.payload, TtsRequest::Shutdown);
         let result = match stdin.as_mut() {
-            Some(s) => handle_one_request(s, &mut stdout_lines, req.payload).await,
+            Some(s) => tokio::select! {
+                res = handle_one_request(s, &mut stdout_lines, req.payload) => res,
+                // Kill requested mid-request: SIGKILL the child, fail the
+                // in-flight request with Died (the supervisor retries other
+                // entries' requests against a respawned process), and exit.
+                _ = kill_rx.changed() => {
+                    info!(target: "ttsd", "kill requested mid-request — terminating subprocess");
+                    let _ = child.start_kill();
+                    let _ = child.wait().await;
+                    let _ = req.reply.send(Err(TtsError::Died));
+                    return;
+                }
+            },
             None => Err(TtsError::Died),
         };
+        let died = matches!(result, Err(TtsError::Died));
         let _ = req.reply.send(result);
 
         if is_shutdown {
@@ -346,6 +414,13 @@ async fn driver_task(mut child: Child, mut rx: mpsc::Receiver<DriverRequest>) {
                     let _ = child.wait().await;
                 }
             }
+            return;
+        }
+
+        if died {
+            // stdout hit EOF — the child is gone. Exit so queued and future
+            // senders observe Died and the supervisor respawns.
+            info!(target: "ttsd", "subprocess died mid-request — driver exiting");
             return;
         }
     }

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -183,6 +183,22 @@ impl TtsSupervisor {
         Err(err)
     }
 
+    /// Forcibly terminate the current ttsd subprocess, if any.
+    ///
+    /// The slot is deliberately left untouched: the driver task of the killed
+    /// process exits, so in-flight and queued requests on the old handle fail
+    /// with [`TtsError::Died`] and the next request respawns through the
+    /// existing `ensure_respawned` path (`ttsd_restarting` + backoff +
+    /// background warmup), exactly as if the process had crashed. Used by
+    /// `cancel_synthesis` when the cancelled entry had already entered the
+    /// TTS stage.
+    pub async fn kill_current(&self) {
+        if let Some(handle) = self.current_handle().await {
+            info!(target: "tts::supervisor", "kill_current: terminating ttsd subprocess");
+            handle.kill_now();
+        }
+    }
+
     /// Run `warmup` against the freshly-spawned handle in a background task,
     /// mirroring the `model_loading` → `model_loaded` / `model_error`
     /// lifecycle that startup uses. Failures here do not invalidate the

--- a/src-tauri/src/tts/switcher.rs
+++ b/src-tauri/src/tts/switcher.rs
@@ -37,6 +37,10 @@ struct Slot {
     /// Currently-loaded Piper voice id, when the active engine is Piper.
     /// Used to decide whether a `piper_voice` change requires a rebuild.
     piper_voice: Option<String>,
+    /// Concrete supervisor while the active engine is Silero. Reaches
+    /// [`TtsSupervisor::kill_current`] through the `Arc<dyn TtsEngine>`
+    /// type erasure for `cancel_synthesis`. `None` while Piper is active.
+    silero: Option<Arc<TtsSupervisor>>,
 }
 
 const KIND_PIPER: u8 = 0;
@@ -60,11 +64,14 @@ impl EngineSwitcher {
     /// Construct a switcher around an already-built initial engine. The
     /// caller must pass `initial_kind` matching the engine's `kind()` and,
     /// when the engine is Piper, the voice id its `default_voice` was
-    /// constructed with.
+    /// constructed with. When the initial engine is Silero,
+    /// `initial_silero` must carry the same supervisor behind `initial` so
+    /// [`EngineSwitcher::kill_current_ttsd`] can reach it.
     pub fn new(
         initial: Arc<dyn TtsEngine>,
         initial_kind: EngineKind,
         initial_piper_voice: Option<String>,
+        initial_silero: Option<Arc<TtsSupervisor>>,
         piper_voices_dir: PathBuf,
         ttsd_dir: PathBuf,
         emitter: Emitter,
@@ -73,6 +80,7 @@ impl EngineSwitcher {
             inner: RwLock::new(Slot {
                 engine: initial,
                 piper_voice: initial_piper_voice,
+                silero: initial_silero,
             }),
             kind: AtomicU8::new(kind_to_u8(initial_kind)),
             piper_voices_dir,
@@ -105,17 +113,19 @@ impl EngineSwitcher {
             return Ok(());
         }
 
-        let (new_engine, new_voice) = match target_kind {
+        let (new_engine, new_voice, new_silero) = match target_kind {
             EngineKind::Piper => {
                 let engine = self.build_piper(target_piper_voice.to_string());
                 (
                     engine as Arc<dyn TtsEngine>,
                     Some(target_piper_voice.to_string()),
+                    None,
                 )
             }
             EngineKind::Silero => {
-                let engine = self.build_silero()?;
-                (engine as Arc<dyn TtsEngine>, None)
+                let supervisor = self.build_silero()?;
+                let engine: Arc<dyn TtsEngine> = supervisor.clone();
+                (engine, None, Some(supervisor))
             }
         };
 
@@ -123,6 +133,7 @@ impl EngineSwitcher {
             let mut slot = self.inner.write().await;
             slot.engine = Arc::clone(&new_engine);
             slot.piper_voice = new_voice;
+            slot.silero = new_silero;
         }
         self.kind.store(kind_to_u8(target_kind), Ordering::SeqCst);
 
@@ -152,6 +163,17 @@ impl EngineSwitcher {
 
     async fn current_engine(&self) -> Arc<dyn TtsEngine> {
         Arc::clone(&self.inner.read().await.engine)
+    }
+
+    /// Terminate the current ttsd subprocess when Silero is the active
+    /// engine; no-op for Piper (in-process synthesis has no subprocess to
+    /// kill). See [`TtsSupervisor::kill_current`]. Called by
+    /// `cancel_synthesis` when the cancelled entry had entered the TTS stage.
+    pub async fn kill_current_ttsd(&self) {
+        let silero = self.inner.read().await.silero.clone();
+        if let Some(supervisor) = silero {
+            supervisor.kill_current().await;
+        }
     }
 }
 
@@ -223,6 +245,7 @@ mod tests {
             initial,
             EngineKind::Piper,
             Some("ruslan".to_string()),
+            None,
             voices_dir,
             ttsd_dir,
             emitter,

--- a/src-tauri/tests/fixtures/mock_ttsd_sleepy.py
+++ b/src-tauri/tests/fixtures/mock_ttsd_sleepy.py
@@ -1,0 +1,66 @@
+"""Mock ttsd whose first-ever synthesize call sleeps until killed.
+
+Used by `tests/supervisor.rs` to verify `TtsSupervisor::kill_current`
+terminates an in-flight request and the next request transparently
+respawns. A marker file (path from the MOCK_TTSD_SLEEP_MARKER env var)
+distinguishes the first process from respawned ones: the first process
+creates the marker and sleeps ~forever on synthesize; any later process
+(marker already present) replies immediately.
+
+Behaviour:
+  - `warmup`     -> always replies ok.
+  - `synthesize` -> first process (no marker): create marker, sleep 30 s
+                    (long enough that only a real kill unblocks it), then
+                    reply ok. Later processes: reply ok immediately.
+  - `shutdown`   -> replies ok and exits.
+
+Run via:  MOCK_TTSD_SLEEP_MARKER=/tmp/marker python tests/fixtures/mock_ttsd_sleepy.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+SLEEP_SEC = 30
+
+
+def _write(payload: dict) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    marker = os.environ["MOCK_TTSD_SLEEP_MARKER"]
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _write({"ok": False, "error": "bad_json", "message": str(exc)})
+            continue
+
+        cmd = req.get("cmd")
+        if cmd == "warmup":
+            _write({"ok": True, "version": "mock-0.0.0"})
+        elif cmd == "synthesize":
+            if not os.path.exists(marker):
+                # Create the marker BEFORE sleeping so a respawned process
+                # replies instantly.
+                with open(marker, "w"):
+                    pass
+                time.sleep(SLEEP_SEC)
+            _write({"ok": True, "timestamps": [], "duration_sec": 0.0})
+        elif cmd == "shutdown":
+            _write({"ok": True})
+            return
+        else:
+            _write({"ok": False, "error": "bad_cmd", "message": f"unknown cmd: {cmd}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -14,6 +14,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use ruvox_tauri_lib::tts::supervisor::test_helpers::recording_emitter;
 use ruvox_tauri_lib::tts::supervisor::{CommandFactory, TtsSupervisor};
@@ -84,6 +85,91 @@ async fn supervisor_respawns_after_subprocess_suicide() {
     assert_eq!(second.timestamps.len(), 0);
 
     // Supervisor must have emitted ttsd_restarting at least once.
+    let log = log.lock().unwrap();
+    let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"ttsd_restarting"),
+        "expected ttsd_restarting in {names:?}",
+    );
+    assert!(
+        !names.contains(&"tts_fatal"),
+        "did not expect tts_fatal in {names:?}",
+    );
+}
+
+/// `kill_current` must terminate a ttsd stuck on an in-flight request, and
+/// the killed request must be retried transparently against a respawned
+/// process. The sleepy mock's first process blocks for 30 s on synthesize
+/// (creating a marker file first); any respawned process sees the marker
+/// and replies instantly, so finishing well under 30 s proves the first
+/// process was really killed, not merely outlived.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kill_current_terminates_in_flight_request_and_respawns() {
+    let script = common::resolve_test_path("tests/fixtures/mock_ttsd_sleepy.py")
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("mock_ttsd_sleepy.py not found: {e}"));
+
+    let out_dir = tempfile::TempDir::new().expect("tempdir for kill_current test");
+    let marker = out_dir.path().join("first-process-sleeping");
+    let out_wav = out_dir.path().join("kill-out.wav");
+
+    let marker_for_factory = marker.clone();
+    let factory: CommandFactory = Arc::new(move || {
+        let mut cmd = Command::new("python3");
+        cmd.arg(&script)
+            .env("MOCK_TTSD_SLEEP_MARKER", &marker_for_factory);
+        cmd
+    });
+
+    let (emitter, log) = recording_emitter();
+    let sup = Arc::new(TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok"));
+
+    // Kick off a request that the mock will sleep on until killed.
+    let sup_for_task = Arc::clone(&sup);
+    let out_wav_str = out_wav.to_string_lossy().into_owned();
+    let inflight = tokio::spawn(async move {
+        sup_for_task
+            .synthesize(
+                "hello".to_string(),
+                "xenia".to_string(),
+                48_000,
+                out_wav_str,
+                None,
+            )
+            .await
+    });
+
+    // Wait until the mock has actually entered its sleep: it creates the
+    // marker file at exactly that point, so this is a real synchronization
+    // signal (unlike a fixed sleep, which is flaky on slow CI — killing
+    // before the marker exists would make the respawned process "first"
+    // again and it would sleep another 30 s).
+    let wait_for_marker = async {
+        while !marker.exists() {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(10), wait_for_marker)
+        .await
+        .expect("mock never entered its sleep (marker file did not appear)");
+
+    sup.kill_current().await;
+
+    // with_retry observes Died, respawns via ensure_respawned (1s backoff on
+    // the first attempt) and retries against the fresh process. Bound the
+    // whole thing well under the mock's 30 s sleep.
+    let output = tokio::time::timeout(Duration::from_secs(20), inflight)
+        .await
+        .expect("in-flight request hung — kill_current did not terminate the mock")
+        .expect("in-flight task panicked")
+        .expect("request should succeed after transparent respawn");
+    assert_eq!(output.timestamps.len(), 0);
+
+    assert!(
+        marker.exists(),
+        "the first process should have entered its sleep (marker missing)"
+    );
+
     let log = log.lock().unwrap();
     let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
     assert!(


### PR DESCRIPTION
## Summary

`cancel_synthesis` used to only flip the entry back to `pending` while the in-flight ttsd request ran to completion — and the completion handler then silently resurrected the entry to `ready`. This implements real cancellation in three layers (issue #88):

- **Stale-completion guard:** the ready/error/autoplay paths only apply their result when the entry is still `processing`; a late completion is discarded together with its generated files. Also hardens `regenerate_entry` races.
- **Abort registry:** each synthesis task is registered by `entry_id`; cancelling aborts the task, so queued work stops immediately without touching ttsd.
- **In-flight kill:** if the cancelled entry had reached the TTS stage, the driver SIGKILLs the ttsd child (watch-channel driven, works mid-request), the in-flight request fails with `Died`, and the existing `ensure_respawned` brings a fresh instance up; other entries' requests are retried transparently.

Cooperative protocol-level cancel was evaluated and rejected (see `design.md` in the archived change).

## Spec

OpenSpec change archived as `2026-07-25-real-synthesis-cancellation`; `ipc-commands`, `queue-lifecycle`, and `ttsd-protocol` specs synced.

## Test plan

- `cargo test`: 850 lib + golden green (8 new unit tests: guard, cancel, cleanup)
- Supervisor integration 2/2 with new `mock_ttsd_sleepy.py` fixture (real kill of a 30s-sleeping mock in ~1s, stable across repeated runs)
- Live verification against the real Silero ttsd: long synthesis killed mid-flight (cancel path resolves in ~85 µs), respawn + warmup + fresh synthesis succeeds with a real WAV and timestamps
- App smoke: dev build starts, window renders, queue intact, ttsd spawns
- `just lint` green; `openspec validate --specs --strict` 12/12

## Notes

- Accepted trade-off (documented in the spec): killing may restart another entry's in-flight request; it is retried transparently.
- Pre-PR review: both findings fixed (fixed-delay test race → marker polling; cross-task registry cleanup race → reaper task).
- Follow-ups filed: #127 (cancel after engine switch does not kill the old ttsd), #128 (retried request races background warmup → `model_not_loaded` — pre-existing on the crash path, found during live verification).
- Piper mid-inference cancellation is out of scope.

Closes #88