### PR TITLE
refactor: epic 2 follow-up refactorings

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -395,28 +395,28 @@ fn apply_ready_if_current(
     ts_filename: Option<String>,
     audio_filename: &str,
 ) -> bool {
-    let Some(mut entry) = storage.get_entry(entry_id) else {
-        // Vanished mid-synthesis (deleted) — drop the late files too.
+    // A late result whose entry vanished or left `processing` is dropped
+    // together with the files it just wrote.
+    let discard = |ts_filename: Option<String>| {
         discard_late_files(
             storage,
             [Some(audio_filename.to_string()), ts_filename]
                 .into_iter()
                 .flatten(),
         );
-        return false;
+        false
+    };
+
+    let Some(mut entry) = storage.get_entry(entry_id) else {
+        // Vanished mid-synthesis (deleted).
+        return discard(ts_filename);
     };
     if !completion_is_current(entry.status) {
         info!(
             "discarding stale completion for {entry_id} (status: {:?})",
             entry.status
         );
-        discard_late_files(
-            storage,
-            [Some(audio_filename.to_string()), ts_filename]
-                .into_iter()
-                .flatten(),
-        );
-        return false;
+        return discard(ts_filename);
     }
 
     entry.status = EntryStatus::Ready;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -100,34 +100,55 @@ fn char_mapping_to_entries(mapping: &CharMapping) -> Vec<CharMappingEntry> {
 
 // ── Background synthesis ───────────────────────────────────────────────────────
 
-/// Public alias used by the tray module to avoid duplicating the synthesis logic.
-#[allow(clippy::too_many_arguments)]
-pub fn spawn_synthesis_pub<R: Runtime + 'static>(
-    app: AppHandle<R>,
-    storage: Arc<StorageService>,
-    tts: Arc<dyn TtsEngine>,
-    piper_voices_dir: PathBuf,
-    emitter: crate::tts::supervisor::Emitter,
-    player: Arc<dyn crate::player::PlayerBackend>,
-    pipeline: Arc<parking_lot::Mutex<crate::pipeline::TTSPipeline>>,
-    synthesis_tasks: Arc<Mutex<HashMap<EntryId, AbortHandle>>>,
-    synthesize_entered: Arc<Mutex<HashSet<EntryId>>>,
-    entry_id: EntryId,
-    play_when_ready: bool,
-) {
-    spawn_synthesis(
-        app,
-        storage,
-        tts,
-        piper_voices_dir,
-        emitter,
-        player,
-        pipeline,
-        synthesis_tasks,
-        synthesize_entered,
-        entry_id,
-        play_when_ready,
-    );
+/// Everything [`spawn_synthesis`] needs, snapshotted in one shot so call
+/// sites stay one line. Built from the managed state via
+/// [`SynthesisDeps::from_state`] in commands; the tray handler (which runs
+/// before the state exists) fills the struct literal directly.
+pub struct SynthesisDeps<R: Runtime> {
+    pub app: AppHandle<R>,
+    pub storage: Arc<StorageService>,
+    pub tts: Arc<dyn TtsEngine>,
+    pub piper_voices_dir: PathBuf,
+    pub emitter: crate::tts::supervisor::Emitter,
+    pub player: Arc<dyn crate::player::PlayerBackend>,
+    pub pipeline: Arc<Mutex<TTSPipeline>>,
+    pub synthesis_tasks: Arc<Mutex<HashMap<EntryId, AbortHandle>>>,
+    pub synthesize_entered: Arc<Mutex<HashSet<EntryId>>>,
+}
+
+// Manual impl: `#[derive(Clone)]` would add an `R: Clone` bound, which
+// `Runtime` does not guarantee (every field is cheap-Clone regardless).
+impl<R: Runtime> Clone for SynthesisDeps<R> {
+    fn clone(&self) -> Self {
+        Self {
+            app: self.app.clone(),
+            storage: Arc::clone(&self.storage),
+            tts: Arc::clone(&self.tts),
+            piper_voices_dir: self.piper_voices_dir.clone(),
+            emitter: Arc::clone(&self.emitter),
+            player: Arc::clone(&self.player),
+            pipeline: Arc::clone(&self.pipeline),
+            synthesis_tasks: Arc::clone(&self.synthesis_tasks),
+            synthesize_entered: Arc::clone(&self.synthesize_entered),
+        }
+    }
+}
+
+impl<R: Runtime> SynthesisDeps<R> {
+    /// Snapshot the synthesis-relevant pieces of the managed app state.
+    pub fn from_state(app: &AppHandle<R>, state: &AppState) -> Self {
+        Self {
+            app: app.clone(),
+            storage: Arc::clone(&state.storage),
+            tts: Arc::clone(&state.tts),
+            piper_voices_dir: state.piper_voices_dir.clone(),
+            emitter: Arc::clone(&state.emitter),
+            player: Arc::clone(&state.player),
+            pipeline: Arc::clone(&state.pipeline),
+            synthesis_tasks: Arc::clone(&state.synthesis_tasks),
+            synthesize_entered: Arc::clone(&state.synthesize_entered),
+        }
+    }
 }
 
 /// Distinct failure points for a synthesis task. Each variant maps to the
@@ -447,20 +468,22 @@ fn autoplay(player: &dyn crate::player::PlayerBackend, audio_path: PathBuf, entr
 /// `cancel_synthesis` can abort it; a detached reaper removes the task's
 /// registry entry once it terminates, taking care not to remove a newer
 /// task's handle for the same entry.
-#[allow(clippy::too_many_arguments)]
-fn spawn_synthesis<R: Runtime + 'static>(
-    app: AppHandle<R>,
-    storage: Arc<StorageService>,
-    tts: Arc<dyn TtsEngine>,
-    piper_voices_dir: PathBuf,
-    emitter: crate::tts::supervisor::Emitter,
-    player: Arc<dyn crate::player::PlayerBackend>,
-    pipeline: Arc<Mutex<TTSPipeline>>,
-    synthesis_tasks: Arc<Mutex<HashMap<EntryId, AbortHandle>>>,
-    synthesize_entered: Arc<Mutex<HashSet<EntryId>>>,
+pub fn spawn_synthesis<R: Runtime + 'static>(
+    deps: SynthesisDeps<R>,
     entry_id: EntryId,
     play_when_ready: bool,
 ) {
+    let SynthesisDeps {
+        app,
+        storage,
+        tts,
+        piper_voices_dir,
+        emitter,
+        player,
+        pipeline,
+        synthesis_tasks,
+        synthesize_entered,
+    } = deps;
     let entered_for_task = Arc::clone(&synthesize_entered);
     let tasks_for_cleanup = Arc::clone(&synthesis_tasks);
     let entered_for_cleanup = Arc::clone(&synthesize_entered);
@@ -644,15 +667,7 @@ fn ingest_text<R: Runtime>(
     emit_entry_updated(&app, &entry);
 
     spawn_synthesis(
-        app,
-        Arc::clone(&state.storage),
-        Arc::clone(&state.tts),
-        state.piper_voices_dir.clone(),
-        Arc::clone(&state.emitter),
-        Arc::clone(&state.player),
-        Arc::clone(&state.pipeline),
-        Arc::clone(&state.synthesis_tasks),
-        Arc::clone(&state.synthesize_entered),
+        SynthesisDeps::from_state(&app, state),
         entry_id,
         play_when_ready,
     );
@@ -855,19 +870,7 @@ pub async fn regenerate_entry<R: Runtime>(
         .map_err(CommandError::from)?;
     emit_entry_updated(&app, &entry);
 
-    spawn_synthesis(
-        app,
-        Arc::clone(&state.storage),
-        Arc::clone(&state.tts),
-        state.piper_voices_dir.clone(),
-        Arc::clone(&state.emitter),
-        Arc::clone(&state.player),
-        Arc::clone(&state.pipeline),
-        Arc::clone(&state.synthesis_tasks),
-        Arc::clone(&state.synthesize_entered),
-        uuid,
-        false,
-    );
+    spawn_synthesis(SynthesisDeps::from_state(&app, &state), uuid, false);
 
     Ok(())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2022,44 +2022,6 @@ mod tests {
         }
     }
 
-    // ── set_speed / set_volume boundary contract ──────────────────────────────
-    //
-    // These tests predate the MockRuntime harness (`crate::test_support`):
-    // they pin down the *documented* contract read from the source
-    // (`set_speed`/`set_volume` in this file) — out-of-range values are
-    // rejected with `CommandError::ConfigError`, not silently clamped — via a
-    // local re-implementation of the range guard. Exercising the real commands
-    // through a managed `AppState` now belongs in `test_support`-based tests;
-    // if the range literals below ever disagree with the guard clauses in
-    // `set_speed`/`set_volume`, whoever edits them should notice.
-
-    /// Pins down current behavior: `set_speed` rejects (does not clamp)
-    /// speeds outside `[0.5, 2.0]`, per its `!(0.5..=2.0).contains(&speed)`
-    /// guard.
-    #[test]
-    fn set_speed_range_contract_is_inclusive_0_5_to_2_0() {
-        let in_range = |speed: f32| (0.5..=2.0).contains(&speed);
-        assert!(in_range(0.5), "lower bound is inclusive");
-        assert!(in_range(2.0), "upper bound is inclusive");
-        assert!(in_range(1.0));
-        assert!(!in_range(0.499_999));
-        assert!(!in_range(2.000_001));
-        assert!(!in_range(-1.0));
-    }
-
-    /// Pins down current behavior: `set_volume` rejects (does not clamp)
-    /// volumes outside `[0.0, 1.0]`, per its `!(0.0..=1.0).contains(&volume)`
-    /// guard.
-    #[test]
-    fn set_volume_range_contract_is_inclusive_0_0_to_1_0() {
-        let in_range = |volume: f32| (0.0..=1.0).contains(&volume);
-        assert!(in_range(0.0), "lower bound is inclusive");
-        assert!(in_range(1.0), "upper bound is inclusive");
-        assert!(in_range(0.5));
-        assert!(!in_range(-0.000_001));
-        assert!(!in_range(1.000_001));
-    }
-
     // ── preview_normalize ────────────────────────────────────────────────────
 
     /// The preview returns the normalized text together with a char mapping

--- a/src-tauri/src/commands/orchestration_tests.rs
+++ b/src-tauri/src/commands/orchestration_tests.rs
@@ -17,6 +17,42 @@ fn audio_dir(t: &TestApp) -> PathBuf {
     t.state().storage.cache_dir().join("audio")
 }
 
+/// Parse the id string returned by the commands into the storage UUID.
+fn entry_uuid(id: &str) -> uuid::Uuid {
+    id.parse().unwrap()
+}
+
+/// Paths of an entry's audio file and timestamps sidecar in the storage
+/// audio directory.
+fn audio_paths(t: &TestApp, uuid: &uuid::Uuid) -> (PathBuf, PathBuf) {
+    let dir = audio_dir(t);
+    (
+        dir.join(format!("{uuid}.wav")),
+        dir.join(format!("{uuid}.timestamps.json")),
+    )
+}
+
+/// Wait until the entry reaches `status` in storage.
+async fn wait_entry_status(t: &TestApp, uuid: &uuid::Uuid, status: EntryStatus) {
+    wait_until(&format!("entry status {status:?}"), TIMEOUT, || {
+        t.state()
+            .storage
+            .get_entry(uuid)
+            .is_some_and(|e| e.status == status)
+    })
+    .await;
+}
+
+/// Payload of the most recent `entry_updated` event in the log.
+fn last_entry_updated(log: &[(String, serde_json::Value)]) -> serde_json::Value {
+    log.iter()
+        .rev()
+        .find(|(n, _)| n == "entry_updated")
+        .unwrap_or_else(|| panic!("no entry_updated event in {log:?}"))
+        .1
+        .clone()
+}
+
 /// Add an entry through the real ingestion command and wait until the
 /// background synthesis (StubEngine) has marked it `ready`.
 async fn add_ready_entry(t: &TestApp) -> String {
@@ -28,14 +64,7 @@ async fn add_ready_entry(t: &TestApp) -> String {
     )
     .await
     .unwrap();
-    wait_until("entry ready", TIMEOUT, || {
-        let uuid: uuid::Uuid = id.parse().unwrap();
-        t.state()
-            .storage
-            .get_entry(&uuid)
-            .is_some_and(|e| e.status == EntryStatus::Ready)
-    })
-    .await;
+    wait_entry_status(t, &entry_uuid(&id), EntryStatus::Ready).await;
     id
 }
 
@@ -49,10 +78,8 @@ async fn add_ready_entry(t: &TestApp) -> String {
 async fn delete_entry_stops_playback_and_removes_entry_and_files() {
     let t = build_test_app();
     let id = add_ready_entry(&t).await;
-    let uuid: uuid::Uuid = id.parse().unwrap();
-    let dir = audio_dir(&t);
-    let audio_file = dir.join(format!("{uuid}.wav"));
-    let ts_file = dir.join(format!("{uuid}.timestamps.json"));
+    let uuid = entry_uuid(&id);
+    let (audio_file, ts_file) = audio_paths(&t, &uuid);
     assert!(audio_file.exists());
     assert!(ts_file.exists());
 
@@ -111,8 +138,8 @@ async fn delete_entry_of_other_entry_keeps_playback_running() {
 async fn regenerate_entry_replaces_audio_and_resynthesizes() {
     let t = build_test_app();
     let id = add_ready_entry(&t).await;
-    let uuid: uuid::Uuid = id.parse().unwrap();
-    let audio_file = audio_dir(&t).join(format!("{uuid}.wav"));
+    let uuid = entry_uuid(&id);
+    let (audio_file, _) = audio_paths(&t, &uuid);
     // Sentinel content: proves the new file was written from scratch,
     // not just left over from the first synthesis.
     std::fs::write(&audio_file, b"old-marker").unwrap();
@@ -122,13 +149,7 @@ async fn regenerate_entry_replaces_audio_and_resynthesizes() {
         .await
         .unwrap();
 
-    wait_until("entry ready again", TIMEOUT, || {
-        t.state()
-            .storage
-            .get_entry(&uuid)
-            .is_some_and(|e| e.status == EntryStatus::Ready)
-    })
-    .await;
+    wait_entry_status(&t, &uuid, EntryStatus::Ready).await;
 
     assert_eq!(
         std::fs::read(&audio_file).unwrap().as_slice(),
@@ -160,14 +181,8 @@ async fn regenerate_entry_rejects_processing_entry_and_synthesis_continues() {
     )
     .await
     .unwrap();
-    let uuid: uuid::Uuid = id.parse().unwrap();
-    wait_until("entry processing", TIMEOUT, || {
-        t.state()
-            .storage
-            .get_entry(&uuid)
-            .is_some_and(|e| e.status == EntryStatus::Processing)
-    })
-    .await;
+    let uuid = entry_uuid(&id);
+    wait_entry_status(&t, &uuid, EntryStatus::Processing).await;
 
     let err = regenerate_entry(t.app.handle().clone(), t.state(), id.clone())
         .await
@@ -181,13 +196,7 @@ async fn regenerate_entry_rejects_processing_entry_and_synthesis_continues() {
 
     // Releasing the gate lets the original synthesis finish normally.
     t.engine.release_synthesis();
-    wait_until("entry ready after gate release", TIMEOUT, || {
-        t.state()
-            .storage
-            .get_entry(&uuid)
-            .is_some_and(|e| e.status == EntryStatus::Ready)
-    })
-    .await;
+    wait_entry_status(&t, &uuid, EntryStatus::Ready).await;
 }
 
 // ── cancel_synthesis (new #129 semantics) ─────────────────────────────
@@ -204,7 +213,7 @@ async fn cancel_synthesis_aborts_in_flight_task_and_keeps_entry_pending() {
     let id = add_text_entry(t.app.handle().clone(), t.state(), "текст".to_string(), true)
         .await
         .unwrap();
-    let uuid: uuid::Uuid = id.parse().unwrap();
+    let uuid = entry_uuid(&id);
     // Deterministic "inside the TTS stage": the marker is set right
     // before the (blocked) engine await.
     wait_until("entry entered TTS stage", TIMEOUT, || {
@@ -224,11 +233,7 @@ async fn cancel_synthesis_aborts_in_flight_task_and_keeps_entry_pending() {
     // The last entry_updated is the reset to pending.
     {
         let log = events.lock().unwrap();
-        let (_, payload) = log
-            .iter()
-            .rev()
-            .find(|(n, _)| n == "entry_updated")
-            .unwrap();
+        let payload = last_entry_updated(&log);
         assert_eq!(payload["entry"]["id"], id);
         assert_eq!(payload["entry"]["status"], "pending");
     }
@@ -290,7 +295,7 @@ async fn play_entry_loads_audio_and_starts_playback() {
 
     play_entry(t.state(), id.clone()).await.unwrap();
 
-    let expected_path = audio_dir(&t).join(format!("{id}.wav"));
+    let (expected_path, _) = audio_paths(&t, &entry_uuid(&id));
     let calls = t.player.calls();
     assert_eq!(calls.len(), 2);
     match &calls[0] {
@@ -345,10 +350,8 @@ async fn update_config_failed_engine_switch_preserves_previous_config() {
 async fn delete_audio_resets_entry_and_emits_entry_updated() {
     let t = build_test_app();
     let id = add_ready_entry(&t).await;
-    let uuid: uuid::Uuid = id.parse().unwrap();
-    let dir = audio_dir(&t);
-    let audio_file = dir.join(format!("{uuid}.wav"));
-    let ts_file = dir.join(format!("{uuid}.timestamps.json"));
+    let uuid = entry_uuid(&id);
+    let (audio_file, ts_file) = audio_paths(&t, &uuid);
 
     let events = record_events(&t.app, &["entry_updated"]);
     delete_audio(t.app.handle().clone(), t.state(), id.clone())
@@ -364,8 +367,7 @@ async fn delete_audio_resets_entry_and_emits_entry_updated() {
     assert!(!ts_file.exists());
 
     let log = events.lock().unwrap();
-    let (name, payload) = log.last().unwrap();
-    assert_eq!(name, "entry_updated");
+    let payload = last_entry_updated(&log);
     assert_eq!(payload["entry"]["id"], id);
     assert_eq!(payload["entry"]["status"], "pending");
     assert!(payload["entry"]["audio_path"].is_null());
@@ -388,7 +390,7 @@ async fn tts_failure_emits_entry_updated_error_then_tts_error() {
     )
     .await
     .unwrap();
-    let uuid: uuid::Uuid = id.parse().unwrap();
+    let uuid = entry_uuid(&id);
     // Wait on the event, not the storage status: the status flips to
     // `error` *before* the events are emitted, so polling the status
     // would race the emits. `tts_error` is emitted last, so once it is

--- a/src-tauri/src/commands/orchestration_tests.rs
+++ b/src-tauri/src/commands/orchestration_tests.rs
@@ -458,3 +458,91 @@ async fn preview_normalize_returns_text_without_history_or_audio_side_effects() 
     assert_eq!(std::fs::read_dir(audio_dir(&t)).unwrap().count(), 0);
     assert!(t.state().synthesis_tasks.lock().is_empty());
 }
+
+// ── set_speed / set_volume range guards ──────────────────────────────
+
+/// The real `set_speed` command accepts the documented inclusive range
+/// [0.5, 2.0], forwards each value to the player, and persists the last
+/// one to `speech_rate`.
+#[tokio::test(flavor = "multi_thread")]
+async fn set_speed_accepts_inclusive_bounds_and_persists() {
+    let t = build_test_app();
+
+    for speed in [0.5_f32, 1.0, 2.0] {
+        set_speed(t.state(), speed).await.unwrap();
+    }
+
+    let speeds: Vec<f32> = t
+        .player
+        .calls()
+        .iter()
+        .filter_map(|c| match c {
+            PlayerCall::SetSpeed(s) => Some(*s),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(speeds, vec![0.5, 1.0, 2.0]);
+    assert_eq!(t.state().storage.load_config().unwrap().speech_rate, 2.0);
+}
+
+/// Speeds outside [0.5, 2.0] are rejected with `config_error` (not
+/// clamped) and never reach the player.
+#[tokio::test(flavor = "multi_thread")]
+async fn set_speed_rejects_out_of_range() {
+    let t = build_test_app();
+
+    for speed in [0.499_999_f32, 2.000_001, -1.0] {
+        let err = set_speed(t.state(), speed).await.unwrap_err();
+        assert!(
+            matches!(err, CommandError::ConfigError { .. }),
+            "speed {speed} must be rejected with config_error, got {err:?}"
+        );
+    }
+    assert!(t
+        .player
+        .calls()
+        .iter()
+        .all(|c| !matches!(c, PlayerCall::SetSpeed(_))));
+}
+
+/// The real `set_volume` command accepts the documented inclusive range
+/// [0.0, 1.0] and forwards each value to the player.
+#[tokio::test(flavor = "multi_thread")]
+async fn set_volume_accepts_inclusive_bounds() {
+    let t = build_test_app();
+
+    for volume in [0.0_f32, 0.5, 1.0] {
+        set_volume(t.state(), volume).await.unwrap();
+    }
+
+    let volumes: Vec<f32> = t
+        .player
+        .calls()
+        .iter()
+        .filter_map(|c| match c {
+            PlayerCall::SetVolume(v) => Some(*v),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(volumes, vec![0.0, 0.5, 1.0]);
+}
+
+/// Volumes outside [0.0, 1.0] are rejected with `config_error` (not
+/// clamped) and never reach the player.
+#[tokio::test(flavor = "multi_thread")]
+async fn set_volume_rejects_out_of_range() {
+    let t = build_test_app();
+
+    for volume in [-0.000_001_f32, 1.000_001, -1.0] {
+        let err = set_volume(t.state(), volume).await.unwrap_err();
+        assert!(
+            matches!(err, CommandError::ConfigError { .. }),
+            "volume {volume} must be rejected with config_error, got {err:?}"
+        );
+    }
+    assert!(t
+        .player
+        .calls()
+        .iter()
+        .all(|c| !matches!(c, PlayerCall::SetVolume(_))));
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -301,6 +301,17 @@ fn spawn_tray_handler<R: Runtime + 'static>(
     let (tray_tx, mut tray_rx) = tokio::sync::mpsc::channel::<TrayCmd>(16);
 
     tauri::async_runtime::spawn(async move {
+        let deps = SynthesisDeps {
+            app: app.clone(),
+            storage: Arc::clone(&storage),
+            tts: Arc::clone(&tts),
+            piper_voices_dir,
+            emitter,
+            player,
+            pipeline,
+            synthesis_tasks,
+            synthesize_entered,
+        };
         while let Some(cmd) = tray_rx.recv().await {
             // Read clipboard on a blocking thread (required on Linux).
             let text_result = tokio::task::spawn_blocking(|| {
@@ -336,19 +347,7 @@ fn spawn_tray_handler<R: Runtime + 'static>(
             let entry_id = entry.id;
             let _ = app.emit("entry_updated", json!({ "entry": entry }));
 
-            spawn_synthesis_pub(
-                app.clone(),
-                Arc::clone(&storage),
-                Arc::clone(&tts),
-                piper_voices_dir.clone(),
-                Arc::clone(&emitter),
-                Arc::clone(&player),
-                Arc::clone(&pipeline),
-                Arc::clone(&synthesis_tasks),
-                Arc::clone(&synthesize_entered),
-                entry_id,
-                cmd.play_when_ready,
-            );
+            spawn_synthesis(deps.clone(), entry_id, cmd.play_when_ready);
         }
     });
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -220,32 +220,28 @@ fn build_engine<R: Runtime>(
     let want_silero = config.engine == "silero";
     let silero_available = want_silero && tts::availability::probe(&ttsd_dir).silero.available;
 
-    let (initial_engine, initial_kind, initial_voice, initial_silero) = if silero_available {
+    let (initial_engine, initial_kind, initial_voice) = if silero_available {
         match try_build_silero(&ttsd_dir, Arc::clone(&emitter)) {
             Ok(sup) => {
-                let engine: Arc<dyn tts::TtsEngine> = sup.clone();
-                (engine, tts::EngineKind::Silero, None, Some(sup))
+                let engine: Arc<dyn tts::TtsEngine> = sup;
+                (engine, tts::EngineKind::Silero, None)
             }
             Err(e) => {
                 tracing::warn!("Silero probe passed but spawn failed ({e}); falling back to Piper");
-                let (engine, kind, voice) =
-                    build_piper_initial(&voices_dir, &config.piper_voice, &emitter);
-                (engine, kind, voice, None)
+                build_piper_initial(&voices_dir, &config.piper_voice, &emitter)
             }
         }
     } else {
         if want_silero {
             tracing::info!("Silero requested in config but unavailable; serving Piper this run");
         }
-        let (engine, kind, voice) = build_piper_initial(&voices_dir, &config.piper_voice, &emitter);
-        (engine, kind, voice, None)
+        build_piper_initial(&voices_dir, &config.piper_voice, &emitter)
     };
 
     let switcher = Arc::new(tts::EngineSwitcher::new(
         initial_engine,
         initial_kind,
         initial_voice,
-        initial_silero,
         voices_dir.clone(),
         ttsd_dir.clone(),
         Arc::clone(&emitter),

--- a/src-tauri/src/player/mod.rs
+++ b/src-tauri/src/player/mod.rs
@@ -430,10 +430,26 @@ impl<R: Runtime> Drop for Player<R> {
 /// [`Player`] is the production implementation (mpv subprocess, generic over
 /// the Tauri runtime). Tests substitute a fake that records calls and scripts
 /// positions, so playback commands and the position-emitter loop can run
-/// without mpv, a window, or a display. Methods mirror [`Player`]'s public
-/// API one-to-one; behavior contracts are documented on the corresponding
-/// [`Player`] methods.
+/// without mpv, a window, or a display. Behavior contracts are documented on
+/// the corresponding [`Player`] methods.
+///
+/// The methods fall into three groups:
+///
+/// - **Playback control** (`load` … `set_volume`) — the command layer's
+///   surface (`play_entry`, `pause_playback`, `seek_to`, …), plus the mpv
+///   lifecycle hooks the tray and the exit handler use.
+/// - **State queries** (`position_sec` … `is_playing`) — read by commands
+///   (which entry is loaded) and polled by the position emitter.
+/// - **Position-emitter internals** (`clear_is_playing`,
+///   `seek_suppression_active`) — exist only because the emitter loop is
+///   generic over this trait; commands never call them. Splitting them into
+///   a second trait was considered and rejected: the emitter shares the
+///   query methods with the command layer, so a second trait would
+///   duplicate those methods and force dual-`Arc` plumbing through
+///   `AppState` without actually narrowing either surface.
 pub trait PlayerBackend: Send + Sync {
+    // ── Playback control (commands, tray, exit handler) ─────────────
+
     /// See [`Player::load`].
     fn load(&self, path: &Path, entry_id: String) -> Result<()>;
     /// See [`Player::play`].
@@ -450,6 +466,9 @@ pub trait PlayerBackend: Send + Sync {
     fn set_speed(&self, speed: f32) -> Result<()>;
     /// See [`Player::set_volume`].
     fn set_volume(&self, volume: f32) -> Result<()>;
+
+    // ── State queries (commands + position emitter) ─────────────────
+
     /// See [`Player::position_sec`].
     fn position_sec(&self) -> Option<f64>;
     /// See [`Player::duration_sec`].
@@ -462,6 +481,8 @@ pub trait PlayerBackend: Send + Sync {
     fn ensure_mpv_alive(&self) -> Result<()>;
     /// See [`Player::mark_destroyed`].
     fn mark_destroyed(&self);
+
+    // ── Position-emitter internals (never called by commands) ───────
 
     /// Flip the internal playing flag off without emitting any event.  Used
     /// by the position emitter's EOF path, which emits `playback_finished` /

--- a/src-tauri/src/test_support.rs
+++ b/src-tauri/src/test_support.rs
@@ -24,7 +24,7 @@ use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use parking_lot::Mutex as ParkingMutex;
@@ -40,6 +40,11 @@ use crate::storage::service::StorageService;
 use crate::tts::engine::EngineKind;
 use crate::tts::supervisor::test_helpers::recording_emitter;
 use crate::tts::{CharMappingEntry, EngineSwitcher, SynthesizeOutput, TtsEngine, TtsError};
+
+// The polling helper lives in `tts::supervisor::test_helpers`, shared with
+// the integration tests under `tests/`; re-exported so command tests import
+// the whole harness from one place.
+pub use crate::tts::supervisor::test_helpers::wait_until;
 
 // ---------------------------------------------------------------------------
 // StubEngine
@@ -381,32 +386,6 @@ pub fn build_test_app() -> TestApp {
         _storage_dir: storage_dir,
         _voices_dir: voices_dir,
         _ttsd_dir: ttsd_dir,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Async waiting
-// ---------------------------------------------------------------------------
-
-/// Poll `predicate` (every 10 ms) until it holds or `timeout` elapses.
-///
-/// Background synthesis runs via `tokio::spawn`, so a command returning
-/// `Ok` does *not* mean the side effects (entry status flip, events) have
-/// landed yet — tests must await them. Panics naming `what` on timeout.
-pub async fn wait_until<F>(what: &str, timeout: Duration, mut predicate: F)
-where
-    F: FnMut() -> bool,
-{
-    let start = Instant::now();
-    loop {
-        if predicate() {
-            return;
-        }
-        assert!(
-            start.elapsed() < timeout,
-            "timed out after {timeout:?} waiting for {what}"
-        );
-        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }
 

--- a/src-tauri/src/test_support.rs
+++ b/src-tauri/src/test_support.rs
@@ -20,11 +20,6 @@
 //! 2. go through the IPC router with [`tauri::test::get_ipc_response`], which
 //!    additionally pins command-name routing and the JSON wire contract.
 
-// Some helpers are consumed only by the command-orchestration tests in
-// `commands::orchestration_tests` and the proof tests at the bottom; keep the
-// allowance so harness additions for future test issues compile unused.
-#![allow(dead_code)]
-
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -140,28 +135,27 @@ impl TtsEngine for StubEngine {
 // ---------------------------------------------------------------------------
 
 /// A playback-control call received by [`FakePlayer`], in receive order.
-/// Floats are stored raw; compare with epsilon where it matters.
+/// Only the calls tests assert on are recorded; `pause`/`resume`,
+/// `ensure_mpv_alive` and `mark_destroyed` update the tracked flags but
+/// leave no trace here. Floats are stored raw; compare with epsilon where
+/// it matters.
 #[derive(Debug, Clone)]
 pub enum PlayerCall {
     Load(PathBuf, String),
     Play,
-    Pause,
-    Resume,
     Stop,
     Seek(f64),
     SetSpeed(f32),
     SetVolume(f32),
-    EnsureMpvAlive,
-    MarkDestroyed,
 }
 
 /// Test double for [`PlayerBackend`].
 ///
-/// Records every control call into [`FakePlayer::calls`] and tracks the
-/// playing/loaded flags the way the real `Player` does. Unlike the real
-/// player it emits **no** Tauri events (`playback_started` etc.) — it holds
-/// no `AppHandle`; tests assert on recorded calls and on the position
-/// emitter's own output instead.
+/// Records the control calls tests assert on into [`FakePlayer::calls`] and
+/// tracks the playing/loaded flags the way the real `Player` does. Unlike
+/// the real player it emits **no** Tauri events (`playback_started` etc.) —
+/// it holds no `AppHandle`; tests assert on recorded calls and on the
+/// position emitter's own output instead.
 ///
 /// `position_sec()` answers from a scripted queue (see
 /// [`FakePlayer::script_positions`]); once the script is exhausted it returns
@@ -223,16 +217,12 @@ impl PlayerBackend for FakePlayer {
     }
 
     fn pause(&self) -> PlayerResult<()> {
-        let mut inner = self.inner.lock();
-        inner.calls.push(PlayerCall::Pause);
-        inner.is_playing = false;
+        self.inner.lock().is_playing = false;
         Ok(())
     }
 
     fn resume(&self) -> PlayerResult<()> {
-        let mut inner = self.inner.lock();
-        inner.calls.push(PlayerCall::Resume);
-        inner.is_playing = true;
+        self.inner.lock().is_playing = true;
         Ok(())
     }
 
@@ -275,12 +265,10 @@ impl PlayerBackend for FakePlayer {
     }
 
     fn ensure_mpv_alive(&self) -> PlayerResult<()> {
-        self.inner.lock().calls.push(PlayerCall::EnsureMpvAlive);
         Ok(())
     }
 
     fn mark_destroyed(&self) {
-        self.inner.lock().calls.push(PlayerCall::MarkDestroyed);
         self.destroyed.store(true, Ordering::SeqCst);
     }
 
@@ -331,8 +319,6 @@ pub struct TestApp {
     /// The stub TTS engine behind the switcher — steer `synthesize` via its
     /// knobs (`fail_with`, `block_synthesis`).
     pub engine: Arc<StubEngine>,
-    /// Events emitted through the state's `emitter` (engine layer).
-    pub engine_events: EventLog,
     _storage_dir: TempDir,
     _voices_dir: TempDir,
     _ttsd_dir: TempDir,
@@ -359,7 +345,7 @@ pub fn build_test_app() -> TestApp {
     let voices_dir = TempDir::new().expect("voices tempdir");
     let ttsd_dir = TempDir::new().expect("ttsd tempdir");
 
-    let (emitter, engine_events) = recording_emitter();
+    let (emitter, _engine_events) = recording_emitter();
 
     let engine = Arc::new(StubEngine::new());
     let stub: Arc<dyn TtsEngine> = engine.clone();
@@ -392,7 +378,6 @@ pub fn build_test_app() -> TestApp {
         app,
         player,
         engine,
-        engine_events,
         _storage_dir: storage_dir,
         _voices_dir: voices_dir,
         _ttsd_dir: ttsd_dir,

--- a/src-tauri/src/test_support.rs
+++ b/src-tauri/src/test_support.rs
@@ -367,9 +367,6 @@ pub fn build_test_app() -> TestApp {
         Arc::clone(&stub),
         EngineKind::Piper,
         Some("stub-voice".to_string()),
-        // No Silero supervisor in tests: `kill_current_ttsd` degrades to a
-        // no-op, which is all the harness needs.
-        None,
         voices_dir.path().to_path_buf(),
         ttsd_dir.path().to_path_buf(),
         Arc::clone(&emitter),

--- a/src-tauri/src/tts/engine.rs
+++ b/src-tauri/src/tts/engine.rs
@@ -70,6 +70,12 @@ pub trait TtsEngine: Send + Sync {
         char_mapping: Option<Vec<CharMappingEntry>>,
     ) -> Result<SynthesizeOutput, TtsError>;
 
+    /// Forcibly terminate the engine's current in-flight work (for Silero,
+    /// the ttsd subprocess). Default is a no-op: engines with no external
+    /// subprocess (Piper, test stubs) have nothing to kill. Called by
+    /// `cancel_synthesis` when the cancelled entry had entered the TTS stage.
+    async fn kill_current(&self) {}
+
     /// Graceful shutdown. After this call the engine should release model
     /// memory / subprocess handles and refuse subsequent requests.
     async fn shutdown(&self) -> Result<(), TtsError>;

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -378,6 +378,13 @@ impl TtsEngine for TtsSupervisor {
         .await
     }
 
+    /// Forward to the inherent [`TtsSupervisor::kill_current`] so callers
+    /// behind `Arc<dyn TtsEngine>` (e.g. `EngineSwitcher`) can reach it
+    /// without storing the concrete supervisor alongside the trait object.
+    async fn kill_current(&self) {
+        TtsSupervisor::kill_current(self).await;
+    }
+
     /// Graceful shutdown. Does *not* respawn on Died — at this point we are
     /// tearing down anyway.
     async fn shutdown(&self) -> Result<(), TtsError> {

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -396,13 +396,15 @@ impl TtsEngine for TtsSupervisor {
     }
 }
 
-/// Helpers shared between unit tests in this module and integration tests
-/// in `tests/supervisor.rs`. Gated on `cfg(test)` (always available to unit
-/// tests in this crate) and `feature = "test-helpers"` (so integration test
-/// crates can opt in without leaking helpers into release builds).
+/// Helpers shared between unit tests in this crate (`test_support`, module
+/// tests) and integration tests in `tests/`. Gated on `cfg(test)` (always
+/// available to unit tests in this crate) and `feature = "test-helpers"`
+/// (so integration test crates can opt in without leaking helpers into
+/// release builds).
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers {
     use super::*;
+    use std::time::{Duration, Instant};
 
     pub type EventLog = Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>;
 
@@ -414,6 +416,29 @@ pub mod test_helpers {
             log_clone.lock().unwrap().push((name.to_string(), payload));
         });
         (emitter, log)
+    }
+
+    /// Poll `predicate` (every 10 ms) until it holds or `timeout` elapses.
+    ///
+    /// Async side effects (spawned synthesis, background respawn warmup)
+    /// land after the triggering call returns, so a successful return does
+    /// *not* mean they have happened yet — tests must await them. Panics
+    /// naming `what` on timeout.
+    pub async fn wait_until<F>(what: &str, timeout: Duration, mut predicate: F)
+    where
+        F: FnMut() -> bool,
+    {
+        let start = Instant::now();
+        loop {
+            if predicate() {
+                return;
+            }
+            assert!(
+                start.elapsed() < timeout,
+                "timed out after {timeout:?} waiting for {what}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 }
 

--- a/src-tauri/src/tts/switcher.rs
+++ b/src-tauri/src/tts/switcher.rs
@@ -37,10 +37,6 @@ struct Slot {
     /// Currently-loaded Piper voice id, when the active engine is Piper.
     /// Used to decide whether a `piper_voice` change requires a rebuild.
     piper_voice: Option<String>,
-    /// Concrete supervisor while the active engine is Silero. Reaches
-    /// [`TtsSupervisor::kill_current`] through the `Arc<dyn TtsEngine>`
-    /// type erasure for `cancel_synthesis`. `None` while Piper is active.
-    silero: Option<Arc<TtsSupervisor>>,
 }
 
 const KIND_PIPER: u8 = 0;
@@ -64,14 +60,11 @@ impl EngineSwitcher {
     /// Construct a switcher around an already-built initial engine. The
     /// caller must pass `initial_kind` matching the engine's `kind()` and,
     /// when the engine is Piper, the voice id its `default_voice` was
-    /// constructed with. When the initial engine is Silero,
-    /// `initial_silero` must carry the same supervisor behind `initial` so
-    /// [`EngineSwitcher::kill_current_ttsd`] can reach it.
+    /// constructed with.
     pub fn new(
         initial: Arc<dyn TtsEngine>,
         initial_kind: EngineKind,
         initial_piper_voice: Option<String>,
-        initial_silero: Option<Arc<TtsSupervisor>>,
         piper_voices_dir: PathBuf,
         ttsd_dir: PathBuf,
         emitter: Emitter,
@@ -80,7 +73,6 @@ impl EngineSwitcher {
             inner: RwLock::new(Slot {
                 engine: initial,
                 piper_voice: initial_piper_voice,
-                silero: initial_silero,
             }),
             kind: AtomicU8::new(kind_to_u8(initial_kind)),
             piper_voices_dir,
@@ -113,27 +105,18 @@ impl EngineSwitcher {
             return Ok(());
         }
 
-        let (new_engine, new_voice, new_silero) = match target_kind {
-            EngineKind::Piper => {
-                let engine = self.build_piper(target_piper_voice.to_string());
-                (
-                    engine as Arc<dyn TtsEngine>,
-                    Some(target_piper_voice.to_string()),
-                    None,
-                )
-            }
-            EngineKind::Silero => {
-                let supervisor = self.build_silero()?;
-                let engine: Arc<dyn TtsEngine> = supervisor.clone();
-                (engine, None, Some(supervisor))
-            }
+        let (new_engine, new_voice): (Arc<dyn TtsEngine>, Option<String>) = match target_kind {
+            EngineKind::Piper => (
+                self.build_piper(target_piper_voice.to_string()),
+                Some(target_piper_voice.to_string()),
+            ),
+            EngineKind::Silero => (self.build_silero()?, None),
         };
 
         {
             let mut slot = self.inner.write().await;
             slot.engine = Arc::clone(&new_engine);
             slot.piper_voice = new_voice;
-            slot.silero = new_silero;
         }
         self.kind.store(kind_to_u8(target_kind), Ordering::SeqCst);
 
@@ -167,13 +150,12 @@ impl EngineSwitcher {
 
     /// Terminate the current ttsd subprocess when Silero is the active
     /// engine; no-op for Piper (in-process synthesis has no subprocess to
-    /// kill). See [`TtsSupervisor::kill_current`]. Called by
-    /// `cancel_synthesis` when the cancelled entry had entered the TTS stage.
+    /// kill). Reaches [`TtsSupervisor::kill_current`] through the
+    /// [`TtsEngine`] trait, so no concrete supervisor handle is stored here.
+    /// Called by `cancel_synthesis` when the cancelled entry had entered the
+    /// TTS stage.
     pub async fn kill_current_ttsd(&self) {
-        let silero = self.inner.read().await.silero.clone();
-        if let Some(supervisor) = silero {
-            supervisor.kill_current().await;
-        }
+        self.current_engine().await.kill_current().await;
     }
 }
 
@@ -219,6 +201,10 @@ impl TtsEngine for EngineSwitcher {
     async fn shutdown(&self) -> Result<(), TtsError> {
         self.current_engine().await.shutdown().await
     }
+
+    async fn kill_current(&self) {
+        self.current_engine().await.kill_current().await;
+    }
 }
 
 #[cfg(test)]
@@ -245,7 +231,6 @@ mod tests {
             initial,
             EngineKind::Piper,
             Some("ruslan".to_string()),
-            None,
             voices_dir,
             ttsd_dir,
             emitter,

--- a/src-tauri/tests/supervisor.rs
+++ b/src-tauri/tests/supervisor.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ruvox_tauri_lib::tts::supervisor::test_helpers::recording_emitter;
+use ruvox_tauri_lib::tts::supervisor::test_helpers::{recording_emitter, wait_until};
 use ruvox_tauri_lib::tts::supervisor::{CommandFactory, TtsSupervisor};
 // Bring the trait into scope so `sup.synthesize(...)` resolves to its
 // `TtsEngine` impl methods.
@@ -137,20 +137,12 @@ async fn respawn_reemits_model_lifecycle_events() {
     // The post-respawn warmup runs in a background task; poll the event log
     // until the lifecycle completes (the mock answers warmup instantly, so
     // this converges fast even on slow CI).
-    let wait_for_loaded = async {
-        loop {
-            {
-                let log = log.lock().unwrap();
-                if log.iter().any(|(n, _)| n == "model_loaded") {
-                    break;
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(10), wait_for_loaded)
-        .await
-        .expect("model_loaded was not re-emitted after respawn");
+    wait_until(
+        "model_loaded re-emitted after respawn",
+        Duration::from_secs(10),
+        || log.lock().unwrap().iter().any(|(n, _)| n == "model_loaded"),
+    )
+    .await;
 
     let log = log.lock().unwrap();
     let names: Vec<&str> = log.iter().map(|(n, _)| n.as_str()).collect();
@@ -234,14 +226,12 @@ async fn kill_current_terminates_in_flight_request_and_respawns() {
     // signal (unlike a fixed sleep, which is flaky on slow CI — killing
     // before the marker exists would make the respawned process "first"
     // again and it would sleep another 30 s).
-    let wait_for_marker = async {
-        while !marker.exists() {
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(10), wait_for_marker)
-        .await
-        .expect("mock never entered its sleep (marker file did not appear)");
+    wait_until(
+        "mock to enter its sleep (marker file)",
+        Duration::from_secs(10),
+        || marker.exists(),
+    )
+    .await;
 
     sup.kill_current().await;
 


### PR DESCRIPTION
Follow-up refactorings from the final epic-2 refactor review (#108). Each refactoring is a separate commit; behavior is unchanged.

- `refactor(tts): move kill_current into TtsEngine trait` — removes the duplicated supervisor storage (`Slot.silero` mirroring `Slot.engine`) and the manual invariant in `EngineSwitcher::new`
- `refactor(commands): introduce SynthesisDeps for spawn_synthesis` — collapses the 11-parameter function + forwarding wrapper into a context struct; drops both `too_many_arguments` allows
- `test(commands): replace boundary contract stubs with real command tests` — set_speed/set_volume bounds now tested through the real commands + harness instead of a local copy of the range guard
- `refactor(commands): dedupe discard_late_files in apply_ready_if_current`
- `test(commands): remove blanket dead_code allow and dead API from test harness` — drops unused `engine_events` and unmatched `PlayerCall` variants
- `test(commands): extract orchestration test setup helpers` — entry_uuid, audio_paths, wait_entry_status, last_entry_updated
- `refactor(player): document PlayerBackend method groups` — conservative outcome: all 16 methods have live callers, so the trait is documented (control / queries / emitter internals) instead of split
- `test(tts): share polling helper between test_support and integration tests` — `wait_until` moved to `tts::supervisor::test_helpers`, manual poll loops removed

Gates: `just test`, `just lint`, `cargo test --all-features` all green.
