### PR TITLE
fix(tts): wait for post-respawn warmup before sending requests

### DIFF
--- a/openspec/changes/archive/2026-07-26-await-warmup-before-retry/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-await-warmup-before-retry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/archive/2026-07-26-await-warmup-before-retry/design.md
+++ b/openspec/changes/archive/2026-07-26-await-warmup-before-retry/design.md
@@ -1,0 +1,71 @@
+# Design: Await warmup before retry
+
+## Root cause
+
+`ensure_respawned` (`src-tauri/src/tts/supervisor.rs:120-184`) installs the
+fresh `TtsSubprocess` and kicks off `spawn_warmup` as a fire-and-forget
+background task (events `model_loading` → `model_loaded` / `model_error`).
+`with_retry` (supervisor.rs:90-114) then immediately loops and retries the
+failed request against the new handle. Real Silero ttsd answers `synthesize`
+with `model_not_loaded` until warmup finishes, so the retry fails. The mock
+ttsd in `tests/supervisor.rs` needs no model, which is why the suite never
+caught this. The stale comment in `spawn_warmup` ("the next synthesize will
+retrigger model load on the Python side") is factually wrong — ttsd does not
+auto-load.
+
+## Chosen design: per-generation readiness signal in the handle slot
+
+- The supervisor slot becomes `RwLock<Option<LiveHandle>>` where
+  `LiveHandle { proc: Arc<TtsSubprocess>, ready: watch::Receiver<WarmupState> }`
+  and `WarmupState` is `WarmingUp | Ready | Failed`.
+- `ensure_respawned`, after a successful spawn, creates the watch channel in
+  `WarmingUp`, spawns the warmup task (unchanged event emissions; it flips
+  the state to `Ready` or `Failed` at the end), and installs the
+  `LiveHandle`.
+- `with_retry`, after obtaining the current `LiveHandle` (existing or
+  freshly respawned), awaits `ready` while it is `WarmingUp` before running
+  the operation. The receiver is per-generation, so a waiter never confuses
+  an old generation's readiness with the current one.
+- After `Failed`, operations proceed anyway and surface ttsd's own error
+  (e.g. `model_not_loaded`) — no infinite wait, honest error propagation.
+- Initial spawn (`TtsSupervisor::spawn`) installs the handle with state
+  `Ready`, preserving today's startup semantics exactly (the app's explicit
+  startup warmup is unaffected).
+
+This covers all callers, not just the retried request: a queued entry whose
+request hits `Died` from the killed process, and a brand-new request
+arriving while the fresh process is still warming up, both wait for the same
+generation's readiness instead of failing.
+
+## Rejected alternatives
+
+- **Retry loop on `model_not_loaded` in `with_retry`** — turns a state
+  problem into polling: needs a retry budget/delay policy, blurs the line
+  between a transient not-ready and a genuine model load failure, and still
+  emits spurious errors for brand-new requests. Waiting on a readiness
+  signal is deterministic.
+- **Global model-ready gate at the command layer** — pushes TTS-lifecycle
+  knowledge up into `commands/`, duplicates what the supervisor already
+  tracks, and does not help non-command callers of the supervisor.
+- **Await warmup inside `ensure_respawned`** — would hold the single-flight
+  `respawn_lock` across the whole model load (seconds), serializing
+  unrelated requests behind the lock and stalling the `tts_fatal` path;
+  readiness must be observable without the lock.
+
+## Touch points
+
+- `src-tauri/src/tts/supervisor.rs` — `LiveHandle` + `WarmupState`, slot
+  type, `ensure_respawned` (install + spawn warmup with state flip),
+  `with_retry` (await readiness), `spawn_warmup` (state broadcast; fix the
+  stale comment), `kill_current` unchanged in behavior.
+- No changes to `TtsSubprocess`, the driver, Python, or the event payloads.
+
+## Tests
+
+- Integration (`tests/supervisor.rs`): extend the sleepy-mock family with a
+  mock that reports `model_not_loaded` until its `warmup` is called — assert
+  that a request issued right after a kill/crash succeeds without an
+  explicit warmup call from the client (i.e. the retry waited).
+- Keep the existing respawn/second-chance/fatal tests green; add a unit
+  test that operations are not attempted while `WarmingUp` (e.g. via the
+  recording emitter ordering or a counting mock).

