### PR TITLE
fix: small batch — UTC timestamps, dead event removal, SIGTERM before SIGKILL

### DIFF
--- a/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/proposal.md
+++ b/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/proposal.md
@@ -1,0 +1,26 @@
+# Proposal: SIGTERM before SIGKILL in ttsd shutdown escalation (#92)
+
+## Summary
+
+When ttsd does not exit within 5 s of a `shutdown` request, the driver task
+escalates straight to SIGKILL (`start_kill`). SIGKILL gives the Python
+process no chance to run cleanup (flush logs, release resources, `atexit`
+handlers). Insert the conventional middle step: SIGTERM, a short grace
+period, then SIGKILL only if the process is still alive.
+
+## Capabilities
+
+- `ttsd-protocol` (modified)
+
+## Non-goals
+
+- The `kill_now()` path used by `cancel_synthesis` keeps its immediate
+  SIGKILL — cancellation is an explicit, latency-sensitive user action.
+- No changes to the 5 s clean-exit window, the shutdown request schema, or
+  ttsd itself.
+
+## Approach
+
+In the shutdown timeout branch of `driver_task`
+(`src-tauri/src/tts/mod.rs:411-415`): `libc::kill(pid, SIGTERM)` (libc is
+already a dependency), wait up to 2 s, then SIGKILL if still alive.

--- a/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/specs/ttsd-protocol/spec.md
+++ b/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/specs/ttsd-protocol/spec.md
@@ -1,0 +1,25 @@
+# Delta: ttsd-protocol
+
+## MODIFIED Requirements
+
+### Requirement: Shutdown Command
+
+The `shutdown` request (`{ "cmd": "shutdown" }`) SHALL make ttsd respond
+`{ "ok": true }` and then exit with code 0. On the Rust side, after sending
+`shutdown` the driver closes stdin and waits up to 5 seconds for the process
+to exit. If it does not, the driver SHALL escalate in stages: first send
+SIGTERM, wait up to 2 more seconds for a clean exit, and only then force-kill
+the still-running process (SIGKILL via `start_kill`).
+
+#### Scenario: graceful shutdown
+
+- GIVEN a running ttsd
+- WHEN the Rust side sends `{"cmd":"shutdown"}`
+- THEN ttsd writes `{"ok":true}` and terminates with exit code 0
+
+#### Scenario: unresponsive shutdown is force-killed
+
+- GIVEN a ttsd that does not exit after the shutdown response
+- WHEN 5 seconds elapse
+- THEN the Rust driver sends SIGTERM and force-kills the process only if it
+  is still alive 2 seconds later

--- a/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/tasks.md
+++ b/openspec/changes/archive/2026-07-27-sigterm-before-sigkill/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: SIGTERM before SIGKILL
+
+## Implementation
+
+- [x] `src-tauri/src/tts/mod.rs` `driver_task` shutdown timeout branch:
+  SIGTERM via `libc::kill` → 2 s grace (`timeout` on `child.wait()`) →
+  SIGKILL only if still alive; update the surrounding comments.
+
+## Tests
+
+- [x] If practical with the mock fixtures: a mock ttsd that ignores the
+  shutdown command but exits on SIGTERM — assert the driver does not need
+  SIGKILL; otherwise cover by code inspection + existing shutdown tests
+  staying green.
+
+## Validation
+
+- [x] `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml` green.
+- [x] `nix develop -c just lint` green.
+- [x] openspec validate sigterm-before-sigkill --strict green.

