### PR TITLE
test(commands): scaffold Tauri command test harness

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -104,6 +104,10 @@ filetime = "0.2"
 # backoff schedule (1s/3s/5s) doesn't make tests sleep for ~9s.
 tokio = { version = "1", features = ["test-util"] }
 test-case = "3.3.1"
+# The `test` feature exposes `tauri::test` (mock_app / MockRuntime /
+# get_ipc_response) used by the command test harness (`src/test_support.rs`).
+# Dev-only: feature unification adds it to test builds, never to release.
+tauri = { version = "2", features = ["test"] }
 
 [profile.release]
 codegen-units = 1

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tauri::{AppHandle, Emitter, Runtime, State, Wry};
+use tauri::{AppHandle, Emitter, Runtime, State};
 use tracing::{info, warn};
 
 use crate::pipeline::tracked_text::CharMapping;
@@ -106,7 +106,7 @@ pub fn spawn_synthesis_pub<R: Runtime + 'static>(
     tts: Arc<dyn TtsEngine>,
     piper_voices_dir: PathBuf,
     emitter: crate::tts::supervisor::Emitter,
-    player: Arc<crate::player::Player<R>>,
+    player: Arc<dyn crate::player::PlayerBackend>,
     pipeline: Arc<parking_lot::Mutex<crate::pipeline::TTSPipeline>>,
     entry_id: EntryId,
     play_when_ready: bool,