--- a/openspec/changes/archive/2026-07-26-await-warmup-before-retry/proposal.md
+++ b/openspec/changes/archive/2026-07-26-await-warmup-before-retry/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: Await warmup before retrying after a ttsd restart (#128)
+
+## Summary
+
+When ttsd dies mid-session (crash, or an explicit kill from
+`cancel_synthesis`), the supervisor respawns it and `with_retry` retries the
+failed request immediately — while the post-respawn warmup (model load) is
+still running in the background. The real Silero ttsd rejects `synthesize`
+with `model_not_loaded` until warmup completes, so the "transparent retry"
+fails for the real engine and the entry lands in `error` despite a
+successful recovery.
+
+Make requests wait for the post-respawn warmup before they are sent to the
+fresh process: the supervisor's handle slot carries a per-generation
+readiness signal fed by the background warmup task, and `with_retry` awaits
+it (state != warming-up) before issuing an operation against that handle.
+
+## Capabilities
+
+- `ttsd-protocol` (modified) — Auto-Restart on Subprocess Death
+
+## Non-goals
+
+- No change to startup semantics: before the initial warmup completes, an
+  early `synthesize` keeps today's behavior (no waiting at supervisor
+  level).
+- No ttsd protocol or Python changes.
+- No change to the backoff schedule, single-flight respawn, or event names
+  (`ttsd_restarting`, `model_loading`, `model_loaded`, `model_error`,
+  `tts_fatal`).
+
+## Approach
+
+See design.md: per-generation readiness receiver stored alongside the
+subprocess handle; rejected alternatives (retry-loop on `model_not_loaded`,
+global model-ready gate) recorded there.

--- a/openspec/changes/archive/2026-07-26-await-warmup-before-retry/specs/ttsd-protocol/spec.md
+++ b/openspec/changes/archive/2026-07-26-await-warmup-before-retry/specs/ttsd-protocol/spec.md
@@ -1,0 +1,66 @@
+# Delta: ttsd-protocol
+
+## MODIFIED Requirements
+
+### Requirement: Auto-Restart on Subprocess Death
+
+The `TtsSupervisor` SHALL detect a dead ttsd when a request fails with
+`TtsError::Died` (only `Died` triggers respawn — protocol errors and timeouts
+propagate as-is) or when the subprocess was explicitly terminated by
+`cancel_synthesis` for an in-flight entry (see the Synthesis Cancellation
+Command requirement in `ipc-commands`). On detection it SHALL:
+
+1. Log a warning and emit `ttsd_restarting` (`{}`).
+2. Make the respawn single-flight (concurrent callers share one respawn).
+3. Try to spawn a fresh ttsd up to 3 times with backoff delays of 1 s, 3 s, 5 s.
+4. After a successful respawn, run `warmup` re-emitting
+   `model_loading` → `model_loaded` / `model_error`, and send the retried
+   failed request — as well as any request that arrives while the fresh
+   process is still warming up — to the new process only after that warmup
+   completes; if the warmup fails, requests proceed and surface ttsd's own
+   error.
+5. After all attempts fail, emit `tts_fatal { message }` and surface the spawn
+   error to the caller; the next request SHALL trigger a fresh respawn attempt
+   so the system can still recover later.
+
+An in-flight request sent to the crashed or terminated process fails; after
+an explicit kill for cancellation, in-flight and queued requests belonging
+to OTHER entries SHALL be retried transparently via the existing retry loop,
+while the cancelled entry's own request is not retried (its task is
+aborted). Pending entries whose requests ultimately fail go to the `error`
+state via the normal command-error path.
+
+#### Scenario: transparent respawn and retry
+
+- GIVEN a ttsd that crashed mid-session
+- WHEN the next request hits `TtsError::Died`
+- THEN `ttsd_restarting` is emitted, a new process is spawned within the
+  backoff schedule, warmup replays the model lifecycle events, and the
+  request is retried against the new process after the warmup completes
+
+#### Scenario: request during post-respawn warmup waits
+
+- GIVEN a freshly respawned ttsd whose warmup has not completed yet
+- WHEN a synthesize request arrives
+- THEN the request waits for the warmup to finish instead of failing with
+  `model_not_loaded`, and completes against the warmed-up process
+
+#### Scenario: respawn after cancellation kill
+
+- GIVEN a ttsd terminated by `cancel_synthesis` for an in-flight entry
+- WHEN the next request arrives
+- THEN a fresh ttsd is spawned per the same backoff/warmup procedure and
+  other entries' requests proceed against the new process
+
+#### Scenario: respawn exhausted
+
+- GIVEN a supervisor whose spawn attempts all fail
+- WHEN the third attempt fails
+- THEN `tts_fatal` is emitted with the error message and the caller receives
+  the spawn error
+
+#### Scenario: protocol errors do not trigger respawn
+
+- GIVEN a live ttsd that responds with an error (e.g. `bad_input`)
+- WHEN the request completes with that error
+- THEN no respawn is attempted and no `ttsd_restarting` event is emitted