--- a/openspec/changes/archive/2026-07-27-utc-history-timestamps/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-utc-history-timestamps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-utc-history-timestamps/proposal.md
+++ b/openspec/changes/archive/2026-07-27-utc-history-timestamps/proposal.md
@@ -1,0 +1,31 @@
+# Proposal: Store history timestamps in UTC (#91)
+
+## Summary
+
+`created_at` and `audio_generated_at` are generated from the local clock
+(`Local::now().naive_local()`), while the storage schema documents naive
+timestamps that readers treat as UTC. The two only agree in a fixed
+timezone; after a timezone change entries interleave incorrectly, and any
+consumer parsing `history.json` as UTC shows times shifted by the local
+offset.
+
+Generate both fields with `Utc::now().naive_utc()` instead.
+
+## Capabilities
+
+- `storage` (modified)
+
+## Non-goals
+
+- No migration of existing `history.json` data: timestamps written so far
+  are local-naive. For a single-user desktop app in a fixed timezone the
+  stakes are ordering-only; the cutover is documented here instead of
+  migrating (a one-time local→UTC rewrite of old entries is possible but
+  not worth the risk of misinterpreting mixed data).
+- No change to the wire format (still naive, no timezone suffix).
+
+## Approach
+
+Two-line change (`src-tauri/src/storage/service.rs`,
+`src-tauri/src/commands/mod.rs`) plus a spec delta; existing entries stay
+as they are.

--- a/openspec/changes/archive/2026-07-27-utc-history-timestamps/specs/storage/spec.md
+++ b/openspec/changes/archive/2026-07-27-utc-history-timestamps/specs/storage/spec.md
@@ -1,0 +1,59 @@
+# Delta: storage
+
+## MODIFIED Requirements
+
+### Requirement: History File Schema
+
+The system SHALL persist the text entry queue to `history.json` as a versioned JSON document with schema version `1`:
+
+```typescript
+interface HistoryFile {
+  version: number;          // Schema version. Starts at 1.
+  entries: TextEntry[];
+}
+
+type EntryId = string;      // UUID v4, e.g. "550e8400-e29b-41d4-a716-446655440000"
+
+type EntryStatus =
+  | "pending"     // Waiting for TTS synthesis
+  | "processing"  // TTS synthesis is running
+  | "ready"       // Audio is synthesized and playable
+  | "playing"     // Runtime-only: entry is currently playing. NEVER persisted.
+  | "error";      // Synthesis failed
+
+interface TextEntry {
+  id: EntryId;
+  original_text: string;
+  normalized_text: string | null;       // Output of the Rust TTS pipeline
+  status: EntryStatus;
+  created_at: string;                   // Naive UTC timestamp, e.g. "2026-02-15T11:46:51.504055" (no TZ suffix)
+  audio_generated_at: string | null;    // Naive UTC timestamp when audio file was written
+  audio_path: string | null;            // Filename relative to audio/, e.g. "{uuid}.opus"
+  timestamps_path: string | null;       // Filename relative to audio/, e.g. "{uuid}.timestamps.json"
+  duration_sec: number | null;          // Audio duration in seconds
+  was_regenerated: boolean;             // True if audio was re-synthesized at least once
+  error_message: string | null;         // Human-readable error if status == "error"
+}
+```
+
+Status values SHALL serialize as lowercase strings. `created_at` and `audio_generated_at` SHALL be stored as naive timestamps without a timezone suffix; both SHALL be generated from the UTC clock (`Utc::now().naive_utc()`), and readers treat the values as UTC. `audio_path` and `timestamps_path` SHALL store the filename only; the full path resolves as `<cache_root>/audio/{filename}`. All optional `TextEntry` fields SHALL default when absent from the JSON, so entries written by older builds keep parsing.
+
+#### Scenario: New entry is persisted
+- GIVEN an empty history
+- WHEN a new entry is added
+- THEN `history.json` contains a `version: 1` wrapper and the entry with status `"pending"`, a UUID v4 `id`, and null audio fields
+
+#### Scenario: Entry written with UTC timestamp
+- GIVEN a newly ingested entry
+- WHEN the entry is persisted to `history.json`
+- THEN its `created_at` is the current UTC time in naive form (no timezone suffix), independent of the machine's local timezone
+
+#### Scenario: History round-trips through disk
+- GIVEN an entry with `normalized_text` set and status `"ready"`
+- WHEN the storage service is re-initialized against the same cache directory
+- THEN the loaded entry has the same `normalized_text` and field values as before the restart
+
+#### Scenario: Older entries without optional fields parse
+- GIVEN a `history.json` entry that lacks `normalized_text`, `audio_path`, `was_regenerated`, and other optional fields
+- WHEN the history is loaded
+- THEN the entry parses successfully with the missing fields defaulted (null / false)

