### PR TITLE
fix(ui): compute word-highlight offsets in codepoints, not UTF-16 units

### DIFF
--- a/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/proposal.md
+++ b/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: Codepoint-based highlight offsets (#77)
+
+## Summary
+
+The frontend rendered `data-orig-start` / `data-orig-end` span attributes in
+UTF-16 code units, while the Rust pipeline's `char_map` (and therefore
+`WordTimestamp.original_pos`) is defined in Unicode codepoints
+(position-mapping spec, pinned in #52). For BMP-only text the two coincide;
+after any astral character (emoji, mathematical alphanumerics) every span
+offset drifts by +1 per astral char and word highlighting matches the wrong
+span (or none) for the rest of the document.
+
+Bring the frontend offset chain in line with the codepoint contract:
+`wrapWordsWithOrigPos` (`src/lib/wordSpans.ts`) tracks a codepoint cursor,
+and both callers (`plainToWordHtml` in `src/lib/plainTextHtml.ts`,
+`renderMarkdown` in `src/lib/markdown.ts`) pass codepoint-based start
+offsets.
+
+## Capabilities
+
+- `word-highlight` (modified)
+
+## Non-goals
+
+- No changes to the Rust side — its codepoint contract is unchanged and
+  already correct.
+- No changes to span-matching logic (`findSpanByOrigPos` exact-match /
+  containment fallback) — with correct offsets it works as designed.
+- No rendering/visual changes for BMP-only documents (behavior identical).
+
+## Approach
+
+Minimal, mechanical: a codepoint cursor next to the UTF-16 index in
+`wrapWordsWithOrigPos`; `Array.from(...).length` for line/token lengths in
+the two callers (markdown keeps its UTF-16 `indexOf` cursor for search
+mechanics and maintains a parallel codepoint cursor). Vitest coverage with
+astral characters for all three modules.

--- a/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/specs/word-highlight/spec.md
+++ b/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/specs/word-highlight/spec.md
@@ -1,0 +1,32 @@
+# Delta: word-highlight
+
+## MODIFIED Requirements
+
+### Requirement: Highlight application and styling
+
+The system SHALL locate the rendered span whose `data-orig-start` /
+`data-orig-end` range matches the active timestamp's `original_pos`
+(preferring an exact match, falling back to the smallest containing span)
+and add the `word-highlight` CSS class to it, removing the class from the
+previously highlighted span. The `data-orig-start` / `data-orig-end`
+attributes SHALL be expressed in Unicode codepoints, matching the
+codepoint-based `char_map` contract of the position-mapping spec — an
+astral-plane character (occupying two UTF-16 code units) SHALL advance the
+offsets by exactly 1. The highlight background SHALL be
+`rgba(255, 213, 0, 0.45)` in light mode and `rgba(255, 213, 0, 0.3)` in dark
+mode (via the `--ruvox-highlight-bg` token), with an 80 ms transition.
+
+#### Scenario: Highlight moves to the next word
+
+- GIVEN word N is highlighted
+- WHEN playback advances into word N+1
+- THEN the `word-highlight` class moves from word N's span to word N+1's
+  span
+
+#### Scenario: Offsets after an astral character
+
+- GIVEN the source text "Привет 🌍 мир" rendered for the viewer
+- WHEN the span attributes are computed
+- THEN the span for "🌍" carries `data-orig-start` / `data-orig-end` = 7 / 8
+  and the span for "мир" carries 9 / 12 (codepoints), so a timestamp whose
+  `original_pos` points at "мир" matches it exactly

--- a/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/tasks.md
+++ b/openspec/changes/archive/2026-07-26-codepoint-highlight-offsets/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Codepoint-based highlight offsets
+
+## Implementation
+
+- [x] `src/lib/wordSpans.ts`: `wrapWordsWithOrigPos` tracks a codepoint
+  cursor next to the UTF-16 index; data-orig-* emitted in codepoints.
+- [x] `src/lib/plainTextHtml.ts`: per-line offset accumulation in
+  codepoints.
+- [x] `src/lib/markdown.ts`: parallel codepoint cursor next to the UTF-16
+  `indexOf` cursor; codepoint start offset passed to
+  `wrapWordsWithOrigPos`.
+
+## Tests
+
+- [x] `wordSpans.test.ts`: astral case asserts codepoint offsets (replaces
+  the test that pinned the old UTF-16 behavior).
+- [x] `plainTextHtml.test.ts`: astral character before a newline — second
+  line offset in codepoints.
+- [x] `markdown.test.ts` (new): astral before a word; repeated fragments
+  after an astral char get distinct codepoint positions.
+
+## Validation
+
+- [x] `nix develop -c pnpm test:unit` — 69/69 green.
+- [x] `nix develop -c pnpm typecheck` + `nix develop -c pnpm lint` green.
+- [x] `nix develop -c pnpm dlx @fission-ai/openspec@1.6.0 validate
+  codepoint-highlight-offsets --strict` green.

--- a/openspec/specs/word-highlight/spec.md
+++ b/openspec/specs/word-highlight/spec.md
@@ -7,9 +7,7 @@ playback: loading word timestamps, mapping playback positions to the active
 word, applying and clearing the highlight, auto-scrolling, and the lifecycle
 of the highlight across pause, stop, entry switches, and display-mode
 switches.
-
 ## Requirements
-
 ### Requirement: Timestamp loading
 
 When playback of an entry starts, the system SHALL load that entry's
@@ -53,7 +51,11 @@ The system SHALL locate the rendered span whose `data-orig-start` /
 `data-orig-end` range matches the active timestamp's `original_pos`
 (preferring an exact match, falling back to the smallest containing span)
 and add the `word-highlight` CSS class to it, removing the class from the
-previously highlighted span. The highlight background SHALL be
+previously highlighted span. The `data-orig-start` / `data-orig-end`
+attributes SHALL be expressed in Unicode codepoints, matching the
+codepoint-based `char_map` contract of the position-mapping spec — an
+astral-plane character (occupying two UTF-16 code units) SHALL advance the
+offsets by exactly 1. The highlight background SHALL be
 `rgba(255, 213, 0, 0.45)` in light mode and `rgba(255, 213, 0, 0.3)` in dark
 mode (via the `--ruvox-highlight-bg` token), with an 80 ms transition.
 
@@ -63,6 +65,14 @@ mode (via the `--ruvox-highlight-bg` token), with an 80 ms transition.
 - WHEN playback advances into word N+1
 - THEN the `word-highlight` class moves from word N's span to word N+1's
   span
+
+#### Scenario: Offsets after an astral character
+
+- GIVEN the source text "Привет 🌍 мир" rendered for the viewer
+- WHEN the span attributes are computed
+- THEN the span for "🌍" carries `data-orig-start` / `data-orig-end` = 7 / 8
+  and the span for "мир" carries 9 / 12 (codepoints), so a timestamp whose
+  `original_pos` points at "мир" matches it exactly
 
 ### Requirement: Auto-scroll
 
@@ -103,3 +113,4 @@ ignored because no original-position mapping exists.
 - GIVEN the viewer is in HTML mode and the displayed entry is playing
 - WHEN `playback_position` events arrive
 - THEN no span is highlighted
+

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderMarkdown } from './markdown';
+
+describe('renderMarkdown data-orig-* offsets', () => {
+  it('tracks codepoint offsets with astral characters before a word', () => {
+    // '🌍' is one codepoint (two UTF-16 units): "мир" must start at
+    // codepoint 2, matching the Rust char_map contract.
+    expect(renderMarkdown('🌍 мир')).toContain(
+      '<span data-orig-start="2" data-orig-end="5">мир</span>',
+    );
+  });
+
+  it('keeps distinct codepoint positions for repeated fragments after an astral char', () => {
+    // Codepoints: 🌍(0) space(1) мир(2-5) \n(5) \n(6) мир(7-10).
+    const html = renderMarkdown('🌍 мир\n\nмир');
+    expect(html).toContain('<span data-orig-start="2" data-orig-end="5">мир</span>');
+    expect(html).toContain('<span data-orig-start="7" data-orig-end="10">мир</span>');
+  });
+
+  it('counts astral characters in the skipped region between text tokens', () => {
+    // The emoji sits inside the fenced code block, i.e. in the region
+    // skipped between text tokens (source.slice(searchFrom, pos)) — a
+    // different accounting line than token content. Codepoints before
+    // "мир": ```(3) \n(1) 🌍(1) \n(1) ```(3) \n\n(2) = 11, so "мир"
+    // starts at 11 (a UTF-16 count would give 12).
+    const html = renderMarkdown('```\n🌍\n```\n\nмир');
+    expect(html).toContain('<span data-orig-start="11" data-orig-end="14">мир</span>');
+  });
+});

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -51,8 +51,11 @@ md.renderer.rules.fence = (tokens, idx) => {
  * text fragments map to distinct, non-overlapping source positions.
  */
 export function renderMarkdown(source: string): string {
-  // Cursor shared across all text-token renders in this call.
+  // Cursor shared across all text-token renders in this call. `searchFrom`
+  // is a UTF-16 index for indexOf mechanics; `cpCursor` is its codepoint
+  // twin used for the data-orig-* contract (see wrapWordsWithOrigPos).
   let searchFrom = 0;
+  let cpCursor = 0;
 
   const origTextRule = md.renderer.rules.text;
 
@@ -72,10 +75,13 @@ export function renderMarkdown(source: string): string {
         ? origTextRule(tokens, idx, options, env, self)
         : escapeHtml(content);
     }
+    cpCursor += Array.from(source.slice(searchFrom, pos)).length;
     searchFrom = pos + content.length;
+    const startCp = cpCursor;
+    cpCursor += Array.from(content).length;
     // Wrap each word in its own span so that word-highlighting targets a
     // single word, not the whole text-token (which can be a paragraph).
-    return wrapWordsWithOrigPos(content, pos);
+    return wrapWordsWithOrigPos(content, startCp);
   };
 
   const html = md.render(source);

--- a/src/lib/plainTextHtml.test.ts
+++ b/src/lib/plainTextHtml.test.ts
@@ -62,4 +62,14 @@ describe('plainToWordHtml', () => {
       '<span data-orig-start="0" data-orig-end="3">foo</span><br>',
     );
   });
