### PR TITLE
fix(pipeline): unify English letter-name tables (#120)

### DIFF
--- a/openspec/changes/archive/2026-07-27-unify-letter-tables/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-unify-letter-tables/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-unify-letter-tables/design.md
+++ b/openspec/changes/archive/2026-07-27-unify-letter-tables/design.md
@@ -1,0 +1,55 @@
+# Design: unify-letter-tables
+
+## Context
+
+`LETTER_MAP` (`abbreviations.rs`, 26 entries, HashMap) and `letter_name`
+(`code.rs`, match on uppercase char) duplicate the same knowledge — English
+letter names — with drift in exactly three letters (x/y/z). Callers:
+
+- `AbbreviationNormalizer`: unknown all-caps words length ≥ 2 → spelled via
+  `LETTER_MAP`.
+- `CodeIdentifierNormalizer::spell_abbreviation`: all-caps parts of code
+  identifiers; also called by the English phase for lone single letters in
+  prose (#109).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One canonical letter-name table, one home (per `ai/rules/code-quality.md`:
+  "Dictionaries and normalization tables have one home").
+- Canonical x/y/z readings "икс/вай/зет" (decision: variant В2 of the #120
+  discussion — smallest behavior radius, consistent with #109 and with
+  `IT_TERMS` "xml" → "икс эм эль").
+
+**Non-Goals:**
+
+- Touching readings other than x/y/z; touching `AS_WORD`, `IT_TERMS`.
+- Changing behavior of lone letters / identifiers (stays "икс/вай/зет").
+
+## Decisions
+
+### Table lives in `english.rs`
+
+`pub(crate) static LETTER_NAMES: [(char, &str); 26]` next to `IT_TERMS` and
+the transliteration tables — `english.rs` is the existing home of
+pronunciation data. A sorted array with lookup (linear scan over 26 entries
+is fine and keeps it dependency-free) rather than another `HashMap`.
+
+### Both consumers delegate
+
+- `abbreviations.rs`: `LETTER_MAP` deleted; the spelling path calls the
+  shared lookup. Fallback for non-listed characters stays as today
+  (verbatim) — unreachable for ASCII letters.
+- `code.rs`: `letter_name` becomes a lookup into the shared table; the
+  `_ => "?"` arm stays for non-letters (existing behavior).
+
+### Behavior change is limited to unknown caps abbreviations
+
+"UX", "XSS", "WXYZ" and similar change to "икс/вай/зет" readings. Everything
+else (lone letters, identifiers, `IT_TERMS` entries) is byte-identical.
+
+## Risks / Trade-offs
+
+- Users accustomed to "экс уай зед" for abbreviations hear "икс вай зет" —
+  accepted per the #120 decision; pinned by a delta-spec scenario.

--- a/openspec/changes/archive/2026-07-27-unify-letter-tables/proposal.md
+++ b/openspec/changes/archive/2026-07-27-unify-letter-tables/proposal.md
@@ -1,0 +1,51 @@
+# Proposal: unify-letter-tables
+
+## Why
+
+Two letter-name tables for English letters have drifted apart
+(#120): `LETTER_MAP` in `abbreviations.rs` reads unknown all-caps
+abbreviations with x/y/z as "экс/уай/зед", while `letter_name` in `code.rs`
+(used for code identifiers and, since #109, lone letters in prose) reads
+them "икс/вай/зет". The same letter sounds different depending on code path,
+and the duplication violates the project rule that pronunciation tables have
+one home (`ai/rules/code-quality.md`). `IT_TERMS` already leans to the
+"икс" style ("xml" → "икс эм эль").
+
+## What Changes
+
+- **BREAKING (pronunciation)**: unknown all-caps abbreviations containing
+  x/y/z change reading: "экс/уай/зед" → "икс/вай/зет" ("UX" → "ю икс",
+  "XSS" → "икс эс эс"). Lone letters and identifiers keep their current
+  reading (no change).
+- The two tables are merged into a single shared `LETTER_NAMES` table in
+  `english.rs` (the home of `IT_TERMS` and the transliteration tables);
+  `abbreviations.rs` and `code.rs` both use it.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `text-pipeline`: the "English words, abbreviations, and transliteration"
+  requirement now names one shared letter-name table with the canonical
+  x/y/z readings "икс/вай/зет".
+
+## Impact
+
+- `src-tauri/src/pipeline/normalizers/english.rs` — new shared table.
+- `src-tauri/src/pipeline/normalizers/abbreviations.rs` — `LETTER_MAP`
+  removed, table imported; unit-test expectations updated (x/y/z readings).
+- `src-tauri/src/pipeline/normalizers/code.rs` — `letter_name` delegates to
+  the shared table; behavior unchanged.
+- Golden fixtures unaffected (caps abbreviations in fixtures resolve via
+  `IT_TERMS`, e.g. "xml" → "икс эм эль").
+
+## Non-goals
+
+- Changing any reading other than x/y/z in unknown all-caps abbreviations.
+- A stop-list for over-matched artifacts ("e.g.", article "A") — noted in
+  #120 as a possible ride-along, deliberately left for a separate change.
+- Auditing `AS_WORD` or other dictionaries.

--- a/openspec/changes/archive/2026-07-27-unify-letter-tables/specs/text-pipeline/spec.md
+++ b/openspec/changes/archive/2026-07-27-unify-letter-tables/specs/text-pipeline/spec.md
@@ -1,0 +1,68 @@
+# Delta spec: text-pipeline
+
+## MODIFIED Requirements
+
+### Requirement: English words, abbreviations, and transliteration
+
+The system SHALL replace every remaining English word with speakable
+Cyrillic. Special language names `C++`, `C#`, `F#` (any case) SHALL be
+replaced first ("си плюс плюс", "си шарп", "эф шарп"). Single Latin letters
+(length-1 runs) SHALL be read by their English letter names via the shared
+letter-name table ("a" → "эй", "I" → "ай", "x" → "икс"),
+case-insensitively; they SHALL NOT be recorded in the unknown-words map.
+For remaining multi-letter words the resolution order SHALL be: `IT_TERMS`
+dictionary ("api" → "эй пи ай", "github" → "гитхаб"); all-uppercase words of
+length ≥ 2 via `AbbreviationNormalizer` (special cases like "ios" →
+"ай оу эс", `AS_WORD` entries like "json" → "джейсон", otherwise
+letter-by-letter via the same shared letter-name table); `AS_WORD`
+dictionary for mixed-case entries; and finally digraph-first
+transliteration (`sh` → "ш", `tion` → "шн", longest match first). Custom
+terms registered via `EnglishNormalizer::add_custom_terms` SHALL override
+`IT_TERMS`. Words resolved by transliteration SHALL be recorded in the
+unknown-words map, which SHALL be cleared at the start of every
+`process_with_char_mapping` call.
+
+The letter-name table SHALL have a single home shared by the abbreviation
+spelling, code-identifier spelling, and lone-letter reading paths; its
+canonical readings for x/y/z SHALL be "икс", "вай", "зет" — so an unknown
+abbreviation and a lone letter sound the same ("x" and "X" both → "икс").
+
+#### Scenario: Uppercase abbreviation spelled out
+
+- GIVEN the input "через API"
+- WHEN the pipeline processes it
+- THEN the abbreviation is read letter by letter as "эй пи ай" and not
+  transliterated as a word
+
+#### Scenario: Unknown abbreviation with x/y/z
+
+- GIVEN the input "формат XYZ"
+- WHEN the pipeline processes it
+- THEN the abbreviation is read "икс вай зет" — the same letter names as
+  for lone letters
+
+#### Scenario: IT term from dictionary
+
+- GIVEN the input "на github"
+- WHEN the pipeline processes it
+- THEN the word is read as "гитхаб"
+
+#### Scenario: Unknown word transliterated
+
+- GIVEN an English word absent from all dictionaries, e.g. "workflow"
+- WHEN the pipeline processes it
+- THEN the word is transliterated to Cyrillic via the digraph rules and
+  recorded in the unknown-words map
+
+#### Scenario: Single Latin letter read by letter name
+
+- GIVEN the input "Переменная x равна 5"
+- WHEN the pipeline processes it
+- THEN the letter is read as "икс" ("Переменная икс равна пять") and no Latin
+  characters remain in the output
+
+#### Scenario: Single letters of any case
+
+- GIVEN the input "пункты a и I"
+- WHEN the pipeline processes it
+- THEN the letters are read as "эй" and "ай" ("пункты эй и ай")

--- a/openspec/changes/archive/2026-07-27-unify-letter-tables/tasks.md
+++ b/openspec/changes/archive/2026-07-27-unify-letter-tables/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: unify-letter-tables
+
+## 1. Shared table
+
+- [x] 1.1 Add `pub(crate) static LETTER_NAMES: [(char, &str); 26]` in
+  `src-tauri/src/pipeline/normalizers/english.rs` with the canonical
+  readings (x → "икс", y → "вай", z → "зет") plus a lookup helper
+
+## 2. Migrate consumers
+
+- [x] 2.1 `abbreviations.rs`: delete `LETTER_MAP`, use the shared table in
+  the spelling path
+- [x] 2.2 `code.rs`: `letter_name` delegates to the shared table (behavior
+  unchanged)
+
+## 3. Tests
+
+- [x] 3.1 Update `abbreviations.rs` expectations: XML → "икс эм эл",
+  XSS → "икс эс эс", UX → "ю икс", X/Y/Z → "икс"/"вай"/"зет",
+  XYZ → "икс вай зет", WXYZ → "дабл ю икс вай зет"
+- [x] 3.2 Add a test pinning table identity: abbreviation spelling and
+  `spell_abbreviation` return the same reading for the same letter
+
+## 4. Gates
+
+- [x] 4.1 `cargo fmt`, `cargo clippy --no-deps -- -D warnings`,
+  `cargo test --manifest-path src-tauri/Cargo.toml` — all green
+- [x] 4.2 `pnpm dlx @fission-ai/openspec validate unify-letter-tables --strict`

--- a/openspec/specs/text-pipeline/spec.md
+++ b/openspec/specs/text-pipeline/spec.md
@@ -456,19 +456,25 @@ numeric parts SHALL be read as Russian number words.
 The system SHALL replace every remaining English word with speakable
 Cyrillic. Special language names `C++`, `C#`, `F#` (any case) SHALL be
 replaced first ("си плюс плюс", "си шарп", "эф шарп"). Single Latin letters
-(length-1 runs) SHALL be read by their English letter names via the
-letter-name spelling table ("a" → "эй", "I" → "ай", "x" → "икс"),
+(length-1 runs) SHALL be read by their English letter names via the shared
+letter-name table ("a" → "эй", "I" → "ай", "x" → "икс"),
 case-insensitively; they SHALL NOT be recorded in the unknown-words map.
 For remaining multi-letter words the resolution order SHALL be: `IT_TERMS`
 dictionary ("api" → "эй пи ай", "github" → "гитхаб"); all-uppercase words of
 length ≥ 2 via `AbbreviationNormalizer` (special cases like "ios" →
 "ай оу эс", `AS_WORD` entries like "json" → "джейсон", otherwise
-letter-by-letter via `LETTER_MAP`); `AS_WORD` dictionary for mixed-case
-entries; and finally digraph-first transliteration (`sh` → "ш", `tion` →
-"шн", longest match first). Custom terms registered via
-`EnglishNormalizer::add_custom_terms` SHALL override `IT_TERMS`. Words
-resolved by transliteration SHALL be recorded in the unknown-words map, which
-SHALL be cleared at the start of every `process_with_char_mapping` call.
+letter-by-letter via the same shared letter-name table); `AS_WORD`
+dictionary for mixed-case entries; and finally digraph-first
+transliteration (`sh` → "ш", `tion` → "шн", longest match first). Custom
+terms registered via `EnglishNormalizer::add_custom_terms` SHALL override
+`IT_TERMS`. Words resolved by transliteration SHALL be recorded in the
+unknown-words map, which SHALL be cleared at the start of every
+`process_with_char_mapping` call.
+
+The letter-name table SHALL have a single home shared by the abbreviation
+spelling, code-identifier spelling, and lone-letter reading paths; its
+canonical readings for x/y/z SHALL be "икс", "вай", "зет" — so an unknown
+abbreviation and a lone letter sound the same ("x" and "X" both → "икс").
 
 #### Scenario: Uppercase abbreviation spelled out
 
@@ -476,6 +482,13 @@ SHALL be cleared at the start of every `process_with_char_mapping` call.
 - WHEN the pipeline processes it
 - THEN the abbreviation is read letter by letter as "эй пи ай" and not
   transliterated as a word
+
+#### Scenario: Unknown abbreviation with x/y/z
+
+- GIVEN the input "формат XYZ"
+- WHEN the pipeline processes it
+- THEN the abbreviation is read "икс вай зет" — the same letter names as
+  for lone letters
 
 #### Scenario: IT term from dictionary
 

--- a/src-tauri/src/pipeline/normalizers/abbreviations.rs
+++ b/src-tauri/src/pipeline/normalizers/abbreviations.rs
@@ -1,38 +1,6 @@
+use super::english::letter_name;
 use std::collections::HashMap;
 use std::sync::LazyLock;
-
-static LETTER_MAP: LazyLock<HashMap<char, &'static str>> = LazyLock::new(|| {
-    [
-        ('a', "эй"),
-        ('b', "би"),
-        ('c', "си"),
-        ('d', "ди"),
-        ('e', "и"),
-        ('f', "эф"),
-        ('g', "джи"),
-        ('h', "эйч"),
-        ('i', "ай"),
-        ('j', "джей"),
-        ('k', "кей"),
-        ('l', "эл"),
-        ('m', "эм"),
-        ('n', "эн"),
-        ('o', "о"),
-        ('p', "пи"),
-        ('q', "кью"),
-        ('r', "ар"),
-        ('s', "эс"),
-        ('t', "ти"),
-        ('u', "ю"),
-        ('v', "ви"),
-        ('w', "дабл ю"),
-        ('x', "экс"),
-        ('y', "уай"),
-        ('z', "зед"),
-    ]
-    .into_iter()
-    .collect()
-});
 
 static AS_WORD: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     [
@@ -104,8 +72,7 @@ impl AbbreviationNormalizer {
 
         if abbrev.len() == 1 {
             let ch = lower.chars().next().unwrap();
-            return LETTER_MAP
-                .get(&ch)
+            return letter_name(ch)
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| abbrev.to_string());
         }
@@ -122,8 +89,7 @@ impl AbbreviationNormalizer {
             .to_lowercase()
             .chars()
             .map(|c| {
-                LETTER_MAP
-                    .get(&c)
+                letter_name(c)
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| c.to_string())
             })
@@ -136,7 +102,7 @@ impl AbbreviationNormalizer {
             .to_lowercase()
             .chars()
             .map(|c| {
-                if let Some(&pronunciation) = LETTER_MAP.get(&c) {
+                if let Some(pronunciation) = letter_name(c) {
                     pronunciation.to_string()
                 } else {
                     c.to_string()
@@ -151,10 +117,6 @@ impl Default for AbbreviationNormalizer {
     fn default() -> Self {
         Self::new()
     }
-}
-
-pub fn letter_map() -> &'static HashMap<char, &'static str> {
-    &LETTER_MAP
 }
 
 pub fn as_word() -> &'static HashMap<&'static str, &'static str> {
@@ -198,7 +160,7 @@ mod tests {
     #[test_case("HTTPS" => "эйч ти ти пи эс"; "https")]
     #[test_case("HTML" => "эйч ти эм эл"; "html")]
     #[test_case("CSS" => "си эс эс"; "css")]
-    #[test_case("XML" => "экс эм эл"; "xml")]
+    #[test_case("XML" => "икс эм эл"; "xml")]
     #[test_case("URL" => "ю ар эл"; "url")]
     #[test_case("URI" => "ю ар ай"; "uri")]
     #[test_case("API" => "эй пи ай"; "api")]
@@ -210,7 +172,7 @@ mod tests {
     #[test_case("SSH" => "эс эс эйч"; "ssh")]
     #[test_case("VPN" => "ви пи эн"; "vpn")]
     #[test_case("JWT" => "джей дабл ю ти"; "jwt")]
-    #[test_case("XSS" => "экс эс эс"; "xss")]
+    #[test_case("XSS" => "икс эс эс"; "xss")]
     #[test_case("CSRF" => "си эс ар эф"; "csrf")]
     #[test_case("TCP" => "ти си пи"; "tcp")]
     #[test_case("UDP" => "ю ди пи"; "udp")]
@@ -225,7 +187,7 @@ mod tests {
     #[test_case("USB" => "ю эс би"; "usb")]
     #[test_case("HDMI" => "эйч ди эм ай"; "hdmi")]
     #[test_case("UI" => "ю ай"; "ui")]
-    #[test_case("UX" => "ю экс"; "ux")]
+    #[test_case("UX" => "ю икс"; "ux")]
     #[test_case("CI" => "си ай"; "ci")]
     #[test_case("CD" => "си ди"; "cd")]
     #[test_case("AI" => "эй ай"; "ai")]
@@ -269,9 +231,9 @@ mod tests {
     #[test_case("U" => "ю"; "u")]
     #[test_case("V" => "ви"; "v")]
     #[test_case("W" => "дабл ю"; "w")]
-    #[test_case("X" => "экс"; "x")]
-    #[test_case("Y" => "уай"; "y")]
-    #[test_case("Z" => "зед"; "z")]
+    #[test_case("X" => "икс"; "x")]
+    #[test_case("Y" => "вай"; "y")]
+    #[test_case("Z" => "зет"; "z")]
     fn letter(input: &str) -> String {
         normalizer().normalize(input)
     }
@@ -284,10 +246,10 @@ mod tests {
         normalizer().normalize(input)
     }
 
-    #[test_case("XYZ" => "экс уай зед"; "xyz")]
+    #[test_case("XYZ" => "икс вай зет"; "xyz")]
     #[test_case("ABC" => "эй би си"; "abc")]
     #[test_case("QRS" => "кью ар эс"; "qrs")]
-    #[test_case("WXYZ" => "дабл ю экс уай зед"; "wxyz")]
+    #[test_case("WXYZ" => "дабл ю икс вай зет"; "wxyz")]
     fn unknown_abbreviation(input: &str) -> String {
         normalizer().normalize(input)
     }
@@ -305,14 +267,20 @@ mod tests {
         normalizer().normalize(input)
     }
 
-    // --- Public accessors ---
+    // --- Shared letter-name table (#120) ---
 
     #[test]
-    fn test_letter_map_accessible() {
-        let map = letter_map();
-        assert_eq!(map.get(&'a'), Some(&"эй"));
-        assert_eq!(map.get(&'z'), Some(&"зед"));
-        assert_eq!(map.len(), 26);
+    fn letter_names_match_code_spelling() {
+        // One shared table: abbreviations and code identifiers read the
+        // same letter identically ("x" and "X" both → "икс").
+        for c in 'a'..='z' {
+            let s = c.to_string();
+            assert_eq!(
+                normalizer().normalize(&s),
+                super::super::code::CodeIdentifierNormalizer::spell_abbreviation(&s),
+                "letter {c} differs between abbreviation and code spelling"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/pipeline/normalizers/code.rs
+++ b/src-tauri/src/pipeline/normalizers/code.rs
@@ -605,35 +605,8 @@ impl CodeIdentifierNormalizer {
     }
 
     fn letter_name(c: char) -> &'static str {
-        match c.to_ascii_uppercase() {
-            'A' => "эй",
-            'B' => "би",
-            'C' => "си",
-            'D' => "ди",
-            'E' => "и",
-            'F' => "эф",
-            'G' => "джи",
-            'H' => "эйч",
-            'I' => "ай",
-            'J' => "джей",
-            'K' => "кей",
-            'L' => "эл",
-            'M' => "эм",
-            'N' => "эн",
-            'O' => "о",
-            'P' => "пи",
-            'Q' => "кью",
-            'R' => "ар",
-            'S' => "эс",
-            'T' => "ти",
-            'U' => "ю",
-            'V' => "ви",
-            'W' => "дабл ю",
-            'X' => "икс",
-            'Y' => "вай",
-            'Z' => "зет",
-            _ => "?",
-        }
+        // Shared letter-name table (#120) — same reading as abbreviations.
+        super::english::letter_name(c).unwrap_or("?")
     }
 
     fn basic_transliterate(&self, word: &str) -> String {

--- a/src-tauri/src/pipeline/normalizers/english.rs
+++ b/src-tauri/src/pipeline/normalizers/english.rs
@@ -2,6 +2,48 @@ use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
+/// English letter names — the single home for letter-name readings
+/// (issue #120). Used by abbreviation spelling, code-identifier spelling,
+/// and lone-letter reading, so "x" sounds "икс" in every context.
+/// Keys are lowercase.
+pub static LETTER_NAMES: [(char, &str); 26] = [
+    ('a', "эй"),
+    ('b', "би"),
+    ('c', "си"),
+    ('d', "ди"),
+    ('e', "и"),
+    ('f', "эф"),
+    ('g', "джи"),
+    ('h', "эйч"),
+    ('i', "ай"),
+    ('j', "джей"),
+    ('k', "кей"),
+    ('l', "эл"),
+    ('m', "эм"),
+    ('n', "эн"),
+    ('o', "о"),
+    ('p', "пи"),
+    ('q', "кью"),
+    ('r', "ар"),
+    ('s', "эс"),
+    ('t', "ти"),
+    ('u', "ю"),
+    ('v', "ви"),
+    ('w', "дабл ю"),
+    ('x', "икс"),
+    ('y', "вай"),
+    ('z', "зет"),
+];
+
+/// Look up an English letter name case-insensitively.
+pub fn letter_name(c: char) -> Option<&'static str> {
+    let lower = c.to_ascii_lowercase();
+    LETTER_NAMES
+        .iter()
+        .find(|(k, _)| *k == lower)
+        .map(|(_, v)| *v)
+}
+
 /// IT terms with established Russian pronunciation.
 ///
 /// Keys are lowercase English. Values are Russian phonetic spelling.


### PR DESCRIPTION
Closes #120.

## Summary

Two English letter-name tables drifted apart: `LETTER_MAP` (unknown all-caps abbreviations) read x/y/z as "экс/уай/зед", while `letter_name` (code identifiers, lone letters in prose since #109) read them "икс/вай/зет". Both are merged into one shared `LETTER_NAMES` table in `english.rs` with the "икс/вай/зет" readings — consistent with #109 and with `IT_TERMS` ("xml" → "икс эм эль").

**Behavior change:** only unknown all-caps abbreviations containing x/y/z ("UX" → "ю икс", "XSS" → "икс эс эс"). Lone letters and identifiers are unchanged.

OpenSpec change `unify-letter-tables` is archived in this PR; the `text-pipeline` spec is synced (new scenario "Unknown abbreviation with x/y/z").

## Changes

- `english.rs`: shared `LETTER_NAMES` + `letter_name()` lookup
- `abbreviations.rs`: `LETTER_MAP` / `letter_map()` removed, all paths use the shared table; expectations updated; new identity test (`letter_names_match_code_spelling`)
- `code.rs`: `letter_name` delegates to the shared table (behavior unchanged)
- `openspec/specs/text-pipeline/spec.md` synced + archived change

## Verification

- cargo fmt / clippy -D warnings: clean
- cargo test: 949 lib tests + golden fixtures green
- openspec validate --specs --strict: 12/12
- Note: reviewer subagent could not run (API quota); self-review done instead — no stale references, no leftover old readings
