### PR TITLE
fix(nix): make ruvox package runnable and devshell clippy-stable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,12 @@
           libpulseaudio
           pipewire
           alsa-lib
+          # libayatana-appindicator is in buildInputs for the build, but
+          # tauri's libappindicator-sys dlopens libayatana-appindicator3.so.1
+          # at runtime, so it must also be on the wrapper's LD_LIBRARY_PATH —
+          # otherwise the app panics on startup with
+          # "Failed to load ayatana-appindicator3 or appindicator3 dynamic library".
+          libayatana-appindicator
         ];
 
         extraRuntimeLibPath = lib.makeLibraryPath extraRuntimeLibs;

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -90,6 +90,14 @@ pkgs.mkShell {
     # the C library at link time and at runtime.
     libopus
 
+    # ── libsonic (espeak-ng dependency) ────────────────────────────────────
+    # espeak-rs-sys 0.2.0 vendors espeak-ng and builds it via cmake; its
+    # deps.cmake does find_library(SONIC_LIB sonic) and falls back to
+    # git-cloning https://github.com/waywardgeek/sonic via FetchContent,
+    # which is flaky and breaks `cargo clippy` in the pre-push hook
+    # (same rationale as `sonic` in flake.nix buildInputs).
+    sonic
+
     # ── Wayland + X11 support ──────────────────────────────────────────────
     wayland
     wayland-protocols


### PR DESCRIPTION
## Summary
- flake.nix: added libayatana-appindicator to the wrapper's LD_LIBRARY_PATH — libappindicator-sys dlopens libayatana-appindicator3.so.1 at runtime and the app panicked on startup without it
- nix/devshell.nix: added sonic so espeak-rs-sys's cmake find_library finds the system library instead of git-cloning it via FetchContent (flaky pre-push cargo-clippy failures)

## Test plan
- nix build .#ruvox — succeeds
- ./result/bin/ruvox-tauri — starts without panic, manual smoke test passed
- cargo clippy (pre-push hook) — passes