--- a/openspec/changes/archive/2026-07-27-utc-history-timestamps/tasks.md
+++ b/openspec/changes/archive/2026-07-27-utc-history-timestamps/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: UTC history timestamps
+
+## Implementation
+
+- [x] `src-tauri/src/storage/service.rs:222` — `Local::now().naive_local()` →
+  `Utc::now().naive_utc()`.
+- [x] `src-tauri/src/commands/mod.rs` (`audio_generated_at`) — same change.
+
+## Validation
+
+- [x] `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml` green.
+- [x] `nix develop -c just lint` green.
+- [x] openspec validate utc-history-timestamps --strict green.

--- a/openspec/specs/storage/spec.md
+++ b/openspec/specs/storage/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Covers the on-disk persistence layer of RuVox (`src-tauri/src/storage/`): the per-user cache directory layout, the `history.json` entry store, the `config.json` application configuration, synthesized audio files (`{uuid}.opus`), word-level timestamp files (`{uuid}.timestamps.json`), the legacy WAV-to-Opus migration, and cache hygiene (orphan sweep and size-based eviction).
-
 ## Requirements
-
 ### Requirement: Cache Directory Layout
 
 The system SHALL store all persistent data under a per-user cache root resolved as `dirs::cache_dir()/ruvox` (e.g. `~/.cache/ruvox/`), with the following layout:
