### PR TITLE
fix(tts): kill the swapped-out engine's ttsd on cancel (#127)

### DIFF
--- a/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/design.md
+++ b/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/design.md
@@ -1,0 +1,55 @@
+# Design: Reach the swapped-out engine on cancel
+
+## Context
+
+`EngineSwitcher::apply_config` swaps `slot.engine` and drops the old
+`Arc<dyn TtsEngine>`. An in-flight `synthesize` future still holds its own
+`Arc` clone, so the old `TtsSupervisor` (and its ttsd child) stays alive
+until the request settles. When no reference remains, dropping the last
+`Arc<TtsSubprocess>` closes the driver channel; the driver task exits and
+`kill_on_drop` SIGKILLs the child — so an *idle* swapped-out engine cleans
+itself up and only the *in-flight* case leaks CPU.
+
+## Decision
+
+Store `last_silero: RwLock<Option<Weak<dyn TtsEngine>>>` in
+`EngineSwitcher`:
+
+- Set in `new()` when `initial_kind == Silero` (the startup-built engine is
+  otherwise unreachable after the first switch).
+- Reset in `apply_config` each time a Silero engine is built
+  (`Arc::downgrade`).
+- `kill_current_ttsd()` kills the current engine, then upgrades the weak
+  reference and kills that engine too when it is still alive.
+
+`Weak` (not `Arc`) is load-bearing: a strong reference would keep the
+swapped-out supervisor — and its idle ttsd child, via the driver's
+`kill_on_drop` semantics — alive forever, trading a CPU leak for a permanent
+process leak. When the in-flight synthesis finishes and drops its `Arc`,
+the weak reference dies on its own.
+
+## Rejected alternatives
+
+- **Kill the old engine on swap (`apply_config` calls
+  `old_engine.kill_current()`).** Aborts work the user never asked to
+  cancel, and is actively harmful: the killed handle fails in-flight
+  requests with `TtsError::Died`, and the orphaned supervisor's retry loop
+  would *respawn* a fresh ttsd and re-run the synthesis — more waste, not
+  less.
+- **Strong `previous_engine` slot.** Pins the old supervisor and its ttsd
+  child alive for the rest of the session even when nothing is running
+  (see above).
+- **Track every swapped-out engine (Vec of weak refs).** Covers the
+  double-switch-mid-synthesis edge (Silero → Piper → Silero while the
+  first synthesis still runs), but adds bookkeeping for a scenario that
+  requires two engine switches inside one synthesis window. One slot
+  covers the reported case; the edge is documented as a non-goal.
+
+## Testing
+
+Unit test in `switcher.rs`: a fake `TtsEngine` reporting
+`EngineKind::Silero` with a kill counter is installed as the initial
+engine; after `apply_config("piper", …)` swaps it out,
+`kill_current_ttsd()` must reach the fake (counter increments) while the
+caller still holds its `Arc` — mirroring the in-flight synthesis holding
+the engine alive.

--- a/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/proposal.md
+++ b/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: Cancel must reach the swapped-out engine's ttsd (#127)
+
+## Summary
+
+A synthesis is running on Silero; the user switches the engine to Piper
+mid-synthesis and then cancels the entry. The entry returns to `pending`,
+but `EngineSwitcher::kill_current_ttsd()` only reads the *current* engine
+slot, where Silero is already gone — the orphaned ttsd keeps burning CPU on
+the cancelled synthesis until it finishes (up to the 5-minute timeout).
+
+Keep a weak reference to the most recently built Silero engine in
+`EngineSwitcher` so `cancel_synthesis` can also terminate the previous
+engine's ttsd after a switch.
+
+## Capabilities
+
+- `ipc-commands` (modified — Synthesis Cancellation Command)
+
+## Non-goals
+
+- No kill-on-switch: swapping the engine does not, by itself, abort an
+  in-flight synthesis — only an explicit `cancel_synthesis` does.
+- No tracking of more than one swapped-out engine: a double switch
+  (Silero → Piper → Silero) while the first synthesis is still in flight
+  leaves that first orphan unreachable; this edge is accepted (see
+  design.md).
+
+## Approach
+
+`EngineSwitcher` gains a `last_silero: RwLock<Option<Weak<dyn TtsEngine>>>`
+slot, populated at construction (when the initial engine is Silero) and on
+every Silero build in `apply_config`. `kill_current_ttsd()` kills the
+current engine and then, if the weak reference is still alive, the previous
+one — a no-op for Piper and for already-dead handles, so the double kill
+when both point to the same engine is harmless.