--- a/openspec/changes/archive/2026-07-26-await-warmup-before-retry/tasks.md
+++ b/openspec/changes/archive/2026-07-26-await-warmup-before-retry/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Await warmup before retry
+
+## Implementation
+
+- [x] `src-tauri/src/tts/supervisor.rs`: introduce `WarmupState`
+  (`WarmingUp | Ready | Failed`) and make the slot
+  `RwLock<Option<LiveHandle>>` with `LiveHandle { proc, ready:
+  watch::Receiver<WarmupState> }`; initial spawn installs state `Ready`.
+- [x] `ensure_respawned`: after a successful spawn, create the readiness
+  channel (`WarmingUp`), spawn the warmup task (unchanged events, state flip
+  at the end), install the `LiveHandle`.
+- [x] `with_retry`: after obtaining the current `LiveHandle`, await
+  readiness while `WarmingUp` before running the operation.
+- [x] Fix the stale `spawn_warmup` comment (ttsd does not auto-load the
+  model on synthesize).
+
+## Tests
+
+- [x] New mock ttsd fixture that answers `model_not_loaded` until `warmup`
+  is called; integration test: request issued right after a kill/crash
+  succeeds without the client calling warmup explicitly.
+- [x] Existing supervisor tests (suicide respawn, kill_current, fatal,
+  second-chance) stay green.
+
+## Validation
+
+- [x] `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml` (incl.
+  `--features test-helpers --test supervisor`) green.
+- [x] `nix develop -c just lint` green.
+- [x] `nix develop -c pnpm dlx @fission-ai/openspec@1.6.0 validate
+  await-warmup-before-retry --strict` green.

--- a/openspec/specs/ttsd-protocol/spec.md
+++ b/openspec/specs/ttsd-protocol/spec.md
@@ -253,9 +253,12 @@ Command requirement in `ipc-commands`). On detection it SHALL:
 1. Log a warning and emit `ttsd_restarting` (`{}`).
 2. Make the respawn single-flight (concurrent callers share one respawn).
 3. Try to spawn a fresh ttsd up to 3 times with backoff delays of 1 s, 3 s, 5 s.
-4. After a successful respawn, run `warmup` in the background re-emitting
-   `model_loading` → `model_loaded` / `model_error`, and retry the failed
-   request against the new handle.
+4. After a successful respawn, run `warmup` re-emitting
+   `model_loading` → `model_loaded` / `model_error`, and send the retried
+   failed request — as well as any request that arrives while the fresh
+   process is still warming up — to the new process only after that warmup
+   completes; if the warmup fails, requests proceed and surface ttsd's own
+   error.
 5. After all attempts fail, emit `tts_fatal { message }` and surface the spawn
    error to the caller; the next request SHALL trigger a fresh respawn attempt
    so the system can still recover later.
@@ -273,7 +276,14 @@ state via the normal command-error path.
 - WHEN the next request hits `TtsError::Died`
 - THEN `ttsd_restarting` is emitted, a new process is spawned within the
   backoff schedule, warmup replays the model lifecycle events, and the
-  request is retried against the new process
+  request is retried against the new process after the warmup completes
+
+#### Scenario: request during post-respawn warmup waits
+
+- GIVEN a freshly respawned ttsd whose warmup has not completed yet
+- WHEN a synthesize request arrives
+- THEN the request waits for the warmup to finish instead of failing with
+  `model_not_loaded`, and completes against the warmed-up process
 
 #### Scenario: respawn after cancellation kill
 

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -16,7 +16,14 @@
 //! - After every successful respawn the supervisor kicks off `warmup` in the
 //!   background and re-emits `model_loading` / `model_loaded` (or
 //!   `model_error`) so the UI can mirror the lifecycle without a separate
