### PR TITLE
feat(ui): highlight the upcoming word in gaps between words (#78)

### DIFF
--- a/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/design.md
+++ b/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/design.md
@@ -1,0 +1,43 @@
+# Design: Upcoming-word highlighting in gaps
+
+## Context
+
+`findActiveTimestamp` binary-searches the word active at `positionSec`. Its
+post-loop `lo` index already is the answer for gaps: by the loop invariant
+every word before `lo` has `end <= positionSec` and every word from `lo` on
+has `start > positionSec`, so `lo` is exactly the closest upcoming word.
+The dead `if`/`return -1` block suggests the author intended to use it and
+never did. All three timestamp producers (ttsd, silero-native
+char-proportional, piper) emit lists sorted by `start`; nothing asserted
+this at the boundary.
+
+## Decision
+
+- Gap → `return lo` (upcoming word). Past the last word's end (`lo ==
+  timestamps.length`) → -1, as before.
+- The invariant is documented on `findActiveTimestamp` and enforced by a
+  dev-only `debugAssertSortedTimestamps()` invoked once per timestamp load
+  (both load sites in `TextViewer.tsx`), not per `playback_position` event.
+
+## Rejected alternatives
+
+- **Keep the previous word highlighted through the gap** (common in
+  read-along UIs): contradicts the original code's documented intent
+  ("closest upcoming word") and the issue's framing; highlighting ahead of
+  speech also doubles as a visual prefetch cue. Can be revisited if the
+  ahead-of-time highlight feels wrong in practice.
+- **Assert inside `findActiveTimestamp`**: it runs on every
+  `playback_position` event; an O(n) check per tick is wasteful when the
+  list never changes between loads. Checking at load time covers the same
+  invariant once per entry.
+- **Throw on unsorted input instead of `console.assert`**: unsorted input
+  is a producer bug, but crashing playback highlighting in a dev build
+  blocks unrelated manual testing; a loud console assertion is enough.
+
+## Testing
+
+Update `wordHighlight.test.ts`: gap/before-first cases now expect the
+upcoming index; the unsorted-input case pins the new (still wrong, still
+documented) answer. New cases: gap picks the *immediate* next word among
+several; position past the last word stays -1; `debugAssertSortedTimestamps`
+fires `console.assert` on unsorted input and stays silent on sorted input.

--- a/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/proposal.md
+++ b/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: Highlight the upcoming word in gaps between words (#78)
+
+## Summary
+
+`findActiveTimestamp` returns -1 for playback positions in a gap between
+words, so the highlight blinks out during every pause. A leftover comment
+("find the closest upcoming word") shows the intended behavior was never
+implemented — both post-loop branches return -1.
+
+Resolve gap positions to the closest upcoming word (the next word lights up
+ahead of its interval), document the sorted-by-`start` invariant the binary
+search relies on, and assert it in development builds where timestamps are
+loaded.
+
+## Capabilities
+
+- `word-highlight` (modified — Active word detection)
+
+## Non-goals
+
+- No threshold on the gap size: any position before the next word's start
+  highlights that word, however long the pause.
+- No runtime validation in production builds: the sorted invariant is
+  guaranteed by all current producers (ttsd, piper, silero-native) and is
+  asserted in dev builds only.
+- No change to span lookup, styling, or auto-scroll.
+
+## Approach
+
+- `findActiveTimestamp`: after the binary-search loop, `lo` already points
+  at the first word with `start > positionSec` — return it instead of -1;
+  return -1 only when `lo` is past the end.
+- Document the sorted invariant in the function's JSDoc.
+- New exported `debugAssertSortedTimestamps()` (dev-only, `console.assert`)
+  called at both timestamp-load sites in `TextViewer.tsx`.

--- a/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/specs/word-highlight/spec.md
+++ b/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/specs/word-highlight/spec.md
@@ -1,0 +1,49 @@
+# Delta: word-highlight
+
+## MODIFIED Requirements
+
+### Requirement: Active word detection
+
+On every `playback_position` event the system SHALL binary-search the
+timestamp active at `position_sec` (a timestamp `t` is active when
+`t.start <= position_sec < t.end`). A position falling in a gap between
+words SHALL resolve to the closest upcoming word, so the next word is
+highlighted ahead of its interval instead of the highlight blinking out
+during a pause; only a position at or past the last word's `end` SHALL
+produce no active word. The timestamp list MUST be sorted by `start`
+ascending — the binary search silently misses matches otherwise; all
+producers (ttsd, piper, silero-native) emit sorted lists, and the invariant
+SHALL be asserted in development builds when timestamps are loaded.
+Highlighting SHALL update only when the active word index changes, and MUST
+be ignored when the event's `entry_id` does not match the displayed entry.
+
+#### Scenario: Word under playback position
+
+- GIVEN timestamps for the playing entry and a `playback_position` event
+- WHEN `position_sec` falls inside a word's `[start, end)` interval
+- THEN exactly that word's span receives the highlight
+
+#### Scenario: Gap between words highlights the upcoming word
+
+- GIVEN timestamps with a pause between word N and word N+1
+- WHEN `position_sec` falls inside that gap
+- THEN word N+1's span receives the highlight ahead of its interval
+
+#### Scenario: Position past the last word
+
+- GIVEN timestamps for the playing entry
+- WHEN `position_sec` is at or past the last word's `end`
+- THEN no span is highlighted
+
+#### Scenario: Unsorted timestamps flagged in development
+
+- GIVEN a development build and a `WordTimestamp[]` that is not sorted by
+  `start`
+- WHEN the timestamps are loaded for highlighting
+- THEN a console assertion flags the violated invariant
+
+#### Scenario: Event for another entry
+
+- GIVEN the viewer displays entry A while entry B is playing
+- WHEN a `playback_position` event for entry B arrives
+- THEN no highlight changes in the viewer

--- a/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/tasks.md
+++ b/openspec/changes/archive/2026-07-30-highlight-upcoming-word-in-gaps/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Highlight the upcoming word in gaps
+
+## Implementation
+
+- [x] `src/lib/wordHighlight.ts` — `findActiveTimestamp` returns the closest
+  upcoming word's index in gaps (`return lo` when `lo < len`); JSDoc
+  documents the sorted-by-`start` invariant.
+- [x] `src/lib/wordHighlight.ts` — new dev-only
+  `debugAssertSortedTimestamps()` (`import.meta.env.DEV` gate,
+  `console.assert` per out-of-order pair).
+- [x] `src/components/TextViewer.tsx` — call `debugAssertSortedTimestamps`
+  at both timestamp-load sites (prefetch effect and `playbackStarted`
+  handler).
+
+## Tests
+
+- [x] Update `wordHighlight.test.ts`: before-first and gap cases expect the
+  upcoming index; unsorted case pins the new documented answer.
+- [x] New cases: gap picks the immediate next word among several; past the
+  last word stays -1; `debugAssertSortedTimestamps` asserts on unsorted
+  input and is silent on sorted input.
+
+## Validation
+
+- [x] `nix develop -c pnpm test:unit` green.
+- [x] `nix develop -c just lint` green.
+- [x] openspec validate highlight-upcoming-word-in-gaps --strict green.

--- a/openspec/specs/word-highlight/spec.md
+++ b/openspec/specs/word-highlight/spec.md
@@ -28,16 +28,41 @@ refetched when the playing entry changes.
 
 On every `playback_position` event the system SHALL binary-search the
 timestamp active at `position_sec` (a timestamp `t` is active when
-`t.start <= position_sec < t.end`). Positions falling in a gap between words
-SHALL produce no active word. Highlighting SHALL update only when the active
-word index changes, and MUST be ignored when the event's `entry_id` does not
-match the displayed entry.
+`t.start <= position_sec < t.end`). A position falling in a gap between
+words SHALL resolve to the closest upcoming word, so the next word is
+highlighted ahead of its interval instead of the highlight blinking out
+during a pause; only a position at or past the last word's `end` SHALL
+produce no active word. The timestamp list MUST be sorted by `start`
+ascending — the binary search silently misses matches otherwise; all
+producers (ttsd, piper, silero-native) emit sorted lists, and the invariant
+SHALL be asserted in development builds when timestamps are loaded.
+Highlighting SHALL update only when the active word index changes, and MUST
+be ignored when the event's `entry_id` does not match the displayed entry.
 
 #### Scenario: Word under playback position
 
 - GIVEN timestamps for the playing entry and a `playback_position` event
 - WHEN `position_sec` falls inside a word's `[start, end)` interval
 - THEN exactly that word's span receives the highlight
+
+#### Scenario: Gap between words highlights the upcoming word
+
+- GIVEN timestamps with a pause between word N and word N+1
+- WHEN `position_sec` falls inside that gap
+- THEN word N+1's span receives the highlight ahead of its interval
+
+#### Scenario: Position past the last word
+
+- GIVEN timestamps for the playing entry
+- WHEN `position_sec` is at or past the last word's `end`
+- THEN no span is highlighted
+
+#### Scenario: Unsorted timestamps flagged in development
+
+- GIVEN a development build and a `WordTimestamp[]` that is not sorted by
+  `start`
+- WHEN the timestamps are loaded for highlighting
+- THEN a console assertion flags the violated invariant
 
 #### Scenario: Event for another entry
 

--- a/src/components/TextViewer.tsx
+++ b/src/components/TextViewer.tsx
@@ -20,6 +20,7 @@ import {
   findActiveTimestamp,
   applyHighlight,
   clearHighlight,
+  debugAssertSortedTimestamps,
 } from '../lib/wordHighlight';
 import { plainToWordHtml } from '../lib/plainTextHtml';
 import classes from './TextViewer.module.css';
@@ -99,6 +100,7 @@ export function TextViewer({ entry }: Props) {
       .getTimestamps(entry.id)
       .then((ts) => {
         if (cancelled) return;
+        debugAssertSortedTimestamps(ts);
         timestampsRef.current = ts;
         playingEntryIdRef.current = entry.id;
       })
@@ -188,6 +190,7 @@ export function TextViewer({ entry }: Props) {
       .playbackStarted(async ({ entry_id }) => {
         try {
           const ts = await commands.getTimestamps(entry_id);
+          debugAssertSortedTimestamps(ts);
           timestampsRef.current = ts;
           playingEntryIdRef.current = entry_id;
           activeIdxRef.current = -1;

--- a/src/lib/wordHighlight.test.ts
+++ b/src/lib/wordHighlight.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { WordTimestamp } from './tauri';
 import {
   applyHighlight,
   clearHighlight,
+  debugAssertSortedTimestamps,
   findActiveTimestamp,
 } from './wordHighlight';
 
@@ -25,10 +26,10 @@ describe('findActiveTimestamp', () => {
       expected: -1,
     },
     {
-      name: 'returns -1 when position is before the first timestamp',
+      name: 'before the first timestamp, highlights the upcoming first word',
       list: [ts(1, 2)],
       pos: 0,
-      expected: -1,
+      expected: 0,
     },
     {
       name: 'returns -1 when position is after the last timestamp',
@@ -49,7 +50,7 @@ describe('findActiveTimestamp', () => {
       expected: 0,
     },
     {
-      name: 'excludes the interval end (upper bound is exclusive)',
+      name: 'at the interval end of the last word, no upcoming word remains',
       list: [ts(1, 2)],
       pos: 2,
       expected: -1,
@@ -61,10 +62,16 @@ describe('findActiveTimestamp', () => {
       expected: 1,
     },
     {
-      name: 'returns -1 for a position that falls in a gap between intervals',
+      name: 'in a gap between intervals, highlights the closest upcoming word',
       list: [ts(0, 1), ts(2, 3)],
       pos: 1.5,
-      expected: -1,
+      expected: 1,
+    },
+    {
+      name: 'in a gap among several intervals, picks the immediate next word',
+      list: [ts(0, 1), ts(2, 3), ts(4, 5)],
+      pos: 1.5,
+      expected: 1,
     },
     {
       name: 'finds the interval at the start among several intervals',
@@ -92,18 +99,51 @@ describe('findActiveTimestamp', () => {
     },
     {
       // findActiveTimestamp is a binary search: it assumes timestamps are
-      // sorted ascending by start. If that invariant is violated, a real
+      // sorted ascending by start. If that invariant is violated, the real
       // match can be missed entirely — here index 2 genuinely contains
-      // position 0.5, but the search prunes it away and returns -1.
+      // position 0.5, but the search prunes it away and falls through to
+      // the upcoming-word fallback, returning index 0 (also wrong: word
+      // 0 is 100+ seconds away).
       // This case pins down current (surprising) behavior; it does not
-      // assert that -1 is the "right" answer.
+      // assert that 0 is the "right" answer.
       name: 'documents current behavior when timestamps are not sorted ascending',
       list: [ts(100, 101), ts(102, 103), ts(0, 1), ts(104, 105)],
       pos: 0.5,
-      expected: -1,
+      expected: 0,
     },
   ])('$name', ({ list, pos, expected }) => {
     expect(findActiveTimestamp(list, pos)).toBe(expected);
+  });
+});
+
+describe('debugAssertSortedTimestamps', () => {
+  // Without this a failing expect would leak the console.assert mock into
+  // the rest of the file (vitest restoreMocks defaults to false).
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** console.assert(condition, …) fires per pair — count the failing ones. */
+  function failedAssertions(spy: ReturnType<typeof vi.spyOn>) {
+    return spy.mock.calls.filter(([condition]) => condition === false);
+  }
+
+  it('stays silent on sorted timestamps', () => {
+    const assertSpy = vi.spyOn(console, 'assert').mockImplementation(() => {});
+    debugAssertSortedTimestamps([ts(0, 1), ts(1, 2), ts(2, 3)]);
+    expect(failedAssertions(assertSpy)).toHaveLength(0);
+  });
+
+  it('tolerates equal starts (non-decreasing order is enough)', () => {
+    const assertSpy = vi.spyOn(console, 'assert').mockImplementation(() => {});
+    debugAssertSortedTimestamps([ts(0, 1), ts(0.5, 2), ts(2, 3)]);
+    expect(failedAssertions(assertSpy)).toHaveLength(0);
+  });
+
+  it('flags every out-of-order pair', () => {
+    const assertSpy = vi.spyOn(console, 'assert').mockImplementation(() => {});
+    debugAssertSortedTimestamps([ts(0, 1), ts(5, 6), ts(2, 3), ts(1, 4)]);
+    expect(failedAssertions(assertSpy)).toHaveLength(2);
   });
 });
 

--- a/src/lib/wordHighlight.ts
+++ b/src/lib/wordHighlight.ts
@@ -3,8 +3,21 @@ import type { WordTimestamp } from './tauri';
 const HIGHLIGHT_CLASS = 'word-highlight';
 
 /**
- * Binary search: find the index of the timestamp active at `positionSec`.
- * Returns -1 if no timestamp covers this position.
+ * Binary search: find the index of the timestamp active at `positionSec`
+ * (active when `start <= positionSec < end`).
+ *
+ * `timestamps` MUST be sorted by `start` ascending and non-overlapping —
+ * the search silently misses matches otherwise. All producers (ttsd, piper,
+ * silero-native) emit sorted, contiguous lists; the sorted half of the
+ * invariant is asserted in dev builds where timestamps are loaded (see
+ * {@link debugAssertSortedTimestamps}).
+ *
+ * A position in a gap between words resolves to the closest upcoming word:
+ * by the loop invariant every word before `lo` has `end <= positionSec`
+ * and every word from `lo` on has `start > positionSec`, so the next word
+ * lights up ahead of its interval instead of the highlight blinking out
+ * during the pause. Returns -1 only when the position is at or past the
+ * last word's `end` (or the list is empty).
  */
 export function findActiveTimestamp(
   timestamps: WordTimestamp[],
@@ -27,11 +40,31 @@ export function findActiveTimestamp(
     }
   }
 
-  // positionSec is in a gap between words — find the closest upcoming word
-  if (lo < timestamps.length && positionSec < timestamps[lo].start) {
-    return -1;
+  // Gap between words — highlight the closest upcoming word.
+  return lo < timestamps.length ? lo : -1;
+}
+
+/**
+ * Dev-only assertion of the sorted-by-`start` half of the invariant
+ * {@link findActiveTimestamp} relies on (the other half — non-overlapping
+ * intervals — is guaranteed by all current producers and not checked here).
+ * Logs a console assertion for every
+ * out-of-order pair; no-op in production builds. Call once per timestamp
+ * load — the list does not change between `playback_position` events, so
+ * checking per event would be waste.
+ */
+export function debugAssertSortedTimestamps(
+  timestamps: WordTimestamp[],
+): void {
+  if (!import.meta.env.DEV) return;
+  for (let i = 1; i < timestamps.length; i++) {
+    console.assert(
+      timestamps[i].start >= timestamps[i - 1].start,
+      `word timestamps must be sorted by start; ` +
+        `entry at index ${i} starts at ${timestamps[i].start} ` +
+        `after ${timestamps[i - 1].start}`,
+    );
   }
-  return -1;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Gap positions in `findActiveTimestamp` resolve to the closest upcoming
  word (the post-loop `lo` already points at it) — the highlight no longer
  blinks out during pauses between words (#78)
- The sorted-by-`start`, non-overlapping invariant is documented and
  asserted in dev builds via `debugAssertSortedTimestamps()`, called once
  per timestamp load in `TextViewer` (not per `playback_position` event)
- Archived OpenSpec change `highlight-upcoming-word-in-gaps`; the
  `word-highlight` spec's "Active word detection" requirement gains gap /
  past-last-word / dev-assertion scenarios

## Notes

- Ahead-of-time highlighting also scrolls the upcoming word into view
  during the pause — accepted as a visual prefetch cue (design.md records
  the rejected "keep previous word highlighted" alternative)
- Reviewer findings folded in: `afterEach(vi.restoreAllMocks)` guards the
  console.assert spy against leaking on failure; JSDoc carries the full
  invariant

## Test plan

- [x] `pnpm test:unit` — 95 tests, incl. new gap / upcoming-word /
  debug-assert cases and the re-pinned unsorted-input case
- [x] `just lint`
- [x] `openspec validate --strict`

Closes #78
