### PR TITLE
chore(rust): migrate all crates to edition 2024 (MSRV 1.85)

### DIFF
--- a/ai/rules/conventions.md
+++ b/ai/rules/conventions.md
@@ -65,7 +65,7 @@ Craft rules (layout, test quality, duplication, idiom, correctness) live in
 
 ## Rust
 
-- Edition 2021 (or newer if a dependency requires it).
+- Edition 2024 (MSRV 1.85).
 - `tracing` for logging, `thiserror` for domain errors, `anyhow::Result` only
   at boundaries.
 - No `unwrap` in production paths — use `?` + typed errors. `expect()` only for

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -95,7 +95,7 @@ Multi-character operators (`===`, `=>`, `>=`) are handled in `pipeline/mod.rs::T
 
 See full rules in [development.md](development.md#code-rules). In short:
 
-- Rust: edition 2021, `tracing` + `thiserror`, no `unwrap` in production paths, `cargo fmt` + `cargo clippy`.
+- Rust: edition 2024 (MSRV 1.85), `tracing` + `thiserror`, no `unwrap` in production paths, `cargo fmt` + `cargo clippy`.
 - TypeScript: `strict: true`, no `React.FC`, no `any`, functional components + hooks.
 - Mantine 8: CSS Modules + `classNames` prop. No `sx`, `createStyles`, `emotion`, or Mantine 6/7 legacy.
 - Python (ttsd): 3.12, uv-managed, clean `ruff check`, JSON over stdin/stdout, logs to stderr.

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,7 +100,7 @@ nix build .#ruvox
 
 ### Rust
 
-- Edition 2021 (or newer if a dependency requires it).
+- Edition 2024 (MSRV 1.85).
 - `tracing` for logs, `thiserror` for domain errors, `anyhow::Result` only at boundaries.
 - `unwrap` is forbidden in production paths — use `?` + typed errors.
 - `cargo fmt` and `cargo clippy` must be clean.

--- a/silero-native/Cargo.toml
+++ b/silero-native/Cargo.toml
@@ -5,8 +5,8 @@ description = "In-process Silero TTS v5 engine on ONNX Runtime (Rust port of the
 authors = []
 license = "GPL-3.0-only"
 repository = "https://github.com/xilec/RuVox"
-edition = "2021"
-rust-version = "1.80"
+edition = "2024"
+rust-version = "1.85"
 
 # `ort`/`ort-sys` pins mirror src-tauri/Cargo.toml exactly (see the long
 # comment there): `load-dynamic` + `disable-linking` mean onnxruntime is

--- a/silero-native/src/engine.rs
+++ b/silero-native/src/engine.rs
@@ -17,10 +17,10 @@ use tracing::{debug, info, instrument};
 
 use crate::bundle::{Manifest, Sessions};
 use crate::error::{EngineError, Result};
+use crate::frontend::FrontendConfig;
 use crate::frontend::accentor::Accentor;
 use crate::frontend::homosolver::HomoSolver;
 use crate::frontend::text::{build_sequence, prepare_text_input};
-use crate::frontend::FrontendConfig;
 use crate::lock_session;
 
 /// Raw synthesis output (pre-WAV).

--- a/silero-native/src/frontend/homosolver.rs
+++ b/silero-native/src/frontend/homosolver.rs
@@ -13,8 +13,8 @@ use ort::session::Session;
 use ort::value::Tensor;
 use tracing::{debug, instrument};
 
-use super::bert::BertTokenizer;
 use super::HomosolverConfig;
+use super::bert::BertTokenizer;
 use crate::error::{EngineError, Result};
 
 /// Char classes of the upstream word pattern `[а-яё+]+` (IGNORECASE).

--- a/silero-native/src/lib.rs
+++ b/silero-native/src/lib.rs
@@ -12,7 +12,7 @@ pub mod error;
 pub mod frontend;
 pub mod timestamps;
 
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 

--- a/silero-native/tests/frontend_accentor.rs
+++ b/silero-native/tests/frontend_accentor.rs
@@ -8,10 +8,10 @@
 //! Skipped when the bundle is absent (set SILERO_NATIVE_BUNDLE to override).
 
 use serde::Deserialize;
+use silero_native::frontend::FrontendConfig;
 use silero_native::frontend::accentor::Accentor;
 use silero_native::frontend::homosolver::HomoSolver;
 use silero_native::frontend::text::{build_sequence, prepare_text_input};
-use silero_native::frontend::FrontendConfig;
 
 mod common;
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,8 +5,8 @@ description = "RuVox — desktop app for reading technical texts aloud"
 authors = []
 license = "GPL-3.0-only"
 repository = "https://github.com/xilec/RuVox"
-edition = "2021"
-rust-version = "1.80"
+edition = "2024"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,8 +15,8 @@ use tauri::{AppHandle, Emitter, Runtime, State};
 use tokio::task::AbortHandle;
 use tracing::{info, warn};
 
-use crate::pipeline::tracked_text::CharMapping;
 use crate::pipeline::TTSPipeline;
+use crate::pipeline::tracked_text::CharMapping;
 use crate::state::AppState;
 use crate::storage::schema::{
     EntryId, EntryStatus, TextEntry, TextFormat, UIConfig, UIConfigPatch, WordTimestamp,
@@ -25,7 +25,7 @@ use crate::storage::service::{StorageError, StorageService};
 use crate::tts::engine::EngineKind;
 use crate::tts::piper::download::download_voice;
 use crate::tts::{
-    availability, AvailableEngines, CharMappingEntry, SynthesizeOutput, TtsEngine, TtsError,
+    AvailableEngines, CharMappingEntry, SynthesizeOutput, TtsEngine, TtsError, availability,
 };
 
 // ── Error type ─────────────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/orchestration_tests.rs
+++ b/src-tauri/src/commands/orchestration_tests.rs
@@ -7,7 +7,7 @@
 use super::*;
 use crate::player::PlayerBackend;
 use crate::test_support::{
-    build_test_app, build_test_app_with_kind, record_events, wait_until, PlayerCall, TestApp,
+    PlayerCall, TestApp, build_test_app, build_test_app_with_kind, record_events, wait_until,
 };
 use crate::tts::engine::EngineKind;
 use std::time::Duration;
@@ -121,11 +121,12 @@ async fn delete_entry_of_other_entry_keeps_playback_running() {
     play_entry(t.state(), playing.clone()).await.unwrap();
     delete_entry(t.state(), other.clone()).await.unwrap();
 
-    assert!(t
-        .player
-        .calls()
-        .iter()
-        .all(|c| !matches!(c, PlayerCall::Stop)));
+    assert!(
+        t.player
+            .calls()
+            .iter()
+            .all(|c| !matches!(c, PlayerCall::Stop))
+    );
     assert!(t.player.is_playing());
     assert_eq!(
         t.player.current_entry_id().as_deref(),
@@ -166,9 +167,10 @@ async fn regenerate_entry_replaces_audio_and_resynthesizes() {
 
     // The command emitted entry_updated carrying was_regenerated: true.
     let log = events.lock().unwrap();
-    assert!(log
-        .iter()
-        .any(|(_, p)| p["entry"]["id"] == id && p["entry"]["was_regenerated"] == true));
+    assert!(
+        log.iter()
+            .any(|(_, p)| p["entry"]["id"] == id && p["entry"]["was_regenerated"] == true)
+    );
 }
 
 /// Regeneration is rejected while the entry is `processing`; the
@@ -276,9 +278,10 @@ async fn cancel_synthesis_on_idle_entry_succeeds_and_stays_pending() {
     let stored = t.state().storage.get_entry(&entry.id).unwrap();
     assert_eq!(stored.status, EntryStatus::Pending);
     let log = events.lock().unwrap();
-    assert!(log
-        .iter()
-        .any(|(_, p)| p["entry"]["id"] == id && p["entry"]["status"] == "pending"));
+    assert!(
+        log.iter()
+            .any(|(_, p)| p["entry"]["id"] == id && p["entry"]["status"] == "pending")
+    );
 }
 
 // ── play_entry ───────────────────────────────────────────────────────
@@ -553,11 +556,13 @@ async fn tts_failure_emits_entry_updated_error_then_tts_error() {
 
     let entry = t.state().storage.get_entry(&uuid).unwrap();
     assert_eq!(entry.status, EntryStatus::Error);
-    assert!(entry
-        .error_message
-        .as_deref()
-        .unwrap_or_default()
-        .contains("stub synthesis boom"));
+    assert!(
+        entry
+            .error_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("stub synthesis boom")
+    );
 
     let log = events.lock().unwrap();
     let err_idx = log
@@ -570,10 +575,12 @@ async fn tts_failure_emits_entry_updated_error_then_tts_error() {
         .expect("tts_error must be emitted");
     assert!(err_idx < tts_idx, "entry_updated(error) precedes tts_error");
     assert_eq!(log[tts_idx].1["entry_id"], id);
-    assert!(log[tts_idx].1["message"]
-        .as_str()
-        .unwrap()
-        .contains("stub synthesis boom"));
+    assert!(
+        log[tts_idx].1["message"]
+            .as_str()
+            .unwrap()
+            .contains("stub synthesis boom")
+    );
 }
 
 /// `seek_to` forwards the absolute position to the player. (The
@@ -585,11 +592,12 @@ async fn tts_failure_emits_entry_updated_error_then_tts_error() {
 async fn seek_to_forwards_absolute_seek_to_player() {
     let t = build_test_app();
     seek_to(t.state(), 2.0).await.unwrap();
-    assert!(t
-        .player
-        .calls()
-        .iter()
-        .any(|c| matches!(c, PlayerCall::Seek(p) if (*p - 2.0).abs() < f64::EPSILON)));
+    assert!(
+        t.player
+            .calls()
+            .iter()
+            .any(|c| matches!(c, PlayerCall::Seek(p) if (*p - 2.0).abs() < f64::EPSILON))
+    );
 }
 
 // ── preview_normalize (restored from the plan journal: removed as a
@@ -794,11 +802,12 @@ async fn set_speed_rejects_out_of_range() {
             "speed {speed} must be rejected with config_error, got {err:?}"
         );
     }
-    assert!(t
-        .player
-        .calls()
-        .iter()
-        .all(|c| !matches!(c, PlayerCall::SetSpeed(_))));
+    assert!(
+        t.player
+            .calls()
+            .iter()
+            .all(|c| !matches!(c, PlayerCall::SetSpeed(_)))
+    );
 }
 
 /// The real `set_volume` command accepts the documented inclusive range
@@ -836,9 +845,10 @@ async fn set_volume_rejects_out_of_range() {
             "volume {volume} must be rejected with config_error, got {err:?}"
         );
     }
-    assert!(t
-        .player
-        .calls()
-        .iter()
-        .all(|c| !matches!(c, PlayerCall::SetVolume(_))));
+    assert!(
+        t.player
+            .calls()
+            .iter()
+            .all(|c| !matches!(c, PlayerCall::SetVolume(_)))
+    );
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,8 +11,8 @@ pub mod tts;
 mod test_support;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use parking_lot::Mutex;
 use serde_json::json;
@@ -389,8 +389,8 @@ fn spawn_tray_handler<R: Runtime + 'static>(
 /// Extracted from `run()` so the test harness (`test_support`) registers the
 /// identical command set on its `MockRuntime` app — no drift between the
 /// production handler list and what tests exercise.
-pub(crate) fn invoke_handler<R: Runtime>(
-) -> impl Fn(tauri::ipc::Invoke<R>) -> bool + Send + Sync + 'static {
+pub(crate) fn invoke_handler<R: Runtime>()
+-> impl Fn(tauri::ipc::Invoke<R>) -> bool + Send + Sync + 'static {
     tauri::generate_handler![
         add_clipboard_entry,
         add_text_entry,

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -13,7 +13,7 @@ use crate::pipeline::normalizers::code_blocks::CodeBlockHandler;
 use crate::pipeline::normalizers::english::EnglishNormalizer;
 use crate::pipeline::normalizers::numbers::NumberNormalizer;
 use crate::pipeline::normalizers::symbols::SymbolNormalizer;
-use crate::pipeline::normalizers::urls::{is_known_tld, URLPathNormalizer};
+use crate::pipeline::normalizers::urls::{URLPathNormalizer, is_known_tld};
 use crate::pipeline::tracked_text::{CharMapping, TrackedText};
 
 // ── Static compiled regexes ───────────────────────────────────────────────────
@@ -592,7 +592,7 @@ impl TTSPipeline {
                     // "[" is a 1-byte ASCII char.
                     let bracket_start = full_m.start();
                     let bracket_end = bracket_start + 1; // just "["
-                                                         // "](url)" starts right after the link text.
+                    // "](url)" starts right after the link text.
                     let suffix_start = text_m.end(); // byte after last char of link text
                     let suffix_end = full_m.end();
                     (bracket_start, bracket_end, suffix_start, suffix_end)

--- a/src-tauri/src/pipeline/normalizers/code_blocks.rs
+++ b/src-tauri/src/pipeline/normalizers/code_blocks.rs
@@ -265,11 +265,7 @@ impl CodeBlockHandler {
             .into_iter()
             .filter_map(|t| {
                 let n = self.normalize_token(t);
-                if n.is_empty() {
-                    None
-                } else {
-                    Some(n)
-                }
+                if n.is_empty() { None } else { Some(n) }
             })
             .collect();
         normalized.join(" ")

--- a/src-tauri/src/pipeline/normalizers/urls.rs
+++ b/src-tauri/src/pipeline/normalizers/urls.rs
@@ -826,9 +826,11 @@ mod tests {
     #[test_case("file:///home/user/doc.txt", "файл"; "file")]
     fn protocol(url: &str, expected_prefix: &str) {
         let (_, nn) = mk_normalizer();
-        assert!(norm_no_en(&nn)
-            .normalize_url(url)
-            .starts_with(expected_prefix));
+        assert!(
+            norm_no_en(&nn)
+                .normalize_url(url)
+                .starts_with(expected_prefix)
+        );
     }
 
     // ---- Email normalization ----

--- a/src-tauri/src/player/mod.rs
+++ b/src-tauri/src/player/mod.rs
@@ -21,15 +21,15 @@
 
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use parking_lot::Mutex;
 use serde_json::json;
 use tauri::{AppHandle, Emitter, Runtime};
 use tauri_plugin_mpv::{MpvCommand, MpvConfig, MpvExt};
-use tokio::time::{interval, Duration};
+use tokio::time::{Duration, interval};
 use tracing::{debug, warn};
 
 pub const WINDOW_LABEL: &str = "main";

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use parking_lot::Mutex;
 use tokio::task::AbortHandle;

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -454,11 +454,7 @@ impl StorageService {
         let map = self.entries.read();
         let filename = map.get(id)?.audio_path.as_ref()?.clone();
         let full = self.audio_dir.join(filename);
-        if full.exists() {
-            Some(full)
-        } else {
-            None
-        }
+        if full.exists() { Some(full) } else { None }
     }
 
     // ── Stats ──────────────────────────────────────────────────────────────

--- a/src-tauri/src/test_support.rs
+++ b/src-tauri/src/test_support.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use parking_lot::Mutex as ParkingMutex;
 use serde_json::Value;
-use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
+use tauri::test::{MockRuntime, mock_builder, mock_context, noop_assets};
 use tauri::{App, Listener, Manager};
 use tempfile::TempDir;
 
@@ -523,9 +523,10 @@ mod tests {
                 .map(|(_, payload)| payload["position_sec"].as_f64().unwrap())
                 .collect();
             assert_eq!(positions, vec![0.1, 0.2, 0.3]);
-            assert!(log
-                .iter()
-                .all(|(_, payload)| payload.get("entry_id").map_or(true, |id| id == "entry-1")));
+            assert!(
+                log.iter()
+                    .all(|(_, payload)| payload.get("entry_id").is_none_or(|id| id == "entry-1"))
+            );
 
             // EOF ordering: playback_finished immediately before playback_stopped.
             let finished_idx = log

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -1,8 +1,8 @@
 use tauri::{
+    AppHandle, Emitter, Manager, Runtime,
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, Emitter, Manager, Runtime,
 };
 
 use crate::state::AppState;

--- a/src-tauri/src/tts/piper/catalog.rs
+++ b/src-tauri/src/tts/piper/catalog.rs
@@ -35,40 +35,32 @@ pub const VOICES: &[Voice] = &[
         label: "Денис (мужской)",
         recommended: false,
         quality: "medium",
-        model_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx",
-        config_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx.json",
+        model_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx",
+        config_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx.json",
     },
     Voice {
         id: "dmitri",
         label: "Дмитрий (мужской)",
         recommended: false,
         quality: "medium",
-        model_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx",
-        config_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx.json",
+        model_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx",
+        config_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx.json",
     },
     Voice {
         id: "irina",
         label: "Ирина (женский)",
         recommended: false,
         quality: "medium",
-        model_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx",
-        config_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx.json",
+        model_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx",
+        config_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx.json",
     },
     Voice {
         id: "ruslan",
         label: "Руслан (мужской)",
         recommended: true,
         quality: "medium",
-        model_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx",
-        config_url:
-            "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx.json",
+        model_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx",
+        config_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx.json",
     },
 ];
 

--- a/src-tauri/src/tts/piper/download.rs
+++ b/src-tauri/src/tts/piper/download.rs
@@ -29,8 +29,8 @@ use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
 use super::catalog;
-use crate::tts::supervisor::Emitter;
 use crate::tts::TtsError;
+use crate::tts::supervisor::Emitter;
 
 /// Throttle progress events to ~1 per 256 KB so the IPC bridge does not
 /// drown the renderer.

--- a/src-tauri/src/tts/piper/timestamps.rs
+++ b/src-tauri/src/tts/piper/timestamps.rs
@@ -9,7 +9,7 @@
 
 use regex::Regex;
 
-use crate::tts::{map_via_spans, CharMappingEntry, WordTimestamp};
+use crate::tts::{CharMappingEntry, WordTimestamp, map_via_spans};
 
 /// Estimate per-word timestamps for `text` over a single audio chunk of length
 /// `total_duration_sec`. `char_mapping`, when present, maps normalized-text

--- a/src-tauri/src/tts/silero_native/download.rs
+++ b/src-tauri/src/tts/silero_native/download.rs
@@ -31,8 +31,8 @@ use silero_native::bundle::{Manifest, ManifestFile};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
-use crate::tts::supervisor::Emitter;
 use crate::tts::TtsError;
+use crate::tts::supervisor::Emitter;
 
 /// Base URL of the GitHub Release that hosts the bundle files. The release
 /// may not exist yet — a 404 surfaces as a typed `bundle_download_failed`

--- a/src-tauri/src/tts/supervisor.rs
+++ b/src-tauri/src/tts/supervisor.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::json;
 use tokio::process::Command;
-use tokio::sync::{watch, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, watch};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 


### PR DESCRIPTION
## Summary

Closes #160.

- Bump `edition` to `"2024"` and `rust-version` to `"1.85"` in `src-tauri/Cargo.toml` and `silero-native/Cargo.toml`
- Re-run `cargo fmt` — style-edition 2024 import reordering and macro reflows (~20 files, mechanical churn only)
- Fix the new clippy violation in `src-tauri/src/test_support.rs` (`map_or(true, ...)` → `is_none_or(...)`)
- Sync the edition pins in `ai/rules/conventions.md`, `docs/development.md`, `docs/contributing.md`

The second pre-identified clippy hit from the issue spike (`MutexGuard` across `await`) no longer reproduces on current `main` — `cargo clippy --all-targets` is clean apart from the fixed `map_or`.

## Verification

- `just lint` and `just test` green (Rust incl. golden fixtures, TS typecheck + vitest, ttsd pytest)
- Production nix build `.#ruvox` succeeds
- `ruvox-reviewer` pass over the diff: no findings (mechanical change confirmed, no remaining edition-2021 pins outside the historical CHANGELOG entry)