+
+  it('tracks offsets in codepoints across lines with astral characters', () => {
+    // '🌍' is one codepoint (two UTF-16 units): the second line must start at
+    // codepoint 2 (emoji + \n), not 3.
+    expect(plainToWordHtml('🌍\nмир')).toBe(
+      '<span data-orig-start="0" data-orig-end="1">🌍</span>' +
+        '<br>' +
+        '<span data-orig-start="2" data-orig-end="5">мир</span>',
+    );
+  });
 });

--- a/src/lib/plainTextHtml.ts
+++ b/src/lib/plainTextHtml.ts
@@ -12,13 +12,14 @@ import { wrapWordsWithOrigPos } from './wordSpans';
 export function plainToWordHtml(s: string): string {
   // Split on newlines so we can insert <br> between lines while still
   // wrapping each word in a data-orig-* span.  Offsets track the position of
-  // each line within the original source text.
+  // each line within the original source text, in codepoints (see
+  // wrapWordsWithOrigPos).
   const lines = s.split('\n');
   const parts: string[] = [];
   let offset = 0;
   for (let i = 0; i < lines.length; i += 1) {
     parts.push(wrapWordsWithOrigPos(lines[i], offset));
-    offset += lines[i].length + 1; // +1 for the consumed \n
+    offset += Array.from(lines[i]).length + 1; // +1 for the consumed \n
     if (i < lines.length - 1) parts.push('<br>');
   }
   return parts.join('');

--- a/src/lib/wordSpans.test.ts
+++ b/src/lib/wordSpans.test.ts
@@ -88,23 +88,18 @@ describe('wrapWordsWithOrigPos', () => {
     );
   });
 