--- a/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/specs/ipc-commands/spec.md
+++ b/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/specs/ipc-commands/spec.md
@@ -1,0 +1,64 @@
+# Delta: ipc-commands
+
+## MODIFIED Requirements
+
+### Requirement: Synthesis Cancellation Command
+
+The system SHALL provide `cancel_synthesis(id)` which actually stops the
+entry's synthesis work and sets the entry status back to `pending`, emitting
+`entry_updated`. Cancellation SHALL abort the entry's spawned synthesis task
+via a per-entry abort registry. If the cancelled entry had already entered
+the TTS stage, the system SHALL additionally terminate the current ttsd
+subprocess; recovery then follows the ttsd-protocol auto-restart procedure,
+and requests belonging to other entries are retried transparently. If the
+active engine was switched while the cancelled entry's synthesis was in
+flight, cancellation SHALL also terminate the previous engine's ttsd
+subprocess — the engine that is actually running the entry's request — so
+the orphaned process does not keep consuming CPU. A late
+completion or failure belonging to a cancelled entry SHALL be discarded: the
+entry MUST NOT flip to `ready` or `error`, any audio/timestamp files written
+by the late completion SHALL be removed, no further `entry_updated` for that
+completion is emitted, and no autoplay starts. A missing entry fails with
+`not_found`.
+
+#### Scenario: cancel a queued synthesis
+
+- GIVEN an entry with status `processing` whose request has not yet reached
+  ttsd
+- WHEN `cancel_synthesis` is invoked
+- THEN the synthesis task is aborted, the entry status becomes `pending`,
+  `entry_updated` is emitted, and the ttsd subprocess keeps running (no
+  restart)
+
+#### Scenario: cancel an in-flight synthesis
+
+- GIVEN an entry with status `processing` whose request is being synthesized
+  by ttsd
+- WHEN `cancel_synthesis` is invoked
+- THEN the synthesis task is aborted, the ttsd subprocess is terminated, the
+  supervisor restarts it per the auto-restart procedure, and the entry
+  status becomes `pending`
+
+#### Scenario: cancel after an engine switch
+
+- GIVEN an entry with status `processing` whose request is being synthesized
+  by ttsd on the Silero engine
+- WHEN the active engine is switched to Piper and `cancel_synthesis` is then
+  invoked for that entry
+- THEN the synthesis task is aborted, the entry status becomes `pending`,
+  and the swapped-out Silero engine's ttsd subprocess is terminated
+
+#### Scenario: late completion is discarded
+
+- GIVEN an entry that was cancelled back to `pending` while its request was
+  in flight
+- WHEN the orphaned request completes
+- THEN the entry remains `pending`, the generated audio/timestamp files are
+  removed, no `entry_updated` with `ready` is emitted, and no autoplay
+  starts
+
+#### Scenario: cancel a missing entry
+
+- GIVEN no entry with the given id
+- WHEN `cancel_synthesis` is invoked
+- THEN the command fails with `not_found`

--- a/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/tasks.md
+++ b/openspec/changes/archive/2026-07-27-fix-cancel-after-engine-switch/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Cancel must reach the swapped-out engine's ttsd
+
+## Implementation
+
+- [x] `src-tauri/src/tts/switcher.rs` — add
+  `last_silero: RwLock<Option<Weak<dyn TtsEngine>>>` to `EngineSwitcher`;
+  populate it in `new()` (when the initial engine is Silero) and in
+  `apply_config` (on every Silero build); `kill_current_ttsd()` kills the
+  current engine and then the weak-referenced previous one when still
+  alive.
+- [x] Unit test: initial fake Silero engine with a kill counter is swapped
+  out via `apply_config("piper", …)`; `kill_current_ttsd()` reaches the
+  swapped-out engine while its `Arc` is still held.
+
+## Validation
+
+- [x] `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml` green.
+- [x] `nix develop -c just lint` green.
+- [x] openspec validate fix-cancel-after-engine-switch --strict green.

