### PR TITLE
refactor(pipeline): post-epic cleanups — byte-range helper, letter table, allocation and boundary-check cleanups

### DIFF
--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -624,13 +624,7 @@ impl TTSPipeline {
             })
             .collect();
 
-        // Apply replacements via TrackedText in reverse order.
-        // Must be by byte range: a literal `replace` would also hit occurrences of
-        // the word embedded in longer tokens (e.g. "use" inside "user"), corrupting
-        // them before their own turn to be replaced.
-        for (start, end, replacement) in matches.into_iter().rev() {
-            tracked.replace_byte_range(start, end, &replacement);
-        }
+        tracked.replace_byte_ranges(matches);
     }
 
     fn process_numbers_tracked(&self, tracked: &mut TrackedText) {
@@ -672,12 +666,7 @@ impl TTSPipeline {
             })
             .collect();
 
-        // Apply in reverse order so byte offsets stay valid.
-        // Must be by byte range: a literal `replace` would also hit the digit run
-        // embedded in a longer number (e.g. "42" inside "142"), corrupting it.
-        for (start, end, replacement) in matches.into_iter().rev() {
-            tracked.replace_byte_range(start, end, &replacement);
-        }
+        tracked.replace_byte_ranges(matches);
     }
 }
 

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -628,11 +628,12 @@ impl TTSPipeline {
     }
 
     fn process_numbers_tracked(&self, tracked: &mut TrackedText) {
-        // Effective pattern: `(?<![.\d])(\d+)(?![.\d]|[a-zA-Zа-яА-Я])`.
-        // The regex crate lacks lookbehind/lookahead, so the boundary check is applied
-        // in the closure below after the bare \d+ match.
+        // Effective pattern: `(?<![.])(\d+)(?![.])` on top of the Unicode-aware
+        // `\b\d+\b` from re_number(). The regex crate lacks lookbehind/lookahead,
+        // and `\b` already rejects digits, letters, and underscore next to the
+        // match, so the manual guard below only needs to exclude '.' (float and
+        // version separators, owned by earlier pipeline phases).
         let snapshot = tracked.text().to_string();
-        let bytes = snapshot.as_bytes();
 
         let matches: Vec<(usize, usize, String)> = re_number()
             .find_iter(&snapshot)
@@ -640,22 +641,8 @@ impl TTSPipeline {
                 let start = m.start();
                 let end = m.end();
 
-                // Check char before: must not be '.' or digit
-                let preceded_ok = start == 0 || {
-                    let prev = snapshot[..start].chars().next_back().unwrap();
-                    prev != '.' && !prev.is_ascii_digit()
-                };
-
-                // Check char after: must not be '.', digit, or Latin/Cyrillic letter
-                let followed_ok = end >= snapshot.len() || {
-                    let next_byte = bytes[end];
-                    let next_str = &snapshot[end..];
-                    let next_ch = next_str.chars().next().unwrap();
-                    next_byte != b'.'
-                        && !next_ch.is_ascii_digit()
-                        && !next_ch.is_ascii_alphabetic()
-                        && !next_ch.is_alphabetic()
-                };
+                let preceded_ok = start == 0 || !snapshot[..start].ends_with('.');
+                let followed_ok = end >= snapshot.len() || !snapshot[end..].starts_with('.');
 
                 if preceded_ok && followed_ok {
                     let replacement = self.number_normalizer.normalize_number(m.as_str());

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -607,7 +607,7 @@ impl TTSPipeline {
                     // Lone letters are read by English letter name via the same
                     // table as code identifiers ("x" → "икс"), not
                     // transliterated, and are not tracked as unknown words.
-                    self.code_normalizer.spell_abbreviation(word)
+                    CodeIdentifierNormalizer::spell_abbreviation(word)
                 } else if let Some(v) = IT_TERMS.get(word_lower.as_str()) {
                     v.to_string()
                 } else if word.chars().all(|c| c.is_ascii_uppercase()) && word.len() >= 2 {

--- a/src-tauri/src/pipeline/normalizers/code.rs
+++ b/src-tauri/src/pipeline/normalizers/code.rs
@@ -582,7 +582,7 @@ impl CodeIdentifierNormalizer {
                     translation.to_string()
                 } else if part.len() >= 2 && part.chars().all(|c| c.is_ascii_uppercase()) {
                     // All-caps abbreviation not in CODE_WORDS: spell letter by letter
-                    self.spell_abbreviation(part)
+                    Self::spell_abbreviation(part)
                 } else {
                     self.basic_transliterate(&part_lower)
                 }
@@ -596,46 +596,44 @@ impl CodeIdentifierNormalizer {
     ///
     /// Also used by the pipeline's English phase for lone single letters in
     /// prose, so "x" sounds the same inside an identifier and standalone.
-    pub fn spell_abbreviation(&self, abbrev: &str) -> String {
-        let letter_names: &[(&str, &str)] = &[
-            ("A", "эй"),
-            ("B", "би"),
-            ("C", "си"),
-            ("D", "ди"),
-            ("E", "и"),
-            ("F", "эф"),
-            ("G", "джи"),
-            ("H", "эйч"),
-            ("I", "ай"),
-            ("J", "джей"),
-            ("K", "кей"),
-            ("L", "эл"),
-            ("M", "эм"),
-            ("N", "эн"),
-            ("O", "о"),
-            ("P", "пи"),
-            ("Q", "кью"),
-            ("R", "ар"),
-            ("S", "эс"),
-            ("T", "ти"),
-            ("U", "ю"),
-            ("V", "ви"),
-            ("W", "дабл ю"),
-            ("X", "икс"),
-            ("Y", "вай"),
-            ("Z", "зет"),
-        ];
-
-        let map: HashMap<&str, &str> = letter_names.iter().copied().collect();
-
+    pub fn spell_abbreviation(abbrev: &str) -> String {
         abbrev
             .chars()
-            .map(|c| {
-                let s: String = c.to_uppercase().collect();
-                map.get(s.as_str()).copied().unwrap_or("?")
-            })
+            .map(Self::letter_name)
             .collect::<Vec<_>>()
             .join(" ")
+    }
+
+    fn letter_name(c: char) -> &'static str {
+        match c.to_ascii_uppercase() {
+            'A' => "эй",
+            'B' => "би",
+            'C' => "си",
+            'D' => "ди",
+            'E' => "и",
+            'F' => "эф",
+            'G' => "джи",
+            'H' => "эйч",
+            'I' => "ай",
+            'J' => "джей",
+            'K' => "кей",
+            'L' => "эл",
+            'M' => "эм",
+            'N' => "эн",
+            'O' => "о",
+            'P' => "пи",
+            'Q' => "кью",
+            'R' => "ар",
+            'S' => "эс",
+            'T' => "ти",
+            'U' => "ю",
+            'V' => "ви",
+            'W' => "дабл ю",
+            'X' => "икс",
+            'Y' => "вай",
+            'Z' => "зет",
+            _ => "?",
+        }
     }
 
     fn basic_transliterate(&self, word: &str) -> String {

--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -156,10 +156,7 @@ impl CodeBlockHandler {
     ///
     /// This is the low-level entry used in tests and by `process()`.
     pub fn process_block(&self, code: &str, language: Option<&str>) -> String {
-        match self.mode {
-            CodeBlockMode::Brief => self.brief_description(language),
-            CodeBlockMode::Full => self.full_normalize(code, language),
-        }
+        self.process_block_with_mode(self.mode, code, language)
     }
 
     /// In-place replacement of all fenced code blocks in `tracked`.
@@ -198,11 +195,7 @@ impl CodeBlockHandler {
                 let replacement = if language.is_some_and(|l| l.eq_ignore_ascii_case("mermaid")) {
                     "Тут мермэйд диаграмма".to_string()
                 } else {
-                    let handler = CodeBlockHandler {
-                        mode: effective_mode,
-                        code_normalizer: CodeIdentifierNormalizer::new(),
-                    };
-                    handler.process_block(code, language)
+                    self.process_block_with_mode(effective_mode, code, language)
                 };
 
                 (m.start(), m.end(), replacement)
@@ -219,6 +212,20 @@ impl CodeBlockHandler {
     }
 
     // ── Private helpers ────────────────────────────────────────────────
+
+    /// Process a block under an explicit mode (used by `process()` when a
+    /// per-section directive overrides the handler's default mode).
+    fn process_block_with_mode(
+        &self,
+        mode: CodeBlockMode,
+        code: &str,
+        language: Option<&str>,
+    ) -> String {
+        match mode {
+            CodeBlockMode::Brief => self.brief_description(language),
+            CodeBlockMode::Full => self.full_normalize(code, language),
+        }
+    }
 
     fn collect_directives(&self, text: &str) -> Vec<(usize, CodeBlockMode)> {
         RE_MODE_SWITCH

--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -209,14 +209,7 @@ impl CodeBlockHandler {
             })
             .collect();
 
-        // Apply replacements via TrackedText in reverse order (right-to-left)
-        // so that byte offsets remain valid after each substitution.
-        // Must be by byte range: a literal `replace` substitutes ALL
-        // occurrences of the matched text, so byte-identical blocks would all
-        // receive the replacement computed for the first processed one (#84).
-        for (start, end, replacement) in blocks.into_iter().rev() {
-            tracked.replace_byte_range(start, end, &replacement);
-        }
+        tracked.replace_byte_ranges(blocks);
 
         // Remove mode-switch directives from the output (they are control markers,
         // not content that should be spoken).

--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -152,9 +152,11 @@ impl CodeBlockHandler {
 
     // ── Public processing entry points ─────────────────────────────────
 
-    /// Process a single code block (code content + optional language tag).
+    /// Process a single code block (code content + optional language tag)
+    /// under the handler's default mode.
     ///
-    /// This is the low-level entry used in tests and by `process()`.
+    /// This is the low-level entry used in tests; `process()` calls
+    /// `process_block_with_mode()` directly to honor per-section directives.
     pub fn process_block(&self, code: &str, language: Option<&str>) -> String {
         self.process_block_with_mode(self.mode, code, language)
     }

--- a/src-tauri/src/pipeline/tracked_text.rs
+++ b/src-tauri/src/pipeline/tracked_text.rs
@@ -245,6 +245,20 @@ impl TrackedText {
         );
     }
 
+    /// Apply several pre-collected replacements by byte range, right-to-left.
+    ///
+    /// `ranges` are `(byte_start, byte_end, new_text)` offsets into the current
+    /// text, typically collected from a regex over a snapshot. Applying in
+    /// reverse order keeps the earlier offsets valid. This is the REQUIRED way
+    /// to apply boundary-checked matches: a literal [`Self::replace`] would
+    /// also hit the matched text embedded in longer tokens (see #75, #84,
+    /// #109).
+    pub fn replace_byte_ranges(&mut self, ranges: Vec<(usize, usize, String)>) {
+        for (start, end, new_text) in ranges.into_iter().rev() {
+            self.replace_byte_range(start, end, &new_text);
+        }
+    }
+
     /// Regex substitution with a callback, tracking positions for `CharMapping`.
     ///
     /// Matches that overlap already-replaced regions are skipped — exactly

--- a/src-tauri/src/pipeline/tracked_text.rs
+++ b/src-tauri/src/pipeline/tracked_text.rs
@@ -165,13 +165,23 @@ impl TrackedText {
     /// WARNING: this is an unbounded replace-all — it also hits `from` embedded
     /// in longer tokens ("use" inside "user", "42" inside "142"). Phases that
     /// collect boundary-checked matches must apply them via
-    /// [`Self::replace_byte_range`] instead (see #75, #84, #109). Literal
+    /// [`Self::replace_byte_ranges`] instead (see #75, #84, #109). Literal
     /// `replace` is reserved for constant patterns where every occurrence must
     /// be substituted (quotes, dashes, operators, symbols, C++/C#/F# terms).
     pub fn replace(&mut self, from: &str, to: &str) {
-        let pattern =
-            regex::Regex::new(&regex::escape(from)).expect("regex::escape produces valid pattern");
-        self.sub(&pattern, |_| to.to_string());
+        if from.is_empty() {
+            return;
+        }
+        // Literal search — no regex compilation per call (this runs ~60 times
+        // per pipeline pass for quote/dash/operator/symbol constants).
+        let matches: Vec<(usize, usize)> = self
+            .current
+            .match_indices(from)
+            .map(|(i, s)| (i, i + s.len()))
+            .collect();
+        for (start, end) in matches.into_iter().rev() {
+            self.replace_byte_range(start, end, to);
+        }
     }
 
     /// Replace exactly one byte range `[byte_start, byte_end)` in the current text.


### PR DESCRIPTION
## Summary

Follow-up cleanups from the final review of epic #109. Five independent refactorings, one commit each, no intended behavior change. Local gates green: `cargo fmt`, `clippy -D warnings`, 873 unit tests + golden pipeline fixtures.

## Commits

- `74ded4e` **TrackedText::replace without per-call regex compilation** — literal `match_indices` + `replace_byte_range` in reverse order instead of building a `Regex` on every call; guard against empty `from`.
- `a2c4e68` **TrackedText::replace_byte_ranges helper** — the collect-then-replace-in-reverse pattern was hand-rolled (with warning comments) in three places (`process_english_tracked`, `process_numbers_tracked`, `CodeBlockHandler::process`); now a single documented helper.
- `af7867d` **spell_abbreviation as an associated fn with a static letter table** — the method never used `&self` and rebuilt a 26-entry `HashMap` on every call; now a `match`-based lookup. Both call sites guarantee ASCII input, so `to_ascii_uppercase` is equivalent.
- `0bdc553` **Reuse code_normalizer across fenced blocks** — `CodeBlockHandler::process` constructed a fresh handler (and a fresh `CodeIdentifierNormalizer` with its two lookup maps) per fenced block just to override the mode; added `process_block_with_mode`, `process_block` delegates to it.
- `a8b5f8e` **Drop dead conditions from the number boundary check** — the Unicode-aware `\b` in `re_number()` (`\b\d+\b`) already rejects digits, letters, and underscore adjacent to a match; only the `.` guard (floats/versions) is load-bearing. Covered by golden fixtures (`date_dot`, `ip_address`, `mixed_paragraph`).

Plus `18270c1` fixing a stale doc comment flagged in review.

## Review

Read-only reviewer pass over the full diff: **APPROVE**, correctness of each transformation verified against regex-crate semantics and call-site invariants; two nits, one fixed here (doc comment), one waived (`replace_byte_ranges` has no dedicated unit test but is exercised through all three call sites and the golden fixtures).

Refs #109
