### PR TITLE
build(lint): run clippy with --all-targets in every gate (#148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           workspaces: "src-tauri\nsilero-native"
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
       - run: cargo fmt --manifest-path silero-native/Cargo.toml -- --check
-      - run: cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings
-      - run: cargo clippy --manifest-path silero-native/Cargo.toml --no-deps -- -D warnings
+      - run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --no-deps -- -D warnings
+      - run: cargo clippy --manifest-path silero-native/Cargo.toml --all-targets --no-deps -- -D warnings
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check

--- a/justfile
+++ b/justfile
@@ -37,8 +37,8 @@ test-python:
 lint:
     cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
     cargo fmt --manifest-path silero-native/Cargo.toml -- --check
-    cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings
-    cargo clippy --manifest-path silero-native/Cargo.toml --no-deps -- -D warnings
+    cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --no-deps -- -D warnings
+    cargo clippy --manifest-path silero-native/Cargo.toml --all-targets --no-deps -- -D warnings
     cargo deny --manifest-path src-tauri/Cargo.toml check
     pnpm lint
     pnpm knip

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,7 +14,7 @@ pre-push:
   parallel: true
   commands:
     cargo-clippy:
-      run: cargo clippy --manifest-path src-tauri/Cargo.toml --no-deps -- -D warnings
+      run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --no-deps -- -D warnings
     typescript:
       run: pnpm typecheck
     eslint:


### PR DESCRIPTION
## Summary

- The original `--all-targets` failure (`await_holding_lock` in
  `src/test_support.rs`) is already fixed on main (cd58d33); what remained
  is flag drift: `just lint`, lefthook and CI ran clippy without
  `--all-targets`, so lib/integration test targets were never linted
- All five clippy invocations (justfile ×2, lefthook ×1, CI ×2) now use
  the same `--all-targets --no-deps -- -D warnings`

## Test plan

- [x] `just lint` green (includes both clippy invocations with the new flags)
- [x] `cargo clippy --all-targets [--all-features] --no-deps -- -D warnings`
  green for src-tauri and silero-native locally

Closes #148