@@ -55,8 +53,8 @@ interface TextEntry {
   original_text: string;
   normalized_text: string | null;       // Output of the Rust TTS pipeline
   status: EntryStatus;
-  created_at: string;                   // Naive timestamp, e.g. "2026-02-15T11:46:51.504055" (no TZ suffix)
-  audio_generated_at: string | null;    // Naive timestamp when audio file was written
+  created_at: string;                   // Naive UTC timestamp, e.g. "2026-02-15T11:46:51.504055" (no TZ suffix)
+  audio_generated_at: string | null;    // Naive UTC timestamp when audio file was written
   audio_path: string | null;            // Filename relative to audio/, e.g. "{uuid}.opus"
   timestamps_path: string | null;       // Filename relative to audio/, e.g. "{uuid}.timestamps.json"
   duration_sec: number | null;          // Audio duration in seconds
@@ -65,12 +63,17 @@ interface TextEntry {
 }
 ```
 
-Status values SHALL serialize as lowercase strings. `created_at` and `audio_generated_at` SHALL be stored as naive timestamps without a timezone suffix; `created_at` is generated from the local clock (`Local::now().naive_local()`) and readers treat the values as UTC. `audio_path` and `timestamps_path` SHALL store the filename only; the full path resolves as `<cache_root>/audio/{filename}`. All optional `TextEntry` fields SHALL default when absent from the JSON, so entries written by older builds keep parsing.
+Status values SHALL serialize as lowercase strings. `created_at` and `audio_generated_at` SHALL be stored as naive timestamps without a timezone suffix; both SHALL be generated from the UTC clock (`Utc::now().naive_utc()`), and readers treat the values as UTC. `audio_path` and `timestamps_path` SHALL store the filename only; the full path resolves as `<cache_root>/audio/{filename}`. All optional `TextEntry` fields SHALL default when absent from the JSON, so entries written by older builds keep parsing.
 
 #### Scenario: New entry is persisted
 - GIVEN an empty history
 - WHEN a new entry is added
 - THEN `history.json` contains a `version: 1` wrapper and the entry with status `"pending"`, a UUID v4 `id`, and null audio fields
+
+#### Scenario: Entry written with UTC timestamp
+- GIVEN a newly ingested entry
+- WHEN the entry is persisted to `history.json`
+- THEN its `created_at` is the current UTC time in naive form (no timezone suffix), independent of the machine's local timezone
 
 #### Scenario: History round-trips through disk
 - GIVEN an entry with `normalized_text` set and status `"ready"`
@@ -344,3 +347,4 @@ The on-disk format originated in the earlier PyQt implementation of RuVox, and e
 - GIVEN a `config.json` containing keys not present in the current `UIConfig` schema
 - WHEN the configuration is loaded
 - THEN it parses successfully and the unknown keys are dropped
+

--- a/openspec/specs/ttsd-protocol/spec.md
+++ b/openspec/specs/ttsd-protocol/spec.md
@@ -140,18 +140,23 @@ loaded with `model_not_loaded`.
 
 The `shutdown` request (`{ "cmd": "shutdown" }`) SHALL make ttsd respond
 `{ "ok": true }` and then exit with code 0. On the Rust side, after sending
-`shutdown` the driver closes stdin, waits up to 5 seconds for the process to
-exit, and force-kills it (SIGKILL via `start_kill`) if it does not.
+`shutdown` the driver closes stdin and waits up to 5 seconds for the process
+to exit. If it does not, the driver SHALL escalate in stages: first send
+SIGTERM, wait up to 2 more seconds for a clean exit, and only then force-kill
+the still-running process (SIGKILL via `start_kill`).
 
 #### Scenario: graceful shutdown
+
 - GIVEN a running ttsd
 - WHEN the Rust side sends `{"cmd":"shutdown"}`
 - THEN ttsd writes `{"ok":true}` and terminates with exit code 0
 
 #### Scenario: unresponsive shutdown is force-killed
+
 - GIVEN a ttsd that does not exit after the shutdown response
 - WHEN 5 seconds elapse
-- THEN the Rust driver task force-kills the process and reaps it
+- THEN the Rust driver sends SIGTERM and force-kills the process only if it
+  is still alive 2 seconds later
 
 ### Requirement: Error Response Schema
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -423,7 +423,7 @@ fn apply_ready_if_current(
     entry.audio_path = Some(audio_filename.to_string());
     entry.timestamps_path = ts_filename;
     entry.duration_sec = Some(output.duration_sec);
-    entry.audio_generated_at = Some(chrono::Local::now().naive_local());
+    entry.audio_generated_at = Some(chrono::Utc::now().naive_utc());
 
     if let Err(e) = storage.update_entry(entry) {
         warn!("failed to update entry to ready: {e}");

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use chrono::Local;
+use chrono::Utc;
 use parking_lot::RwLock;
 use thiserror::Error;
 use uuid::Uuid;
@@ -219,7 +219,7 @@ impl StorageService {
             original_text: clean_text,
             normalized_text: None,
             status: EntryStatus::Pending,
-            created_at: Local::now().naive_local(),
+            created_at: Utc::now().naive_utc(),
             audio_path: None,
             timestamps_path: None,
             duration_sec: None,
@@ -588,7 +588,7 @@ mod tests {
     #[test]
     fn get_all_entries_newest_first() {
         let (svc, _dir) = make_service();
-        let base = Local::now().naive_local();
+        let base = chrono::Local::now().naive_local();
         let e1 = add_entry_at(&svc, "first", base);
         let e2 = add_entry_at(&svc, "second", base + chrono::Duration::seconds(1));
 

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -301,9 +301,9 @@ impl TtsSubprocess {
 
     /// Request graceful shutdown.
     ///
-    /// Waits up to 5 s for the ttsd response. If the subprocess does not respond
-    /// or does not exit cleanly within that window, the driver task force-kills
-    /// the process (see `driver_task`).
+    /// Waits up to 5 s for the ttsd response. If the subprocess does not exit
+    /// cleanly within that window, the driver task escalates in stages:
+    /// SIGTERM, a 2 s grace, then SIGKILL (see `driver_task`).
     pub async fn shutdown(&self) -> Result<(), TtsError> {
         const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
         let resp = timeout(SHUTDOWN_TIMEOUT, self.send(TtsRequest::Shutdown))
@@ -409,9 +409,31 @@ async fn driver_task(
                     warn!(target: "ttsd", "wait() failed: {e}");
                 }
                 Err(_) => {
-                    warn!(target: "ttsd", "did not exit within 5 s, sending SIGKILL");
-                    let _ = child.start_kill();
-                    let _ = child.wait().await;
+                    // Escalate in stages: SIGTERM gives the Python process a
+                    // chance to run cleanup (flush logs, atexit handlers);
+                    // SIGKILL only if it is still alive after the grace.
+                    warn!(target: "ttsd", "did not exit within 5 s, sending SIGTERM");
+                    if let Some(pid) = child.id() {
+                        // SAFETY: plain signal send. The pid is still ours:
+                        // the timed-out wait() above is cancel-safe and only
+                        // dropped the future, so the child has not been
+                        // reaped — it is alive or a zombie, and a zombie
+                        // holds its pid, so the OS cannot have recycled it.
+                        let _ = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+                    }
+                    match timeout(Duration::from_secs(2), child.wait()).await {
+                        Ok(Ok(status)) => {
+                            info!(target: "ttsd", "exited after SIGTERM: {status}");
+                        }
+                        Ok(Err(e)) => {
+                            warn!(target: "ttsd", "wait() after SIGTERM failed: {e}");
+                        }
+                        Err(_) => {
+                            warn!(target: "ttsd", "still alive 2 s after SIGTERM, sending SIGKILL");
+                            let _ = child.start_kill();
+                            let _ = child.wait().await;
+                        }
+                    }
                 }
             }
             return;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -178,7 +178,6 @@ export interface PlaybackFinishedPayload { entry_id: EntryId; }
 export interface ModelErrorPayload { message: string; }
 export interface TtsErrorPayload { entry_id: EntryId; message: string; }
 export interface TtsFatalPayload { message: string; }
-export interface SynthesisProgressPayload { entry_id: EntryId; progress: number; }
 
 export interface VoiceDownloadStartedPayload {
   engine: 'piper';
@@ -244,9 +243,6 @@ export const events = {
 
   ttsFatal: (cb: (p: TtsFatalPayload) => void): Promise<UnlistenFn> =>
     tauriListen<TtsFatalPayload>('tts_fatal', (e) => cb(e.payload)),
-
-  synthesisProgress: (cb: (p: SynthesisProgressPayload) => void): Promise<UnlistenFn> =>
-    tauriListen<SynthesisProgressPayload>('synthesis_progress', (e) => cb(e.payload)),
 
   trayReadNow: (cb: () => void): Promise<UnlistenFn> =>
     tauriListen<Record<string, never>>('tray_read_now', () => cb()),


### PR DESCRIPTION
## Summary

Three independent small fixes, one commit each:

- **#91 — UTC history timestamps:** `created_at` / `audio_generated_at` were generated from the local clock while readers treat them as UTC; now generated with `Utc::now().naive_utc()`. Existing `history.json` data is deliberately not migrated (local-naive so far; ordering-only stakes for a single-user app in a fixed timezone).
- **#90 — dead `synthesis_progress` event removed:** nothing ever emitted it, nothing subscribed; payload type and listener wrapper deleted. Can be re-added with a real implementation if synthesis progress is ever surfaced.
- **#92 — SIGTERM before SIGKILL in ttsd shutdown escalation:** the shutdown timeout branch escalated straight to SIGKILL; now SIGTERM → 2 s grace → SIGKILL only if still alive, so the Python process can run cleanup. The `kill_now` cancellation path keeps its immediate SIGKILL.

## Specs

OpenSpec changes archived as `2026-07-27-utc-history-timestamps` and `2026-07-27-sigterm-before-sigkill`; `storage` and `ttsd-protocol` specs synced. #90 touched no spec (dead code removal).

## Test plan

- `cargo test` green (944 + golden); `pnpm test:unit` 70/70; `just lint` green (knip confirms no dangling references)
- `openspec validate --specs --strict` 12/12
- Pre-PR review: clean; the SIGTERM `unsafe` block documents the pid-ownership invariant (cancel-safe wait, zombie holds the pid)

Closes #90, closes #91, closes #92