--- a/openspec/specs/ipc-commands/spec.md
+++ b/openspec/specs/ipc-commands/spec.md
@@ -223,7 +223,11 @@ entry's synthesis work and sets the entry status back to `pending`, emitting
 via a per-entry abort registry. If the cancelled entry had already entered
 the TTS stage, the system SHALL additionally terminate the current ttsd
 subprocess; recovery then follows the ttsd-protocol auto-restart procedure,
-and requests belonging to other entries are retried transparently. A late
+and requests belonging to other entries are retried transparently. If the
+active engine was switched while the cancelled entry's synthesis was in
+flight, cancellation SHALL also terminate the previous engine's ttsd
+subprocess — the engine that is actually running the entry's request — so
+the orphaned process does not keep consuming CPU. A late
 completion or failure belonging to a cancelled entry SHALL be discarded: the
 entry MUST NOT flip to `ready` or `error`, any audio/timestamp files written
 by the late completion SHALL be removed, no further `entry_updated` for that
@@ -247,6 +251,15 @@ completion is emitted, and no autoplay starts. A missing entry fails with
 - THEN the synthesis task is aborted, the ttsd subprocess is terminated, the
   supervisor restarts it per the auto-restart procedure, and the entry
   status becomes `pending`
+
+#### Scenario: cancel after an engine switch
+
+- GIVEN an entry with status `processing` whose request is being synthesized
+  by ttsd on the Silero engine
+- WHEN the active engine is switched to Piper and `cancel_synthesis` is then
+  invoked for that entry
+- THEN the synthesis task is aborted, the entry status becomes `pending`,
+  and the swapped-out Silero engine's ttsd subprocess is terminated
 
 #### Scenario: late completion is discarded
 