-  it('documents current UTF-16 code-unit indexing for astral (surrogate-pair) characters', () => {
+  it('indexes astral (surrogate-pair) characters in codepoints, matching the char_map contract', () => {
     // '🚀' is a single Unicode codepoint but occupies two UTF-16 code units.
-    // wrapWordsWithOrigPos indexes via plain JS string ops (UTF-16 units), so
-    // the emoji "word" is reported as spanning 2 positions (data-orig-end -
-    // data-orig-start === 2), not 1 codepoint, and "mir" is pushed one
-    // position further out than a codepoint-based scheme would place it.
-    // This diverges from the Rust pipeline's char_map, which is indexed by
-    // Unicode codepoints (see src-tauri/src/pipeline/tracked_text.rs). This
-    // test pins down current behavior; it is not an assertion that the
-    // offset is semantically correct.
+    // data-orig-* must be codepoint-based, like the Rust pipeline's char_map
+    // (position-mapping spec): the emoji spans 1 position, and "mir" starts
+    // right after it (codepoint 2), not one unit further out.
     const text = '🚀 mir';
     expect(text.length).toBe(6); // 2 UTF-16 units for the emoji + 1 space + 3 for "mir"
     const out = wrapWordsWithOrigPos(text, 0);
     expect(out).toBe(
-      '<span data-orig-start="0" data-orig-end="2">🚀</span>' +
+      '<span data-orig-start="0" data-orig-end="1">🚀</span>' +
         ' ' +
-        '<span data-orig-start="3" data-orig-end="6">mir</span>',
+        '<span data-orig-start="2" data-orig-end="5">mir</span>',
     );
   });
 

--- a/src/lib/wordSpans.ts
+++ b/src/lib/wordSpans.ts
@@ -6,26 +6,38 @@
  * `startOffset` is the position of `text[0]` within the original source
  * document (so the caller can still use a cursor when identical fragments
  * appear more than once).
+ *
+ * All offsets — `startOffset` and the emitted data-orig-* values — are in
+ * Unicode codepoints, matching the Rust pipeline's char_map contract
+ * (position-mapping spec). JS string indices are UTF-16 code units, so we
+ * track a codepoint cursor alongside the UTF-16 index; astral characters
+ * (emoji, …) count as 1, not 2.
  */
 export function wrapWordsWithOrigPos(text: string, startOffset: number): string {
   let out = '';
   let i = 0;
+  let cp = 0; // codepoint cursor mirroring the UTF-16 index i
   const len = text.length;
+  const cpLen = (s: string): number => Array.from(s).length;
 
   while (i < len) {
     // Run through whitespace as-is (still escaped) — highlighting skips it.
     const wsStart = i;
     while (i < len && /\s/.test(text[i])) i += 1;
     if (i > wsStart) {
-      out += escapeHtml(text.slice(wsStart, i));
+      const ws = text.slice(wsStart, i);
+      out += escapeHtml(ws);
+      cp += cpLen(ws);
     }
     if (i >= len) break;
 
     const wordStart = i;
     while (i < len && !/\s/.test(text[i])) i += 1;
     const word = text.slice(wordStart, i);
-    const origStart = startOffset + wordStart;
-    const origEnd = startOffset + i;
+    // Whitespace boundaries are always BMP, so surrogate pairs are never split.
+    const origStart = startOffset + cp;
+    cp += cpLen(word);
+    const origEnd = startOffset + cp;
     out += `<span data-orig-start="${origStart}" data-orig-end="${origEnd}">${escapeHtml(word)}</span>`;
   }
 


### PR DESCRIPTION
## Summary

Fixes #77. `data-orig-start` / `data-orig-end` were computed with JS string indices (UTF-16 code units) while the Rust `char_map` contract is Unicode codepoints; after any astral character (emoji, mathematical alphanumerics) every span offset drifted by +1 and word highlighting matched the wrong span (or none) for the rest of the document.

- `wrapWordsWithOrigPos` tracks a codepoint cursor next to the UTF-16 index.
- Both callers (`plainToWordHtml`, `renderMarkdown`) pass codepoint-based start offsets; markdown keeps its UTF-16 `indexOf` cursor for search mechanics with a parallel codepoint cursor.
- BMP-only documents are unaffected (both schemes coincide there).

## Spec

OpenSpec change archived as `2026-07-26-codepoint-highlight-offsets`; `word-highlight` spec synced (offsets SHALL be codepoints + astral scenario).

## Test plan

- `pnpm test:unit`: 70/70 — the test that pinned the old UTF-16 behavior replaced with codepoint assertions; astral cases added for all three modules, including an astral char in the skipped region between markdown text tokens (reviewer finding)
- `just lint` green; `openspec validate --specs --strict` 12/12

Closes #77