### PR TITLE
test(tts): supervisor model-lifecycle re-emission and single-flight respawn

### DIFF
--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -358,6 +358,52 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn respawn_is_single_flight_under_concurrent_died() {
+        // Several callers observing `Died` on the same handle must share a
+        // single respawn: the factory is invoked exactly once past the
+        // initial spawn and exactly one `ttsd_restarting` event is emitted
+        // (the respawn_lock mutex + the Arc::ptr_eq second-chance check
+        // collapse the concurrent callers into one spawn cycle).
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = Arc::clone(&counter);
+        let factory: CommandFactory = Arc::new(move || {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+            Command::new("cat")
+        });
+
+        let (emitter, log) = recording_emitter();
+        let sup = Arc::new(TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok"));
+
+        let dead = sup.current_handle().await.expect("handle present");
+
+        // Fan out concurrent respawn requests that all observed the same
+        // dead handle.
+        let mut tasks = Vec::new();
+        for _ in 0..4 {
+            let sup = Arc::clone(&sup);
+            let dead = Arc::clone(&dead);
+            tasks.push(tokio::spawn(async move {
+                sup.ensure_respawned(Some(&dead)).await
+            }));
+        }
+        for task in tasks {
+            task.await
+                .expect("respawn task panicked")
+                .expect("respawn should succeed for every concurrent caller");
+        }
+
+        // 1 initial spawn + exactly 1 respawn — not one per concurrent caller.
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+
+        let log = log.lock().unwrap();
+        let restarting = log.iter().filter(|(n, _)| n == "ttsd_restarting").count();
+        assert_eq!(
+            restarting, 1,
+            "expected exactly one ttsd_restarting event, got {restarting}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn with_retry_propagates_non_died_error_without_respawn() {
         // A non-`Died` error (here `Timeout`) must be surfaced to the caller
         // as-is: no respawn is attempted and no `ttsd_restarting` event fires.

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -97,6 +97,96 @@ async fn supervisor_respawns_after_subprocess_suicide() {
     );
 }
 
+/// After a respawn the supervisor must replay the model lifecycle events
+/// (`model_loading` → `model_loaded`) in a background warmup, per the
+/// "Auto-Restart on Subprocess Death" requirement of the ttsd-protocol spec:
+/// the UI mirrors the fresh process's state without a separate code path.
+/// `TtsSupervisor::spawn` itself never warms up, so any lifecycle events in
+/// the log can only come from the post-respawn warmup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn respawn_reemits_model_lifecycle_events() {
+    let factory = build_factory();
+    let (emitter, log) = recording_emitter();
+    let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
+
+    let out_dir = tempfile::TempDir::new().expect("tempdir for mock wav outputs");
+    let out_wav_1 = out_dir.path().join("ruvox-mock-out-1.wav");
+    let out_wav_2 = out_dir.path().join("ruvox-mock-out-2.wav");
+
+    sup.synthesize(
+        "hello".to_string(),
+        "xenia".to_string(),
+        48_000,
+        out_wav_1.to_string_lossy().into_owned(),
+        None,
+    )
+    .await
+    .expect("first synthesize should succeed");
+
+    // Triggers the mock's suicide → Died → respawn → background warmup.
+    sup.synthesize(
+        "world".to_string(),
+        "xenia".to_string(),
+        48_000,
+        out_wav_2.to_string_lossy().into_owned(),
+        None,
+    )
+    .await
+    .expect("second synthesize should succeed via respawn");
+
+    // The post-respawn warmup runs in a background task; poll the event log
+    // until the lifecycle completes (the mock answers warmup instantly, so
+    // this converges fast even on slow CI).
+    let wait_for_loaded = async {
+        loop {
+            {
+                let log = log.lock().unwrap();
+                if log.iter().any(|(n, _)| n == "model_loaded") {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(10), wait_for_loaded)
+        .await
+        .expect("model_loaded was not re-emitted after respawn");
+
+    let log = log.lock().unwrap();
+    let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+    let pos = |name: &str| {
+        names
+            .iter()
+            .position(|n| *n == name)
+            .unwrap_or_else(|| panic!("expected {name} in {names:?}"))
+    };
+    let restarting = pos("ttsd_restarting");
+    let loading = pos("model_loading");
+    let loaded = pos("model_loaded");
+    assert!(
+        restarting < loading && loading < loaded,
+        "expected ttsd_restarting < model_loading < model_loaded, got {names:?}",
+    );
+    assert_eq!(
+        names.iter().filter(|n| **n == "model_loading").count(),
+        1,
+        "model_loading must be re-emitted exactly once, got {names:?}",
+    );
+    assert_eq!(
+        names.iter().filter(|n| **n == "model_loaded").count(),
+        1,
+        "model_loaded must be re-emitted exactly once, got {names:?}",
+    );
+    assert!(
+        !names.contains(&"model_error"),
+        "did not expect model_error in {names:?}",
+    );
+    assert!(
+        !names.contains(&"tts_fatal"),
+        "did not expect tts_fatal in {names:?}",
+    );
+}
+
 /// `kill_current` must terminate a ttsd stuck on an in-flight request, and
 /// the killed request must be retried transparently against a respawned
 /// process. The sleepy mock's first process blocks for 30 s on synthesize


### PR DESCRIPTION
## Summary

Adds the two missing supervisor respawn tests from #105.

## Tests

- **`respawn_reemits_model_lifecycle_events`** (integration, `src-tauri/tests/supervisor.rs`, mock ttsd): after a subprocess crash and transparent respawn, the supervisor replays the model lifecycle — `ttsd_restarting` → `model_loading` → `model_loaded`, in that order, each exactly once, with no `model_error` / `tts_fatal`. Existing respawn tests never asserted the lifecycle events; this locks in point 4 of the spec's "Auto-Restart on Subprocess Death" requirement (background warmup re-emitting `model_loading` → `model_loaded` / `model_error`).
- **`respawn_is_single_flight_under_concurrent_died`** (unit, `src-tauri/src/tts/supervisor.rs`): four concurrent callers observing `Died` on the same handle share one respawn — the command factory runs exactly once past the initial spawn and exactly one `ttsd_restarting` event is emitted. Locks in point 2 of the same requirement (single-flight respawn).

## Behaviour vs spec

No divergence found: `TtsSupervisor::ensure_respawned`/`spawn_warmup` already re-emit the model lifecycle after every successful respawn and the `respawn_lock` + `Arc::ptr_eq` second-chance check already make respawns single-flight — the tests only pin the specified behaviour.

## Gates

All green from the worktree (`CARGO_TARGET_DIR` set):

- `just test` (Rust + TS + Python)
- `cargo test --all-features` (covers the `test-helpers`-gated integration suite, as in CI)
- `just lint` (fmt, clippy, deny, eslint, knip, typecheck, ruff)

Closes #105