-//!   code path.
+//!   code path. The fresh handle is installed in the slot together with a
+//!   per-generation readiness signal ([`watch::Receiver<WarmupState>`]) fed
+//!   by that warmup task, and `with_retry` waits for it (state !=
+//!   `WarmingUp`) before sending any operation to the new process — real
+//!   Silero ttsd rejects `synthesize` with `model_not_loaded` until warmup
+//!   completes, so retrying immediately would fail despite a successful
+//!   recovery. After a failed warmup operations proceed anyway and surface
+//!   ttsd's own error instead of waiting forever.
 //!
 //! Only [`TtsError::Died`] triggers a respawn. Protocol errors
 //! (`TtsError::Ttsd`) and `TtsError::Timeout` are propagated as-is — they do
@@ -28,7 +35,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::json;
 use tokio::process::Command;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{watch, Mutex, RwLock};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
@@ -44,6 +51,14 @@ const BACKOFFS: [Duration; 3] = [
     Duration::from_secs(5),
 ];
 
+/// Upper bound for waiting on the post-respawn warmup in `with_retry`.
+/// Silero model load takes seconds to tens of seconds, so 10 minutes is
+/// generous. On expiry the operation proceeds anyway — the request either
+/// surfaces ttsd's own error or times out in the driver, exactly as a failed
+/// warmup would. This guards against a ttsd process that stays alive but
+/// hangs during model load (state stuck in `WarmingUp` forever).
+const WARMUP_WAIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
 /// Emitter callback — abstracts away `tauri::AppHandle` so the supervisor
 /// can be unit/integration-tested without a Tauri runtime.
 pub type Emitter = Arc<dyn Fn(&str, serde_json::Value) + Send + Sync>;
@@ -52,10 +67,32 @@ pub type Emitter = Arc<dyn Fn(&str, serde_json::Value) + Send + Sync>;
 /// spawn attempt — must be idempotent.
 pub type CommandFactory = Arc<dyn Fn() -> Command + Send + Sync>;
 