@@ -351,11 +351,7 @@ fn mark_ready_and_emit<R: Runtime>(
 
 /// Phase 7: kick off auto-play. Errors are logged and swallowed — failed
 /// auto-play must not flip the entry into `Error`.
-fn autoplay<R: Runtime>(
-    player: &crate::player::Player<R>,
-    audio_path: PathBuf,
-    entry_id: &EntryId,
-) {
+fn autoplay(player: &dyn crate::player::PlayerBackend, audio_path: PathBuf, entry_id: &EntryId) {
     if let Err(e) = player.load(&audio_path, entry_id.to_string()) {
         warn!("auto-play load failed: {e}");
     } else if let Err(e) = player.play() {
@@ -371,7 +367,7 @@ fn spawn_synthesis<R: Runtime + 'static>(
     tts: Arc<dyn TtsEngine>,
     piper_voices_dir: PathBuf,
     emitter: crate::tts::supervisor::Emitter,
-    player: Arc<crate::player::Player<R>>,
+    player: Arc<dyn crate::player::PlayerBackend>,
     pipeline: Arc<Mutex<TTSPipeline>>,
     entry_id: EntryId,
     play_when_ready: bool,
@@ -409,7 +405,7 @@ fn spawn_synthesis<R: Runtime + 'static>(
             );
             if play_when_ready {
                 let path = storage.cache_dir().join("audio").join(&audio_filename);
-                autoplay(&player, path, &entry_id);
+                autoplay(player.as_ref(), path, &entry_id);
             }
             Ok(())
         }
@@ -448,8 +444,8 @@ fn set_entry_error<R: Runtime>(
 /// Shared implementation for the two "add text to queue" commands below.
 /// Rejects blank input, persists the entry, emits `entry_updated`, and
 /// spawns background synthesis.
-fn ingest_text(
-    app: AppHandle<Wry>,
+fn ingest_text<R: Runtime>(
+    app: AppHandle<R>,
     state: &AppState,
     text: String,
     play_when_ready: bool,
@@ -486,8 +482,8 @@ fn ingest_text(
 /// crate (which silently fails with `ContentNotAvailable` for
 /// WebKit-sourced clipboard data on KDE Plasma 6).
 #[tauri::command]
-pub async fn add_text_entry(
-    app: AppHandle<Wry>,
+pub async fn add_text_entry<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, AppState>,
     text: String,
     play_when_ready: bool,
@@ -499,8 +495,8 @@ pub async fn add_text_entry(
 /// Used by the tray menu, where no webview context is available.
 /// Frontend code should prefer `add_text_entry` (see above).
 #[tauri::command]
-pub async fn add_clipboard_entry(
-    app: AppHandle<Wry>,
+pub async fn add_clipboard_entry<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, AppState>,
     play_when_ready: bool,
 ) -> CmdResult<String> {
@@ -611,8 +607,8 @@ pub async fn delete_entry(state: State<'_, AppState>, id: String) -> CmdResult<(
 
 /// Delete only the audio files for an entry, resetting its status to pending.
 #[tauri::command]
-pub async fn delete_audio(
-    app: AppHandle<Wry>,
+pub async fn delete_audio<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, AppState>,
     id: String,
 ) -> CmdResult<()> {
@@ -636,8 +632,8 @@ pub async fn delete_audio(
 /// Rejects the call if the entry is currently being synthesized — re-entering
 /// `spawn_synthesis` for the same id would race with the in-flight task.
 #[tauri::command]
-pub async fn regenerate_entry(
-    app: AppHandle<Wry>,
+pub async fn regenerate_entry<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, AppState>,
     id: String,
 ) -> CmdResult<()> {
@@ -694,8 +690,8 @@ pub async fn regenerate_entry(
 /// Currently marks entry as pending (mid-request abort is not supported since
 /// the TTS supervisor serialises all requests into a single channel).
 #[tauri::command]
-pub async fn cancel_synthesis(
-    app: AppHandle<Wry>,
+pub async fn cancel_synthesis<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, AppState>,
     id: String,
 ) -> CmdResult<()> {
@@ -946,8 +942,8 @@ pub struct ClearCacheResult {
 /// removed from `history.json`; otherwise only their audio is dropped.
 /// Always sweeps orphans regardless of `mode` / `delete_texts`.
 #[tauri::command]
-pub async fn clear_cache(
-    app: AppHandle<Wry>,
+pub async fn clear_cache<R: Runtime>(
+    app: AppHandle<R>,
     state: State<'_, AppState>,
     args: ClearCacheArgs,
 ) -> CmdResult<ClearCacheResult> {
@@ -1564,15 +1560,14 @@ mod tests {
 
     // ── set_speed / set_volume boundary contract ──────────────────────────────
     //
-    // Both commands take `State<'_, AppState>`, which (per `AppState::player:
-    // Arc<Player<tauri::Wry>>`) can only be constructed from a live Tauri
-    // app/webview — there is no pure function to call here, and per the task
-    // scope Tauri-specific commands aren't exercised through mock frameworks.
-    // These tests instead pin down the *documented* contract read from the
-    // source (`set_speed`/`set_volume` in this file): out-of-range values are
-    // rejected with `CommandError::ConfigError`, not silently clamped. If that
-    // ever changes, whoever edits the range literals below should notice they
-    // now disagree with the guard clauses in `set_speed`/`set_volume`.
+    // These tests predate the MockRuntime harness (`crate::test_support`):
+    // they pin down the *documented* contract read from the source
+    // (`set_speed`/`set_volume` in this file) — out-of-range values are
+    // rejected with `CommandError::ConfigError`, not silently clamped — via a
+    // local re-implementation of the range guard. Exercising the real commands
+    // through a managed `AppState` now belongs in `test_support`-based tests;
+    // if the range literals below ever disagree with the guard clauses in
+    // `set_speed`/`set_volume`, whoever edits them should notice.
 
     /// Pins down current behavior: `set_speed` rejects (does not clamp)
     /// speeds outside `[0.5, 2.0]`, per its `!(0.5..=2.0).contains(&speed)`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,9 @@ pub mod storage;
 pub mod tray;
 pub mod tts;
 
+#[cfg(test)]
+mod test_support;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -17,7 +20,7 @@ use tauri_plugin_mpv::MpvExt;
 
 use commands::*;
 use pipeline::TTSPipeline;
-use player::Player;
+use player::{Player, PlayerBackend};
 use state::AppState;
 use storage::service::StorageService;
 use tray::TrayCmd;
@@ -288,7 +291,7 @@ fn spawn_tray_handler<R: Runtime + 'static>(
     tts: Arc<dyn tts::TtsEngine>,
     piper_voices_dir: std::path::PathBuf,
     emitter: tts::supervisor::Emitter,
-    player: Arc<Player<R>>,
+    player: Arc<dyn PlayerBackend>,
     pipeline: Arc<Mutex<TTSPipeline>>,
     app: AppHandle<R>,
 ) -> tokio::sync::mpsc::Sender<TrayCmd> {
@@ -347,6 +350,41 @@ fn spawn_tray_handler<R: Runtime + 'static>(
     tray_tx
 }
 
+/// The single registration point for all Tauri commands.
+///
+/// Extracted from `run()` so the test harness (`test_support`) registers the
+/// identical command set on its `MockRuntime` app — no drift between the
+/// production handler list and what tests exercise.
+pub(crate) fn invoke_handler<R: Runtime>(
+) -> impl Fn(tauri::ipc::Invoke<R>) -> bool + Send + Sync + 'static {
+    tauri::generate_handler![
+        add_clipboard_entry,
+        add_text_entry,
+        preview_normalize,
+        get_entries,
+        get_entry,
+        delete_entry,
+        delete_audio,
+        regenerate_entry,
+        cancel_synthesis,
+        play_entry,
+        pause_playback,
+        resume_playback,
+        stop_playback,
+        seek_to,
+        set_speed,
+        set_volume,
+        get_config,
+        update_config,
+        get_available_engines,
+        download_piper_voice,
+        get_timestamps,
+        clear_cache,
+        get_cache_stats,
+        get_cache_dir,
+    ]
+}
+
 pub fn run() {
     reap_orphan_mpv();
     tauri::Builder::default()
@@ -357,8 +395,8 @@ pub fn run() {
             tray::init(app.handle())?;
             install_window_icon(app.handle())?;
 
-            let player = Arc::new(Player::new(app.handle().clone())?);
-            player::spawn_position_emitter(player.clone(), app.handle().clone());
+            let player: Arc<dyn PlayerBackend> = Arc::new(Player::new(app.handle().clone())?);
+            player::spawn_position_emitter(Arc::clone(&player), app.handle().clone());
 
             let storage = Arc::new(StorageService::new().expect("failed to open storage"));
             spawn_audio_migration_and_cleanup(Arc::clone(&storage));
@@ -402,32 +440,7 @@ pub fn run() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![
-            add_clipboard_entry,
-            add_text_entry,
-            preview_normalize,
-            get_entries,
-            get_entry,
-            delete_entry,
-            delete_audio,
-            regenerate_entry,
-            cancel_synthesis,
-            play_entry,
-            pause_playback,
-            resume_playback,
-            stop_playback,
-            seek_to,
-            set_speed,
-            set_volume,
-            get_config,
-            update_config,
-            get_available_engines,
-            download_piper_voice,
-            get_timestamps,
-            clear_cache,
-            get_cache_stats,
-            get_cache_dir,
-        ])
+        .invoke_handler(invoke_handler())
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| match event {

--- a/src-tauri/src/player/mod.rs
+++ b/src-tauri/src/player/mod.rs
@@ -421,6 +421,138 @@ impl<R: Runtime> Drop for Player<R> {
 }
 
 // ---------------------------------------------------------------------------
+// PlayerBackend trait (object-safe seam for tests)
+// ---------------------------------------------------------------------------
+
+/// Object-safe view of the audio player, held by `AppState` and consumed by
+/// commands, the tray, and the position emitter.
+///
+/// [`Player`] is the production implementation (mpv subprocess, generic over
+/// the Tauri runtime). Tests substitute a fake that records calls and scripts
+/// positions, so playback commands and the position-emitter loop can run
+/// without mpv, a window, or a display. Methods mirror [`Player`]'s public
+/// API one-to-one; behavior contracts are documented on the corresponding
+/// [`Player`] methods.
+pub trait PlayerBackend: Send + Sync {
+    /// See [`Player::load`].
+    fn load(&self, path: &Path, entry_id: String) -> Result<()>;
+    /// See [`Player::play`].
+    fn play(&self) -> Result<()>;
+    /// See [`Player::pause`].
+    fn pause(&self) -> Result<()>;
+    /// See [`Player::resume`].
+    fn resume(&self) -> Result<()>;
+    /// See [`Player::stop`].
+    fn stop(&self) -> Result<()>;
+    /// See [`Player::seek`].
+    fn seek(&self, position_sec: f64) -> Result<()>;
+    /// See [`Player::set_speed`].
+    fn set_speed(&self, speed: f32) -> Result<()>;
+    /// See [`Player::set_volume`].
+    fn set_volume(&self, volume: f32) -> Result<()>;
+    /// See [`Player::position_sec`].
+    fn position_sec(&self) -> Option<f64>;
+    /// See [`Player::duration_sec`].
+    fn duration_sec(&self) -> Option<f64>;
+    /// See [`Player::current_entry_id`].
+    fn current_entry_id(&self) -> Option<String>;
+    /// See [`Player::is_playing`].
+    fn is_playing(&self) -> bool;
+    /// See [`Player::ensure_mpv_alive`].
+    fn ensure_mpv_alive(&self) -> Result<()>;
+    /// See [`Player::mark_destroyed`].
+    fn mark_destroyed(&self);
+
+    /// Flip the internal playing flag off without emitting any event.  Used
+    /// by the position emitter's EOF path, which emits `playback_finished` /
+    /// `playback_stopped` itself and only needs the flag cleared so the next
+    /// tick stops polling.
+    fn clear_is_playing(&self);
+
+    /// True while a seek-suppress window is still open (see [`Player::seek`]
+    /// for the rationale).  An expired window is cleared as a side effect so
+    /// subsequent checks are cheap.  The position emitter calls this once per
+    /// tick.
+    fn seek_suppression_active(&self) -> bool;
+}
+
+impl<R: Runtime> PlayerBackend for Player<R> {
+    fn load(&self, path: &Path, entry_id: String) -> Result<()> {
+        Player::load(self, path, entry_id)
+    }
+
+    fn play(&self) -> Result<()> {
+        Player::play(self)
+    }
+
+    fn pause(&self) -> Result<()> {
+        Player::pause(self)
+    }
+
+    fn resume(&self) -> Result<()> {
+        Player::resume(self)
+    }
+
+    fn stop(&self) -> Result<()> {
+        Player::stop(self)
+    }
+
+    fn seek(&self, position_sec: f64) -> Result<()> {
+        Player::seek(self, position_sec)
+    }
+
+    fn set_speed(&self, speed: f32) -> Result<()> {
+        Player::set_speed(self, speed)
+    }
+
+    fn set_volume(&self, volume: f32) -> Result<()> {
+        Player::set_volume(self, volume)
+    }
+
+    fn position_sec(&self) -> Option<f64> {
+        Player::position_sec(self)
+    }
+
+    fn duration_sec(&self) -> Option<f64> {
+        Player::duration_sec(self)
+    }
+
+    fn current_entry_id(&self) -> Option<String> {
+        Player::current_entry_id(self)
+    }
+
+    fn is_playing(&self) -> bool {
+        Player::is_playing(self)
+    }
+
+    fn ensure_mpv_alive(&self) -> Result<()> {
+        Player::ensure_mpv_alive(self)
+    }
+
+    fn mark_destroyed(&self) {
+        Player::mark_destroyed(self)
+    }
+
+    fn clear_is_playing(&self) {
+        self.state.lock().is_playing = false;
+    }
+
+    fn seek_suppression_active(&self) -> bool {
+        let mut s = self.state.lock();
+        if seek_suppressed(Instant::now(), s.seek_suppress_until) {
+            return true;
+        }
+        // Deadline passed: clear it so the check is cheap on subsequent
+        // ticks. Skip the write entirely when it's already None -- the
+        // common case once the window closes.
+        if s.seek_suppress_until.is_some() {
+            s.seek_suppress_until = None;
+        }
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Pure position logic (extracted so it can be unit-tested without mpv)
 // ---------------------------------------------------------------------------
 
@@ -458,7 +590,14 @@ fn seek_suppressed(now: Instant, deadline: Option<Instant>) -> bool {
 /// Spawns a Tokio task that emits `playback_position` every 100 ms while
 /// something is playing.  Also detects EOF (position ≥ duration) and emits
 /// `playback_finished` + `playback_stopped`.
-pub fn spawn_position_emitter<R: Runtime + 'static>(player: Arc<Player<R>>, app: AppHandle<R>) {
+///
+/// Generic over [`PlayerBackend`] (not the concrete [`Player`]) so tests can
+/// drive the loop with a scripted fake player; the loop logic itself is
+/// unchanged.
+pub fn spawn_position_emitter<R: Runtime + 'static>(
+    player: Arc<dyn PlayerBackend>,
+    app: AppHandle<R>,
+) {
     // tauri::async_runtime::spawn works inside the setup hook where the
     // bare tokio runtime context is not yet active.
     tauri::async_runtime::spawn(async move {
@@ -485,28 +624,14 @@ pub fn spawn_position_emitter<R: Runtime + 'static>(player: Arc<Player<R>>, app:
                 debug!("playback finished: entry_id={entry_id}");
                 let _ = app.emit("playback_finished", json!({ "entry_id": entry_id }));
                 let _ = app.emit("playback_stopped", json!({}));
-                player.state.lock().is_playing = false;
+                player.clear_is_playing();
                 continue;
             }
 
             // Suppress emits while mpv is still catching up to a recent seek
             // target (see Player::seek for the rationale).  EOF above has
             // already been handled, so skipping ticks here is safe.
-            let suppressed = {
-                let mut s = player.state.lock();
-                if seek_suppressed(Instant::now(), s.seek_suppress_until) {
-                    true
-                } else {
-                    // Deadline passed: clear it so the check is cheap on
-                    // subsequent ticks. Skip the write entirely when it's
-                    // already None -- the common case once the window closes.
-                    if s.seek_suppress_until.is_some() {
-                        s.seek_suppress_until = None;
-                    }
-                    false
-                }
-            };
-            if suppressed {
+            if player.seek_suppression_active() {
                 continue;
             }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::pipeline::TTSPipeline;
-use crate::player::Player;
+use crate::player::PlayerBackend;
 use crate::storage::service::StorageService;
 use crate::tray::TrayCmd;
 use crate::tts::supervisor::Emitter;
@@ -13,9 +13,9 @@ use crate::tts::{EngineSwitcher, TtsEngine};
 
 /// Application-wide state held in `tauri::State<AppState>`.
 ///
-/// Uses the concrete `tauri::Wry` runtime so that `AppState` is non-generic
-/// and can be registered with `app.manage()` without ambiguity in
-/// `tauri::generate_handler!`.
+/// Runtime-agnostic by design (no `AppHandle` / `Player<R>` generics), so the
+/// same state can be registered with `app.manage()` both in the production
+/// `Wry` app and in the `MockRuntime` test harness.
 pub struct AppState {
     pub storage: Arc<StorageService>,
     /// TTS engine — actually an [`EngineSwitcher`], exposed as a trait object
@@ -36,7 +36,9 @@ pub struct AppState {
     /// Frontend emitter shared with the engine layer. Held here so the
     /// download path can reuse it without rebuilding the closure.
     pub emitter: Emitter,
-    pub player: Arc<Player<tauri::Wry>>,
+    /// Audio player behind an object-safe trait so tests can substitute a
+    /// fake (no mpv subprocess / window). Production holds `Player<Wry>`.
+    pub player: Arc<dyn PlayerBackend>,
     pub pipeline: Arc<Mutex<TTSPipeline>>,
     /// Sender for tray menu commands (read_now / read_later).
     /// `None` before the background loop is started in `setup()`.

--- a/src-tauri/src/test_support.rs
+++ b/src-tauri/src/test_support.rs
@@ -1,0 +1,432 @@
+//! Test harness for Tauri commands and events (issue #103).
+//!
+//! Builds a real [`tauri::App`] on the `MockRuntime` (no display, no webview
+//! process) with the production command set ([`crate::invoke_handler`]) and a
+//! fully managed [`AppState`] whose external pieces are fakes:
+//!
+//! - **storage**: real [`StorageService`] over a [`TempDir`] — real JSON
+//!   persistence, zero filesystem pollution;
+//! - **tts**: [`StubEngine`] behind a real [`EngineSwitcher`], so
+//!   `update_config` exercises the genuine switch logic;
+//! - **emitter**: the supervisor's `recording_emitter`;
+//! - **player**: [`FakePlayer`] — records every control call and scripts
+//!   `position_sec()` polls, so the position-emitter loop (ticks, EOF →
+//!   `playback_finished`) runs without mpv or a window;
+//! - **tray channel**: absent (`tray_cmd_tx: None`).
+//!
+//! Two usage styles, both shown in the proof tests at the bottom:
+//!
+//! 1. call a command handler directly with `app.state::<AppState>()`;
+//! 2. go through the IPC router with [`tauri::test::get_ipc_response`], which
+//!    additionally pins command-name routing and the JSON wire contract.
+
+// The harness is scaffold (issue #103): the proof tests at the bottom
+// exercise only part of its API — the rest (`record_events`, `wait_until`,
+// `FakePlayer` scripting, `TestApp` fields) is consumed by the follow-up
+// command/event test issues.
+#![allow(dead_code)]
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use parking_lot::Mutex as ParkingMutex;
+use serde_json::Value;
+use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
+use tauri::{App, Listener, Manager};
+use tempfile::TempDir;
+
+use crate::pipeline::TTSPipeline;
+use crate::player::{PlayerBackend, Result as PlayerResult};
+use crate::state::AppState;
+use crate::storage::service::StorageService;
+use crate::tts::engine::EngineKind;
+use crate::tts::supervisor::test_helpers::recording_emitter;
+use crate::tts::{CharMappingEntry, EngineSwitcher, SynthesizeOutput, TtsEngine, TtsError};
+
+// ---------------------------------------------------------------------------
+// StubEngine
+// ---------------------------------------------------------------------------
+
+/// Minimal in-memory TTS engine. `synthesize` writes a placeholder file to
+/// `out_wav` (the synthesis pipeline only needs *some* bytes there; the Opus
+/// transcode is best-effort and keeps the WAV on failure) and returns a
+/// fixed-duration output. Never touches the network, ONNX, or a subprocess.
+pub struct StubEngine;
+
+#[async_trait]
+impl TtsEngine for StubEngine {
+    fn kind(&self) -> EngineKind {
+        EngineKind::Piper
+    }
+
+    async fn warmup(&self) -> Result<(), TtsError> {
+        Ok(())
+    }
+
+    async fn spawn_initial_warmup(&self) {}
+
+    async fn synthesize(
+        &self,
+        _text: String,
+        _voice: String,
+        _sample_rate: u32,
+        out_wav: String,
+        _char_mapping: Option<Vec<CharMappingEntry>>,
+    ) -> Result<SynthesizeOutput, TtsError> {
+        std::fs::write(&out_wav, b"stub audio").map_err(TtsError::Ipc)?;
+        Ok(SynthesizeOutput {
+            timestamps: Vec::new(),
+            duration_sec: 1.0,
+        })
+    }
+
+    async fn shutdown(&self) -> Result<(), TtsError> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakePlayer
+// ---------------------------------------------------------------------------
+
+/// A playback-control call received by [`FakePlayer`], in receive order.
+/// Floats are stored raw; compare with epsilon where it matters.
+#[derive(Debug, Clone)]
+pub enum PlayerCall {
+    Load(PathBuf, String),
+    Play,
+    Pause,
+    Resume,
+    Stop,
+    Seek(f64),
+    SetSpeed(f32),
+    SetVolume(f32),
+    EnsureMpvAlive,
+    MarkDestroyed,
+}
+
+/// Test double for [`PlayerBackend`].
+///
+/// Records every control call into [`FakePlayer::calls`] and tracks the
+/// playing/loaded flags the way the real `Player` does. Unlike the real
+/// player it emits **no** Tauri events (`playback_started` etc.) — it holds
+/// no `AppHandle`; tests assert on recorded calls and on the position
+/// emitter's own output instead.
+///
+/// `position_sec()` answers from a scripted queue (see
+/// [`FakePlayer::script_positions`]); once the script is exhausted it returns
+/// `None`, which — with a known `duration_sec` — the position emitter treats
+/// as EOF. This is the intended way to drive the EOF → `playback_finished`
+/// path.
+#[derive(Default)]
+pub struct FakePlayer {
+    inner: ParkingMutex<FakeInner>,
+    destroyed: AtomicBool,
+}
+
+#[derive(Default)]
+struct FakeInner {
+    calls: Vec<PlayerCall>,
+    current_entry_id: Option<String>,
+    is_playing: bool,
+    duration_sec: Option<f64>,
+    positions: VecDeque<Option<f64>>,
+}
+
+impl FakePlayer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of the recorded control calls, in receive order.
+    pub fn calls(&self) -> Vec<PlayerCall> {
+        self.inner.lock().calls.clone()
+    }
+
+    /// What `duration_sec()` reports from now on.
+    pub fn set_duration_sec(&self, duration_sec: Option<f64>) {
+        self.inner.lock().duration_sec = duration_sec;
+    }
+
+    /// Queue the values returned by successive `position_sec()` polls.
+    pub fn script_positions(&self, positions: impl IntoIterator<Item = Option<f64>>) {
+        self.inner.lock().positions = positions.into_iter().collect();
+    }
+}
+
+impl PlayerBackend for FakePlayer {
+    fn load(&self, path: &std::path::Path, entry_id: String) -> PlayerResult<()> {
+        let mut inner = self.inner.lock();
+        inner
+            .calls
+            .push(PlayerCall::Load(path.to_path_buf(), entry_id.clone()));
+        inner.current_entry_id = Some(entry_id);
+        inner.is_playing = false;
+        Ok(())
+    }
+
+    fn play(&self) -> PlayerResult<()> {
+        let mut inner = self.inner.lock();
+        inner.calls.push(PlayerCall::Play);
+        inner.is_playing = true;
+        Ok(())
+    }
+
+    fn pause(&self) -> PlayerResult<()> {
+        let mut inner = self.inner.lock();
+        inner.calls.push(PlayerCall::Pause);
+        inner.is_playing = false;
+        Ok(())
+    }
+
+    fn resume(&self) -> PlayerResult<()> {
+        let mut inner = self.inner.lock();
+        inner.calls.push(PlayerCall::Resume);
+        inner.is_playing = true;
+        Ok(())
+    }
+
+    fn stop(&self) -> PlayerResult<()> {
+        let mut inner = self.inner.lock();
+        inner.calls.push(PlayerCall::Stop);
+        inner.is_playing = false;
+        Ok(())
+    }
+
+    fn seek(&self, position_sec: f64) -> PlayerResult<()> {
+        self.inner.lock().calls.push(PlayerCall::Seek(position_sec));
+        Ok(())
+    }
+
+    fn set_speed(&self, speed: f32) -> PlayerResult<()> {
+        self.inner.lock().calls.push(PlayerCall::SetSpeed(speed));
+        Ok(())
+    }
+
+    fn set_volume(&self, volume: f32) -> PlayerResult<()> {
+        self.inner.lock().calls.push(PlayerCall::SetVolume(volume));
+        Ok(())
+    }
+
+    fn position_sec(&self) -> Option<f64> {
+        self.inner.lock().positions.pop_front().unwrap_or(None)
+    }
+
+    fn duration_sec(&self) -> Option<f64> {
+        self.inner.lock().duration_sec
+    }
+
+    fn current_entry_id(&self) -> Option<String> {
+        self.inner.lock().current_entry_id.clone()
+    }
+
+    fn is_playing(&self) -> bool {
+        self.inner.lock().is_playing
+    }
+
+    fn ensure_mpv_alive(&self) -> PlayerResult<()> {
+        self.inner.lock().calls.push(PlayerCall::EnsureMpvAlive);
+        Ok(())
+    }
+
+    fn mark_destroyed(&self) {
+        self.inner.lock().calls.push(PlayerCall::MarkDestroyed);
+        self.destroyed.store(true, Ordering::SeqCst);
+    }
+
+    fn clear_is_playing(&self) {
+        self.inner.lock().is_playing = false;
+    }
+
+    fn seek_suppression_active(&self) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event recording
+// ---------------------------------------------------------------------------
+
+/// Shared log of `(event_name, payload)` pairs.
+pub type EventLog = Arc<Mutex<Vec<(String, Value)>>>;
+
+/// Record every emission of the given events into a shared log.
+///
+/// `App::listen_any` subscribes per event name (Tauri has no wildcard
+/// listener), so pass the names the test cares about. Rust-side `app.emit`
+/// reaches these listeners synchronously, no webview needed.
+pub fn record_events(app: &App<MockRuntime>, event_names: &[&str]) -> EventLog {
+    let log: EventLog = Arc::new(Mutex::new(Vec::new()));
+    for name in event_names {
+        let log = Arc::clone(&log);
+        let name_owned = name.to_string();
+        app.listen_any(*name, move |event| {
+            let payload = serde_json::from_str(event.payload()).unwrap_or(Value::Null);
+            log.lock().unwrap().push((name_owned.clone(), payload));
+        });
+    }
+    log
+}
+
+// ---------------------------------------------------------------------------
+// App builder
+// ---------------------------------------------------------------------------
+
+/// A mock-runtime app with a fully managed [`AppState`], plus handles to the
+/// fakes and the TempDir guards (dropping them would delete the storage
+/// dirs mid-test).
+pub struct TestApp {
+    pub app: App<MockRuntime>,
+    pub player: Arc<FakePlayer>,
+    /// Events emitted through the state's `emitter` (engine layer).
+    pub engine_events: EventLog,
+    _storage_dir: TempDir,
+    _voices_dir: TempDir,
+    _ttsd_dir: TempDir,
+}
+
+impl TestApp {
+    /// Convenience accessor for the managed state.
+    pub fn state(&self) -> tauri::State<'_, AppState> {
+        self.app.state::<AppState>()
+    }
+}
+
+/// Build the test app: production command set, managed `AppState` with fakes.
+pub fn build_test_app() -> TestApp {
+    let app = mock_builder()
+        .invoke_handler(crate::invoke_handler())
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock app");
+
+    let storage_dir = TempDir::new().expect("storage tempdir");
+    let storage = Arc::new(
+        StorageService::with_cache_dir(storage_dir.path().to_path_buf()).expect("storage service"),
+    );
+    let voices_dir = TempDir::new().expect("voices tempdir");
+    let ttsd_dir = TempDir::new().expect("ttsd tempdir");
+
+    let (emitter, engine_events) = recording_emitter();
+
+    let stub: Arc<dyn TtsEngine> = Arc::new(StubEngine);
+    let switcher = Arc::new(EngineSwitcher::new(
+        Arc::clone(&stub),
+        EngineKind::Piper,
+        Some("stub-voice".to_string()),
+        voices_dir.path().to_path_buf(),
+        ttsd_dir.path().to_path_buf(),
+        Arc::clone(&emitter),
+    ));
+    let player = Arc::new(FakePlayer::new());
+
+    app.manage(AppState {
+        storage,
+        tts: switcher.clone(),
+        engine_switcher: switcher,
+        ttsd_dir: ttsd_dir.path().to_path_buf(),
+        piper_voices_dir: voices_dir.path().to_path_buf(),
+        emitter,
+        player: player.clone(),
+        pipeline: Arc::new(ParkingMutex::new(TTSPipeline::new())),
+        tray_cmd_tx: None,
+        user_quit: Arc::new(AtomicBool::new(false)),
+    });
+
+    TestApp {
+        app,
+        player,
+        engine_events,
+        _storage_dir: storage_dir,
+        _voices_dir: voices_dir,
+        _ttsd_dir: ttsd_dir,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Async waiting
+// ---------------------------------------------------------------------------
+
+/// Poll `predicate` (every 10 ms) until it holds or `timeout` elapses.
+///
+/// Background synthesis runs via `tokio::spawn`, so a command returning
+/// `Ok` does *not* mean the side effects (entry status flip, events) have
+/// landed yet — tests must await them. Panics naming `what` on timeout.
+pub async fn wait_until<F>(what: &str, timeout: Duration, mut predicate: F)
+where
+    F: FnMut() -> bool,
+{
+    let start = Instant::now();
+    loop {
+        if predicate() {
+            return;
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "timed out after {timeout:?} waiting for {what}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Proof tests
+// ---------------------------------------------------------------------------
+
+mod tests {
+    use super::*;
+
+    /// Style (a): direct handler call. `get_entries` on a fresh app returns
+    /// the empty history — proves a command body runs against a managed
+    /// `AppState` under `MockRuntime`, no webview involved.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_entries_direct_call_returns_empty_list() {
+        let t = build_test_app();
+        let entries = crate::commands::get_entries(t.state()).await.unwrap();
+        assert!(entries.is_empty());
+    }
+
+    /// Style (b): full IPC path. `WebviewWindowBuilder` under `MockRuntime`
+    /// plus `get_ipc_response` pins command-name routing and the JSON wire
+    /// contract (`[]` for an empty history).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_entries_over_ipc_returns_empty_json_list() {
+        let t = build_test_app();
+        let webview = tauri::WebviewWindowBuilder::new(&t.app, "main", Default::default())
+            .build()
+            .expect("mock webview window");
+
+        let res = tauri::test::get_ipc_response(
+            &webview,
+            tauri::webview::InvokeRequest {
+                cmd: "get_entries".into(),
+                callback: tauri::ipc::CallbackFn(0),
+                error: tauri::ipc::CallbackFn(1),
+                // Local origin differs by platform: Windows/Android serve the
+                // app from http://tauri.localhost, elsewhere it's the
+                // tauri:// custom protocol. A non-local URL would trip the
+                // remote-origin ACL check and get the command rejected.
+                url: if cfg!(any(windows, target_os = "android")) {
+                    "http://tauri.localhost"
+                } else {
+                    "tauri://localhost"
+                }
+                .parse()
+                .unwrap(),
+                body: tauri::ipc::InvokeBody::default(),
+                headers: Default::default(),
+                invoke_key: tauri::test::INVOKE_KEY.to_string(),
+            },
+        )
+        .map(|b| {
+            b.deserialize::<Vec<crate::storage::schema::TextEntry>>()
+                .unwrap()
+        });
+
+        let entries = res.expect("get_entries IPC call failed");
+        assert!(entries.is_empty());
+    }
+}

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -99,18 +99,11 @@ fn invoke_add_clipboard_entry<R: Runtime>(app: &AppHandle<R>, play_when_ready: b
         }
     };
 
-    // Retrieve the Wry-typed AppHandle stored in AppState's player.
-    // We obtain it by casting through a channel: spawn a task on the Tokio runtime
-    // and pass the player's handle (which is already Wry-typed) from the managed state.
-    //
-    // Since AppState stores `Player<Wry>`, the player's `app` field is `AppHandle<Wry>`.
-    // We need an `AppHandle<Wry>` for spawn_synthesis_pub. The player already holds one,
-    // but there's no public accessor for it. As a pragmatic solution we use a dedicated
-    // tray command channel stored in AppState.
-    //
-    // For now, use the tray-owned AppHandle and clone it to Wry via the command sender
-    // stored in AppState (added below). This is a placeholder until the tray_tx channel
-    // is wired; fall back to emitting a tray event that the frontend forwards.
+    // The menu handler cannot call the `add_clipboard_entry` Tauri command
+    // directly (commands need a webview invoke context), so it forwards the
+    // request through the tray command channel stored in AppState. The
+    // background loop started in `setup()` performs the clipboard read and
+    // kicks off synthesis.
     if let Some(sender) = state.tray_cmd_tx.as_ref() {
         let _ = sender.try_send(TrayCmd { play_when_ready });
     } else {


### PR DESCRIPTION
## Summary

Implements #103 with the agreed **hybrid approach (variant C)**: a real `tauri::App` on `MockRuntime` (no display, no webview process, no mpv) with a fully managed `AppState` whose external pieces are test doubles, plus the `PlayerBackend` trait generalization of the position emitter.

Two usage styles are now possible, both pinned by proof tests:
1. call a command handler directly with `app.state::<AppState>()`;
2. go through the IPC router via `tauri::test::get_ipc_response` (pins command-name routing + JSON wire contract).

## Production code changes (behavior-preserving, types/generalizations only)

- **`player::PlayerBackend`** — new object-safe trait mirroring `Player<R>`'s public API. Two extra methods (`clear_is_playing`, `seek_suppression_active`) expose what the position emitter previously reached into `Player`'s private state for; the emitter loop logic itself is unchanged.
- **`AppState::player`**: `Arc<Player<Wry>>` → `Arc<dyn PlayerBackend>`. `AppState` is now fully runtime-agnostic.
- **Generalized to `R: Runtime`**: the seven handlers that took `AppHandle<Wry>` (`add_text_entry`, `add_clipboard_entry`, `delete_audio`, `regenerate_entry`, `cancel_synthesis`, `clear_cache`, and the shared `ingest_text`), plus `spawn_synthesis` / `spawn_synthesis_pub` / `autoplay` / `spawn_tray_handler` / `spawn_position_emitter` player parameters.
- **`invoke_handler()`** extracted from `run()` so tests register the identical command set — no handler-list drift.
- Stale comments updated (commands test module, tray channel rationale).

## Test harness (`src-tauri/src/test_support.rs`, `#[cfg(test)]`)

- `build_test_app()` → `TestApp`: `App<MockRuntime>` + managed `AppState` with TempDir-backed real `StorageService`, `StubEngine` behind a real `EngineSwitcher`, the supervisor's recording emitter, `FakePlayer` (records control calls, scripts `position_sec()` polls so emitter ticks and EOF → `playback_finished` are reachable), `tray_cmd_tx: None`.
- `record_events(app, &[...])` — `listen_any`-based event log; `wait_until(...)` — polling helper for `tokio::spawn`ed background synthesis.
- `tauri` `test` feature enabled via `[dev-dependencies]` only (feature unification keeps it out of release builds).

## Gates

- `just test` green: 842 Rust unit tests (840 existing + 2 new proof tests) + integration, 49 TS, 65 Python.
- `just lint` green (fmt, clippy, deny, eslint, knip, typecheck, ruff).

Note for the IPC style: the request URL must be a *local* origin (`tauri://localhost` off Windows/Android), otherwise Tauri's remote-origin ACL check rejects the command — this is encoded in the proof test with a comment.

Closes #103