--- a/src-tauri/src/tts/switcher.rs
+++ b/src-tauri/src/tts/switcher.rs
@@ -11,7 +11,7 @@
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 use tokio::sync::RwLock;
@@ -27,6 +27,14 @@ pub struct EngineSwitcher {
     /// Last-installed kind, mirrored as an atomic so the sync `kind()` impl
     /// does not need to acquire the RwLock.
     kind: AtomicU8,
+    /// Weak reference to the most recently built Silero engine. A synthesis
+    /// started on Silero keeps the engine alive via its own `Arc` even after
+    /// the engine is swapped out, so this lets `kill_current_ttsd` still
+    /// reach and terminate the orphaned ttsd on cancel (#127). Weak, not
+    /// strong: pinning the supervisor would keep its idle ttsd child alive
+    /// for the rest of the session (the driver only SIGKILLs the child via
+    /// `kill_on_drop` once the last `Arc` is gone).
+    last_silero: RwLock<Option<Weak<dyn TtsEngine>>>,
     piper_voices_dir: PathBuf,
     ttsd_dir: PathBuf,
     emitter: Emitter,
@@ -69,12 +77,14 @@ impl EngineSwitcher {
         ttsd_dir: PathBuf,
         emitter: Emitter,
     ) -> Self {
+        let last_silero = (initial_kind == EngineKind::Silero).then(|| Arc::downgrade(&initial));
         Self {
             inner: RwLock::new(Slot {
                 engine: initial,
                 piper_voice: initial_piper_voice,
             }),
             kind: AtomicU8::new(kind_to_u8(initial_kind)),
+            last_silero: RwLock::new(last_silero),
             piper_voices_dir,
             ttsd_dir,
             emitter,
@@ -113,6 +123,10 @@ impl EngineSwitcher {
             EngineKind::Silero => (self.build_silero()?, None),
         };
 
+        if target_kind == EngineKind::Silero {
+            *self.last_silero.write().await = Some(Arc::downgrade(&new_engine));
+        }
+
         {
             let mut slot = self.inner.write().await;
             slot.engine = Arc::clone(&new_engine);
@@ -150,12 +164,32 @@ impl EngineSwitcher {
 
     /// Terminate the current ttsd subprocess when Silero is the active
     /// engine; no-op for Piper (in-process synthesis has no subprocess to
-    /// kill). Reaches [`TtsSupervisor::kill_current`] through the
-    /// [`TtsEngine`] trait, so no concrete supervisor handle is stored here.
+    /// kill). Also terminates the most recently built Silero engine when it
+    /// is still alive: a synthesis started on Silero keeps that engine
+    /// running after a mid-synthesis engine switch, and its orphaned ttsd
+    /// would otherwise keep burning CPU on the cancelled request (#127).
+    /// When both references point at the same engine (Silero is active),
+    /// only one kill is issued. Reaches [`TtsSupervisor::kill_current`]
+    /// through the [`TtsEngine`] trait, so no concrete supervisor handle is
+    /// stored here.
     /// Called by `cancel_synthesis` when the cancelled entry had entered the
     /// TTS stage.
     pub async fn kill_current_ttsd(&self) {
-        self.current_engine().await.kill_current().await;
+        let current = self.current_engine().await;
+        current.kill_current().await;
+        let previous = self
+            .last_silero
+            .read()
+            .await
+            .as_ref()
+            .and_then(Weak::upgrade);
+        if let Some(previous) = previous {
+            // Skip the second kill when both references point at the same
+            // engine (Silero is active): one SIGKILL is enough.
+            if !Arc::ptr_eq(&previous, &current) {
+                previous.kill_current().await;
+            }
+        }
     }
 }
 
@@ -202,8 +236,11 @@ impl TtsEngine for EngineSwitcher {
         self.current_engine().await.shutdown().await
     }
 
+    /// Delegate to [`EngineSwitcher::kill_current_ttsd`] so callers behind
+    /// `Arc<dyn TtsEngine>` get the same kill semantics as the direct path
+    /// (current engine plus a swapped-out Silero, #127).
     async fn kill_current(&self) {
-        self.current_engine().await.kill_current().await;
+        self.kill_current_ttsd().await;
     }
 }
 
@@ -279,5 +316,125 @@ mod tests {
             TtsError::Ttsd { code, .. } => assert_eq!(code, "engine_unknown"),
             other => panic!("expected engine_unknown, got {other:?}"),
         }
+    }
+
+    /// Fake engine reporting `EngineKind::Silero` with a kill counter, so
+    /// tests can observe `kill_current` calls without spawning a real ttsd.
+    /// The counter sits behind an `Arc` so the test can still inspect it
+    /// after every engine reference is dropped.
+    struct FakeSilero {
+        kills: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl FakeSilero {
+        fn new() -> (Self, Arc<std::sync::atomic::AtomicUsize>) {
+            let kills = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            (
+                Self {
+                    kills: Arc::clone(&kills),
+                },
+                kills,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl TtsEngine for FakeSilero {
+        fn kind(&self) -> EngineKind {
+            EngineKind::Silero
+        }
+
+        async fn warmup(&self) -> Result<(), TtsError> {
+            Ok(())
+        }
+
+        async fn spawn_initial_warmup(&self) {}
+
+        async fn synthesize(
+            &self,
+            _text: String,
+            _voice: String,
+            _sample_rate: u32,
+            _out_wav: String,
+            _char_mapping: Option<Vec<CharMappingEntry>>,
+        ) -> Result<SynthesizeOutput, TtsError> {
+            unimplemented!("tests never synthesize on the fake")
+        }
+
+        async fn shutdown(&self) -> Result<(), TtsError> {
+            Ok(())
+        }
+
+        async fn kill_current(&self) {
+            self.kills.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn silero_switcher(
+        initial: Arc<dyn TtsEngine>,
+    ) -> (EngineSwitcher, tempfile::TempDir, tempfile::TempDir) {
+        let (emitter, _) = recording_emitter();
+        let voices_tmp = tempfile::TempDir::new().expect("voices tempdir");
+        let ttsd_tmp = tempfile::TempDir::new().expect("ttsd tempdir");
+        let switcher = EngineSwitcher::new(
+            initial,
+            EngineKind::Silero,
+            None,
+            voices_tmp.path().to_path_buf(),
+            ttsd_tmp.path().to_path_buf(),
+            emitter,
+        );
+        (switcher, voices_tmp, ttsd_tmp)
+    }
+
+    #[tokio::test]
+    async fn kill_current_ttsd_reaches_engine_swapped_out_mid_synthesis() {
+        // #127: a synthesis started on Silero keeps the engine alive after a
+        // switch (the in-flight future holds its own Arc, played here by
+        // `fake`); cancel must still reach that engine's ttsd, not only the
+        // current slot.
+        let (fake_engine, kills) = FakeSilero::new();
+        let fake: Arc<dyn TtsEngine> = Arc::new(fake_engine);
+        let (sw, _voices_tmp, _ttsd_tmp) = silero_switcher(Arc::clone(&fake));
+
+        sw.apply_config("piper", "ruslan").await.unwrap();
+        assert_eq!(sw.kind(), EngineKind::Piper);
+
+        sw.kill_current_ttsd().await;
+        assert_eq!(
+            kills.load(Ordering::SeqCst),
+            1,
+            "cancel must kill the swapped-out engine's ttsd"
+        );
+    }
+
+    #[tokio::test]
+    async fn kill_current_ttsd_ignores_fully_dropped_previous_engine() {
+        // When nothing holds the swapped-out engine anymore (its synthesis
+        // already settled), the weak reference is dead and the kill must be
+        // a no-op — the child is already gone via `kill_on_drop`.
+        let (fake_engine, kills) = FakeSilero::new();
+        let (sw, _voices_tmp, _ttsd_tmp) = {
+            let fake: Arc<dyn TtsEngine> = Arc::new(fake_engine);
+            let (sw, voices_tmp, ttsd_tmp) = silero_switcher(fake);
+            sw.apply_config("piper", "ruslan").await.unwrap();
+            (sw, voices_tmp, ttsd_tmp)
+            // Last Arc<FakeSilero> dropped here → weak reference is dead.
+        };
+
+        sw.kill_current_ttsd().await;
+        assert_eq!(kills.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn kill_current_ttsd_kills_active_silero_only_once() {
+        // Silero active and also referenced by `last_silero`: the dedup must
+        // collapse both references into a single kill.
+        let (fake_engine, kills) = FakeSilero::new();
+        let fake: Arc<dyn TtsEngine> = Arc::new(fake_engine);
+        let (sw, _voices_tmp, _ttsd_tmp) = silero_switcher(fake);
+
+        sw.kill_current_ttsd().await;
+        assert_eq!(kills.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Summary

- `EngineSwitcher` keeps a `Weak` reference to the most recently built
  Silero engine, so `cancel_synthesis` can still terminate the previous
  engine's ttsd after a mid-synthesis engine switch (#127)
- `kill_current_ttsd()` kills the current engine plus the still-alive
  previous one, deduped via `Arc::ptr_eq`; the trait `kill_current`
  delegates to it — one kill semantics for both call paths
- Archived OpenSpec change `fix-cancel-after-engine-switch`; synced
  `ipc-commands` spec gains a "cancel after an engine switch" scenario

## Why Weak and not Arc

A strong reference would pin the swapped-out supervisor — and its idle
ttsd child — alive for the rest of the session (the driver SIGKILLs the
child via `kill_on_drop` only once the last `Arc` is gone). With `Weak`
the reference dies on its own when the in-flight synthesis drops its
`Arc`. Rejected alternatives (kill-on-switch, tracking every swapped-out
engine) are recorded in the change's design.md.

## Test plan

- [x] `cargo test` — 3 new switcher unit tests: cancel reaches the
  swapped-out engine, dead weak ref is a no-op, active Silero killed once
- [x] `just lint`
- [x] `openspec validate --strict`

Closes #127
