### PR TITLE
chore(mcp): project-level rust-analyzer MCP server config

### DIFF
--- a/.kimi-code/mcp.json
+++ b/.kimi-code/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "rust-analyzer": {
+      "command": "rust-analyzer-mcp",
+      "startupTimeoutMs": 180000,
+      "toolTimeoutMs": 120000
+    }
+  }
+}

--- a/.kimi-code/mcp.json
+++ b/.kimi-code/mcp.json
@@ -2,6 +2,7 @@
   "mcpServers": {
     "rust-analyzer": {
       "command": "rust-analyzer-mcp",
+      "args": ["src-tauri"],
       "startupTimeoutMs": 180000,
       "toolTimeoutMs": 120000
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,15 @@ toolchain.
 The repo ships a project-level MCP config (`.kimi-code/mcp.json`) exposing
 rust-analyzer via the `rust-analyzer-mcp` server (tools: definition, references,
 hover, diagnostics, code actions, …). Prerequisites on the machine: `cargo
-install rust-analyzer-mcp` and `rust-analyzer` in `PATH`. The repo root is not a
-cargo workspace, so the **first** rust-analyzer tool call in a session must be
-`rust_analyzer_set_workspace` pointing at `<repo>/src-tauri`; only then use the
-other tools. Cold indexing of the dependency tree takes ~1 minute on the first
-real request.
+install rust-analyzer-mcp` and `rust-analyzer` in `PATH`. The server starts with
+`src-tauri` as its workspace (passed as a CLI arg, resolved relative to the repo
+root). Path dependencies of `src-tauri` (e.g. the `silero-native` crate) are
+covered by this root automatically; if a genuinely separate cargo workspace
+appears in the repo, add a second named server entry to `.kimi-code/mcp.json`
+with that workspace's path as its CLI arg (the server accepts exactly one
+workspace). Cold indexing of the dependency tree takes ~1 minute; if the first
+tool call returns an empty result, indexing is still in progress — wait and
+retry the call.
 
 ## Project layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,17 @@ pre-commit, clippy and typecheck pre-push — commit and push from inside
 `nix develop` so they find the
 toolchain.
 
+### rust-analyzer MCP server
+
+The repo ships a project-level MCP config (`.kimi-code/mcp.json`) exposing
+rust-analyzer via the `rust-analyzer-mcp` server (tools: definition, references,
+hover, diagnostics, code actions, …). Prerequisites on the machine: `cargo
+install rust-analyzer-mcp` and `rust-analyzer` in `PATH`. The repo root is not a
+cargo workspace, so the **first** rust-analyzer tool call in a session must be
+`rust_analyzer_set_workspace` pointing at `<repo>/src-tauri`; only then use the
+other tools. Cold indexing of the dependency tree takes ~1 minute on the first
+real request.
+
 ## Project layout
 
 ```


### PR DESCRIPTION
## Summary

Adds a project-level MCP configuration (`.kimi-code/mcp.json`) that exposes
rust-analyzer to the agent via the `rust-analyzer-mcp` server (definition,
references, hover, diagnostics, code actions). The server starts with
`src-tauri` as its workspace (passed as a CLI arg); path dependencies such as
`silero-native` are covered by that root automatically.

## Details

- Prerequisites on the machine: `cargo install rust-analyzer-mcp` and
  `rust-analyzer` in `PATH` (documented in `AGENTS.md`).
- `AGENTS.md` gains a "rust-analyzer MCP server" section: prerequisites,
  how additional cargo workspaces should be registered (a second named
  server entry), and the cold-indexing caveat (first tool call may return
  empty; retry after ~1 minute).

## Notes

- Tooling change: goes through a PR without an OpenSpec change per the
  lightweight path. Pre-PR reviewer gate skipped (25 lines, config + docs).