+/// Readiness of the post-respawn warmup for one generation of the ttsd
+/// process. Stored per handle so a waiter never confuses an old generation's
+/// readiness with the current one.
+#[derive(Debug, Clone)]
+enum WarmupState {
+    /// The background warmup task is still running (model load in progress).
+    WarmingUp,
+    /// Warmup completed; the process accepts `synthesize`.
+    Ready,
+    /// Warmup failed. Operations proceed anyway and surface ttsd's own error
+    /// (e.g. `model_not_loaded`) — no infinite wait, honest error propagation.
+    Failed(String),
+}
+
+/// The live subprocess plus the readiness signal of its post-respawn warmup.
+/// Cloning is cheap (`Arc` + `watch::Receiver`).
+#[derive(Clone)]
+struct LiveHandle {
+    proc: Arc<TtsSubprocess>,
+    ready: watch::Receiver<WarmupState>,
+}
+
 pub struct TtsSupervisor {
     /// Current live handle. `None` only between a failed respawn and the
     /// next successful one.
-    current: RwLock<Option<Arc<TtsSubprocess>>>,
+    current: RwLock<Option<LiveHandle>>,
     /// Held only across respawn attempts to make them single-flight.
     respawn_lock: Mutex<()>,
     factory: CommandFactory,
@@ -71,18 +108,60 @@ impl TtsSupervisor {
     pub fn spawn(factory: CommandFactory, emitter: Emitter) -> Result<Self, TtsError> {
         let cmd = factory();
         let initial = TtsSubprocess::spawn(cmd)?;
+        // Startup semantics are unchanged: the initial handle is `Ready`
+        // immediately — requests are not gated on the app's explicit startup
+        // warmup (`spawn_initial_warmup`), exactly as before. The sender is
+        // dropped on purpose: nothing will ever flip this generation's state.
+        let (_tx, ready) = watch::channel(WarmupState::Ready);
         Ok(Self {
-            current: RwLock::new(Some(Arc::new(initial))),
+            current: RwLock::new(Some(LiveHandle {
+                proc: Arc::new(initial),
+                ready,
+            })),
             respawn_lock: Mutex::new(()),
             factory,
             emitter,
         })
     }
 
-    /// Return the current handle, cloning the inner `Arc` so the read lock
-    /// is released immediately. `None` means we are between respawns.
-    async fn current_handle(&self) -> Option<Arc<TtsSubprocess>> {
+    /// Return the current handle (cheap clone) so the read lock is released
+    /// immediately. `None` means we are between respawns.
+    async fn current_handle(&self) -> Option<LiveHandle> {
         self.current.read().await.clone()
+    }
+
+    /// Wait until the handle's post-respawn warmup leaves [`WarmupState::WarmingUp`].
+    /// Both `Ready` and `Failed` let the operation proceed — after a failed
+    /// warmup ttsd's own error (e.g. `model_not_loaded`) is the honest signal
+    /// to surface. No-op for the initial handle (installed as `Ready`).
+    /// The wait is bounded by [`WARMUP_WAIT_TIMEOUT`]: on expiry the
+    /// operation proceeds anyway (see the constant's doc).
+    async fn await_ready(mut ready: watch::Receiver<WarmupState>) {
+        let wait = async {
+            while matches!(*ready.borrow(), WarmupState::WarmingUp) {
+                if ready.changed().await.is_err() {
+                    // The warmup task was dropped without publishing a final
+                    // state; proceed rather than wait forever.
+                    break;
+                }
+            }
+        };
+        if tokio::time::timeout(WARMUP_WAIT_TIMEOUT, wait)
+            .await
+            .is_err()
+        {
+            warn!(
+                target: "tts::supervisor",
+                "timed out waiting for post-respawn warmup — proceeding; ttsd will surface its own error"
+            );
+            return;
+        }
+        if let WarmupState::Failed(message) = &*ready.borrow() {
+            warn!(
+                target: "tts::supervisor",
+                "post-respawn warmup failed ({message}) — proceeding; ttsd will surface its own error"
+            );
+        }
     }
 
     /// Run an operation against the current ttsd handle, respawning on
@@ -103,10 +182,14 @@ impl TtsSupervisor {
                 }
             };
 
-            match op(handle.clone()).await {
+            // A freshly respawned process is still loading its model; wait
+            // for its warmup before sending anything (see `await_ready`).
+            Self::await_ready(handle.ready.clone()).await;
+
+            match op(Arc::clone(&handle.proc)).await {
                 Err(TtsError::Died) => {
                     info!(target: "tts::supervisor", "operation hit Died — attempting respawn");
-                    self.ensure_respawned(Some(&handle)).await?;
+                    self.ensure_respawned(Some(&handle.proc)).await?;
                     // Loop and retry with the freshly-installed handle.
                 }
                 other => return other,
@@ -126,7 +209,7 @@ impl TtsSupervisor {
         // were waiting on the mutex?
         if let Some(dead) = dead {
             if let Some(current) = self.current.read().await.as_ref() {
-                if !Arc::ptr_eq(current, dead) {
+                if !Arc::ptr_eq(&current.proc, dead) {
                     return Ok(());
                 }
             }
@@ -150,16 +233,24 @@ impl TtsSupervisor {
             match TtsSubprocess::spawn(cmd) {
                 Ok(fresh) => {
                     let fresh = Arc::new(fresh);
+                    // The fresh process still needs its model loaded. Install
+                    // it as WarmingUp together with the readiness receiver;
+                    // the background warmup task flips the state at the end
+                    // and with_retry waits on it before sending requests.
+                    let (state_tx, ready) = watch::channel(WarmupState::WarmingUp);
                     {
                         let mut slot = self.current.write().await;
-                        *slot = Some(Arc::clone(&fresh));
+                        *slot = Some(LiveHandle {
+                            proc: Arc::clone(&fresh),
+                            ready,
+                        });
                     }
                     info!(
                         target: "tts::supervisor",
                         "respawn attempt {} succeeded",
                         attempt + 1
                     );
-                    self.spawn_warmup(fresh);
+                    self.spawn_warmup(fresh, Some(state_tx));
                     return Ok(());
                 }
                 Err(e) => {
@@ -195,16 +286,23 @@ impl TtsSupervisor {
     pub async fn kill_current(&self) {
         if let Some(handle) = self.current_handle().await {
             info!(target: "tts::supervisor", "kill_current: terminating ttsd subprocess");
-            handle.kill_now();
+            handle.proc.kill_now();
         }
     }
 
     /// Run `warmup` against the freshly-spawned handle in a background task,
     /// mirroring the `model_loading` → `model_loaded` / `model_error`
-    /// lifecycle that startup uses. Failures here do not invalidate the
-    /// handle; ttsd treats warmup as idempotent and the next synthesize will
-    /// retrigger model load on the Python side.
-    fn spawn_warmup(&self, handle: Arc<TtsSubprocess>) {
+    /// lifecycle that startup uses. `state_tx` (present for post-respawn
+    /// warmups) is the readiness signal waited on by `with_retry`: it is
+    /// flipped to `Ready`/`Failed` when the warmup settles. Failures here do
+    /// not invalidate the handle; requests then proceed and surface ttsd's
+    /// own error (ttsd does NOT auto-load the model on synthesize — it
+    /// rejects it with `model_not_loaded`).
+    fn spawn_warmup(
+        &self,
+        handle: Arc<TtsSubprocess>,
+        state_tx: Option<watch::Sender<WarmupState>>,
+    ) {
         let emitter = Arc::clone(&self.emitter);
         tokio::spawn(async move {
             emitter("model_loading", json!({}));
@@ -212,10 +310,16 @@ impl TtsSupervisor {
                 Ok(()) => {
                     info!(target: "tts::supervisor", "post-respawn warmup ok");
                     emitter("model_loaded", json!({}));
+                    if let Some(tx) = &state_tx {
+                        let _ = tx.send(WarmupState::Ready);
+                    }
                 }
                 Err(e) => {
                     warn!(target: "tts::supervisor", "post-respawn warmup failed: {e}");
                     emitter("model_error", json!({ "message": e.to_string() }));
+                    if let Some(tx) = &state_tx {
+                        let _ = tx.send(WarmupState::Failed(e.to_string()));
+                    }
                 }
             }
         });
@@ -240,7 +344,9 @@ impl TtsEngine for TtsSupervisor {
     /// callers don't need to duplicate the lifecycle plumbing.
     async fn spawn_initial_warmup(&self) {
         if let Some(handle) = self.current_handle().await {
-            self.spawn_warmup(handle);
+            // The initial handle is already `Ready` (startup semantics), so
+            // no readiness signal to flip here.
+            self.spawn_warmup(handle.proc, None);
         }
     }
 
@@ -279,7 +385,7 @@ impl TtsEngine for TtsSupervisor {
             Some(h) => h,
             None => return Ok(()),
         };
-        handle.shutdown().await
+        handle.proc.shutdown().await
     }
 }
 
@@ -346,7 +452,7 @@ mod tests {
         let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
 
         let dead = sup.current_handle().await.expect("handle present");
-        let res = sup.ensure_respawned(Some(&dead)).await;
+        let res = sup.ensure_respawned(Some(&dead.proc)).await;
         assert!(res.is_err(), "respawn should have failed");
 
         let log = log.lock().unwrap();
@@ -381,7 +487,7 @@ mod tests {
         let mut tasks = Vec::new();
         for _ in 0..4 {
             let sup = Arc::clone(&sup);
-            let dead = Arc::clone(&dead);
+            let dead = Arc::clone(&dead.proc);
             tasks.push(tokio::spawn(async move {
                 sup.ensure_respawned(Some(&dead)).await
             }));
@@ -431,5 +537,82 @@ mod tests {
             !names.contains(&"ttsd_restarting"),
             "non-Died error must not trigger a restart, got events: {names:?}"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn op_is_not_attempted_while_warming_up() {
+        // `tail -f /dev/null` accepts stdin writes but never reads them and
+        // never prints anything on stdout, so the post-respawn warmup against
+        // it deterministically never completes and the fresh handle stays in
+        // `WarmingUp` forever. The retried operation must not run while that
+        // is the case. (Not `cat`: cat echoes stdin back, which would
+        // complete the warmup with a JSON error and flip the state to
+        // `Failed`, making this test race.)
+        let factory: CommandFactory = Arc::new(|| {
+            let mut cmd = Command::new("tail");
+            cmd.arg("-f").arg("/dev/null");
+            cmd
+        });
+        let (emitter, _log) = recording_emitter();
+        let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
+
+        let dead = sup.current_handle().await.expect("handle present");
+        sup.ensure_respawned(Some(&dead.proc))
+            .await
+            .expect("respawn ok");
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+        let op_task = tokio::spawn(async move {
+            let _: Result<(), TtsError> = sup
+                .with_retry(move |_h| {
+                    calls_clone.fetch_add(1, Ordering::SeqCst);
+                    async { Ok(()) }
+                })
+                .await;
+        });
+
+        // Let the retry loop run several turns; the op must not fire while
+        // the fresh handle is still warming up. (The paused clock does not
+        // auto-advance here because this task always has work to do, so the
+        // WARMUP_WAIT_TIMEOUT timer inside await_ready cannot fire.)
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "op ran while the handle was still WarmingUp"
+        );
+        op_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn await_ready_gives_up_after_timeout() {
+        // Sender alive but never sends (as when ttsd hangs during model
+        // load): the wait must still terminate via WARMUP_WAIT_TIMEOUT so
+        // requests proceed instead of blocking forever. With a paused clock
+        // and nothing else to do, tokio auto-advances straight to the timer.
+        let (_tx, ready) = watch::channel(WarmupState::WarmingUp);
+        TtsSupervisor::await_ready(ready).await;
+    }
+
+    #[tokio::test]
+    async fn await_ready_returns_after_failed_warmup() {
+        // A failed warmup must not deadlock the retry loop: waiters are
+        // released so the operation can run and surface ttsd's own error.
+        let (tx, ready) = watch::channel(WarmupState::WarmingUp);
+        tx.send(WarmupState::Failed("model load blew up".to_string()))
+            .expect("receiver alive");
+        TtsSupervisor::await_ready(ready).await;
+    }
+
+    #[tokio::test]
+    async fn await_ready_is_noop_for_initial_ready_handle() {
+        // The initial handle is installed as Ready (startup semantics) — no
+        // waiting happens even though its sender is long gone.
+        let (tx, ready) = watch::channel(WarmupState::Ready);
+        drop(tx);
+        TtsSupervisor::await_ready(ready).await;
     }
 }

--- a/src-tauri/tests/fixtures/mock_ttsd_warmup_gate.py
+++ b/src-tauri/tests/fixtures/mock_ttsd_warmup_gate.py
@@ -1,0 +1,76 @@
+"""Mock ttsd that rejects synthesize until warmup is called.
+
+Used by `tests/supervisor.rs` to verify that the supervisor's retry loop
+waits for the post-respawn warmup before sending requests to a freshly
+respawned process. Like the real Silero ttsd, `synthesize` answers
+`model_not_loaded` until this process has received a `warmup` request.
+
+To keep the test deterministic, `warmup` replies only after a short delay
+(env var MOCK_TTSD_WARMUP_DELAY_SEC, default 0.5 s): without the readiness
+wait the retried synthesize would race the background warmup and reliably
+lose.
+
+Behaviour:
+  - `warmup`     -> sleep the delay, then reply ok; from then on synthesize
+                    succeeds.
+  - `synthesize` -> before warmup: error `model_not_loaded` (no side
+                    effects); after warmup: ok with empty timestamps.
+  - `shutdown`   -> replies ok and exits.
+
+Run via:  MOCK_TTSD_WARMUP_DELAY_SEC=0.5 python tests/fixtures/mock_ttsd_warmup_gate.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+WARMUP_DELAY_SEC = float(os.environ.get("MOCK_TTSD_WARMUP_DELAY_SEC", "0.5"))
+
+_warmed_up = False
+
+
+def _write(payload: dict) -> None:
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    global _warmed_up
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _write({"ok": False, "error": "bad_json", "message": str(exc)})
+            continue
+
+        cmd = req.get("cmd")
+        if cmd == "warmup":
+            time.sleep(WARMUP_DELAY_SEC)
+            _warmed_up = True
+            _write({"ok": True, "version": "mock-0.0.0"})
+        elif cmd == "synthesize":
+            if not _warmed_up:
+                _write(
+                    {
+                        "ok": False,
+                        "error": "model_not_loaded",
+                        "message": "Silero model is not loaded",
+                    }
+                )
+            else:
+                _write({"ok": True, "timestamps": [], "duration_sec": 0.0})
+        elif cmd == "shutdown":
+            _write({"ok": True})
+            return
+        else:
+            _write({"ok": False, "error": "bad_cmd", "message": f"unknown cmd: {cmd}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -271,3 +271,72 @@ async fn kill_current_terminates_in_flight_request_and_respawns() {
         "did not expect tts_fatal in {names:?}",
     );
 }
+
+/// A request issued right after a kill must wait for the post-respawn
+/// warmup instead of failing with `model_not_loaded`. The mock rejects
+/// `synthesize` until it receives `warmup`, and its warmup answer is delayed
+/// (MOCK_TTSD_WARMUP_DELAY_SEC) so that a retry that does not wait would
+/// deterministically hit `model_not_loaded`. Success here — without the test
+/// ever calling warmup for the respawned process — proves the retry waited
+/// for the supervisor's background warmup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retry_after_kill_waits_for_post_respawn_warmup() {
+    let script = common::resolve_test_path("tests/fixtures/mock_ttsd_warmup_gate.py")
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("mock_ttsd_warmup_gate.py not found: {e}"));
+
+    let out_dir = tempfile::TempDir::new().expect("tempdir for warmup-gate test");
+    let out_wav = out_dir.path().join("warmup-gate-out.wav");
+
+    let factory: CommandFactory = Arc::new(move || {
+        let mut cmd = Command::new("python3");
+        cmd.arg(&script).env("MOCK_TTSD_WARMUP_DELAY_SEC", "0.5");
+        cmd
+    });
+
+    let (emitter, log) = recording_emitter();
+    let sup = TtsSupervisor::spawn(factory, emitter).expect("initial spawn ok");
+
+    // Warm up the initial process (mirrors the app's explicit startup
+    // warmup). The point of the test is that NOBODY calls warmup for the
+    // respawned process — only the supervisor's background task does.
+    sup.warmup().await.expect("initial warmup should succeed");
+
+    // Kill the process while idle; the next request observes Died and goes
+    // through the respawn path.
+    sup.kill_current().await;
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(20),
+        sup.synthesize(
+            "hello".to_string(),
+            "xenia".to_string(),
+            48_000,
+            out_wav.to_string_lossy().into_owned(),
+            None,
+        ),
+    )
+    .await
+    .expect("request hung — retry did not finish after respawn")
+    .expect("synthesize should succeed after the post-respawn warmup completes");
+    assert_eq!(output.timestamps.len(), 0);
+
+    let log = log.lock().unwrap();
+    let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"ttsd_restarting"),
+        "expected ttsd_restarting in {names:?}",
+    );
+    assert!(
+        names.contains(&"model_loading"),
+        "expected post-respawn model_loading in {names:?}",
+    );
+    assert!(
+        names.contains(&"model_loaded"),
+        "expected post-respawn model_loaded in {names:?}",
+    );
+    assert!(
+        !names.contains(&"tts_fatal"),
+        "did not expect tts_fatal in {names:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #128. `with_retry` retried the failed request against a freshly respawned ttsd immediately, while the model warmup was still running in the background. Real Silero ttsd rejects `synthesize` with `model_not_loaded` until warmup completes, so the "transparent retry" failed for the real engine and the entry landed in `error` despite a successful recovery. The mock-based supervisor tests could not see this (the mock needs no model); found during live verification of #88.

- The supervisor slot now carries a per-generation readiness signal (watch channel fed by the warmup task); `with_retry` awaits it while `WarmingUp` before issuing an operation — covers retried, queued, and newly arriving requests alike.
- The wait is bounded (10 min) so a live-but-stuck model load cannot block requests forever; after the timeout the operation proceeds and surfaces ttsd's own error.
- Initial spawn keeps startup semantics (`Ready`, no waiting).
- Fixes the stale `spawn_warmup` comment: ttsd does not auto-load the model on synthesize.

## Spec

OpenSpec change archived as `2026-07-26-await-warmup-before-retry`; `ttsd-protocol` spec synced (auto-restart requirement: requests are sent to the fresh process only after the post-respawn warmup completes).

## Test plan

- `cargo test`: 854 lib + golden green (new unit tests: readiness wait, timeout give-up, failed-warmup passthrough)
- Supervisor integration 3/3 with new `mock_ttsd_warmup_gate.py` fixture: a request issued right after a kill succeeds without the client calling warmup explicitly
- `just lint` green; `openspec validate --specs --strict` 12/12

## Notes

- Pre-PR review: both medium findings fixed — the readiness wait is now bounded, and the wait-guard unit test was made deterministic (`tail -f /dev/null` instead of `cat`, which echoes and would have made the test a wall-clock race).

Closes #128