### PR TITLE
docs(readme): reflect the three TTS engines, local synthesis, silero-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 A desktop application for narrating technical Russian-language texts.
 
-Normalizes English terms, abbreviations, code, numbers, and URLs, then pipes the result into [Piper](https://github.com/rhasspy/piper) (in-process via `piper-rs`, primary engine) or, optionally, [Silero TTS](https://github.com/snakers4/silero-models) (out-of-process via the `ttsd` Python sidecar). Unlike a bare TTS, RuVox knows how to read `getUserData()` as «гет юзер дата», `API` as «эй пи ай», and `/api/v2/users` as a path rather than letter by letter.
+Normalizes English terms, abbreviations, code, numbers, and URLs, then pipes the result into one of three TTS engines: [Piper](https://github.com/rhasspy/piper) (in-process via `piper-rs`, default), Silero TTS v5 in-process on ONNX Runtime (the [`silero-native`](silero-native/) crate, model bundle downloaded on demand), or, optionally, [Silero TTS](https://github.com/snakers4/silero-models) out-of-process via the `ttsd` Python sidecar (kept as a fallback). Unlike a bare TTS, RuVox knows how to read `getUserData()` as «гет юзер дата», `API` as «эй пи ай», and `/api/v2/users` as a path rather than letter by letter.
+
+All synthesis runs locally on your machine — no cloud TTS, nothing is sent anywhere. The network is used only to download voice models on demand, once per voice.
 
 ![RuVox screenshot](docs/images/screenshot.png)
 
@@ -18,7 +20,7 @@ Normalizes English terms, abbreviations, code, numbers, and URLs, then pipes the
 | Shell | [Tauri 2](https://tauri.app/) (Rust + native webview) |
 | Frontend | React 18 + TypeScript 5 + [Mantine 8](https://mantine.dev/) |
 | Backend | Rust (normalization pipeline, storage, TTS manager) |
-| TTS | Piper (in-process, `piper-rs` + `onnxruntime`); Silero (optional, Python 3.12 subprocess `ttsd`) |
+| TTS | Piper (in-process, `piper-rs` + `onnxruntime`, default); Silero v5 native (in-process, ONNX Runtime, [`silero-native`](silero-native/) crate); Silero via `ttsd` (optional Python 3.12 subprocess, fallback) |
 | Audio | `tauri-plugin-mpv` (libmpv with `scaletempo2`) |
 
 ## Features
@@ -34,7 +36,7 @@ Normalizes English terms, abbreviations, code, numbers, and URLs, then pipes the
 
 - **OS:** Linux (X11 or Wayland).
 - **Nix:** recommended — the entire toolchain (Rust, Node, Python, Tauri deps) is built from `flake.nix` (dev shell lives in `nix/devshell.nix`).
-- **Without Nix:** Linux distribution that ships `webkit2gtk-4.1` (Ubuntu 24.04+, Debian 13+, Fedora 40+, Arch). Detailed step-by-step build guide: [docs/install.md](docs/install.md). Python 3.12 + `uv` are only required if you want to use Silero (the `ttsd` sidecar).
+- **Without Nix:** Linux distribution that ships `webkit2gtk-4.1` (Ubuntu 24.04+, Debian 13+, Fedora 40+, Arch). Detailed step-by-step build guide: [docs/install.md](docs/install.md). Python 3.12 + `uv` are only required for the Python Silero engine (the `ttsd` sidecar) — Piper and the native Silero engine need neither.
 
 ## Dev environment
 
@@ -54,16 +56,17 @@ All commands in the docs assume execution inside `nix develop` (or via `nix deve
 ## Production build
 
 ```bash
-# Default (slim) — Piper only, no Python/torch/Silero in the closure.
+# Default (slim) — Piper + native Silero, no Python/torch in the closure.
 nix build .#ruvox
 ./result/bin/ruvox
 
-# Opt-in (full) — bundles the ttsd sidecar so Silero is also available.
+# Opt-in (full) — additionally bundles the ttsd sidecar, so the Python
+# Silero engine is also available.
 nix build .#ruvox-with-silero
 ./result/bin/ruvox
 ```
 
-Both variants build the Tauri release binary and wrap it via `wrapProgram` (runtime `LD_LIBRARY_PATH` + `GIO_EXTRA_MODULES`) with `mpv` in `PATH`. `.#ruvox-with-silero` additionally puts the `ttsd` (Silero subprocess) binary in `PATH`; `.#ruvox` does not, and the Settings dialog greys the Silero engine out at runtime.
+Both variants build the Tauri release binary and wrap it via `wrapProgram` (runtime `LD_LIBRARY_PATH` + `GIO_EXTRA_MODULES`) with `mpv` in `PATH`. `.#ruvox-with-silero` additionally puts the `ttsd` (Silero Python subprocess) binary in `PATH`; `.#ruvox` does not, and the Settings dialog greys the Python Silero engine out at runtime. The native Silero engine works in both variants — its ~230 MB ONNX model bundle is downloaded on demand from Settings.
 
 > **First `nix build` run:** the `frontend` derivation uses `pnpm.fetchDeps` with `lib.fakeHash` — Nix will fail with a hash mismatch and print the real hash; substitute it into `flake.nix` and re-run the build. This is the standard pnpm2nix procedure.
 
@@ -73,6 +76,7 @@ Both variants build the Tauri release binary and wrap it via `wrapProgram` (runt
 pnpm typecheck                                                  # TypeScript
 cargo test --manifest-path src-tauri/Cargo.toml                 # Rust (incl. pipeline golden tests)
 cargo test --manifest-path src-tauri/Cargo.toml --test golden   # golden tests only
+cargo test --manifest-path silero-native/Cargo.toml             # native Silero engine (bundle-gated tests skip without SILERO_NATIVE_BUNDLE)
 cd ttsd && uv run python -m pytest                              # Python subprocess
 ```
 
@@ -82,6 +86,7 @@ cd ttsd && uv run python -m pytest                              # Python subproc
 |------|-------------|
 | [AGENTS.md](AGENTS.md) | Development rules, project structure, conventions |
 | [docs/install.md](docs/install.md) | Building from source on Linux without Nix (Ubuntu 24.04+) |
+| [silero-native/](silero-native/) | Native Silero v5 engine crate (ONNX Runtime): architecture, bundle export, parity tests |
 | [openspec/specs/](openspec/specs/) | Behavior specs (OpenSpec): IPC, storage, pipeline, UI, playback |
 | [CHANGELOG.md](CHANGELOG.md) | Change history |
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -7,7 +7,9 @@
 
 Desktop-приложение для озвучивания технических текстов на русском языке.
 
-Нормализует английские термины, аббревиатуры, код, числа, URL и передаёт результат в [Piper](https://github.com/rhasspy/piper) (in-process, через `piper-rs`, основной движок) или, опционально, в [Silero TTS](https://github.com/snakers4/silero-models) (out-of-process, через Python-сайдкар `ttsd`). В отличие от голого TTS, RuVox умеет читать `getUserData()` как «гет юзер дата», `API` как «эй пи ай», `/api/v2/users` как путь, а не по буквам.
+Нормализует английские термины, аббревиатуры, код, числа, URL и передаёт результат в один из трёх TTS-движков: [Piper](https://github.com/rhasspy/piper) (in-process, через `piper-rs`, движок по умолчанию), Silero TTS v5 in-process на ONNX Runtime (крейт [`silero-native`](silero-native/), бандл модели скачивается по запросу) или, опционально, [Silero TTS](https://github.com/snakers4/silero-models) out-of-process через Python-сайдкар `ttsd` (оставлен как fallback). В отличие от голого TTS, RuVox умеет читать `getUserData()` как «гет юзер дата», `API` как «эй пи ай», `/api/v2/users` как путь, а не по буквам.
+
+Синтез полностью локальный — никаких облачных TTS, текст никуда не отправляется. Сеть используется только для одноразового скачивания голосовых моделей по запросу.
 
 ![Скриншот RuVox](docs/images/screenshot.png)
 
@@ -18,7 +20,7 @@ Desktop-приложение для озвучивания технически�
 | Shell | [Tauri 2](https://tauri.app/) (Rust + нативный webview) |
 | Frontend | React 18 + TypeScript 5 + [Mantine 8](https://mantine.dev/) |
 | Backend | Rust (pipeline нормализации, storage, TTS-менеджер) |
-| TTS | Piper (in-process, `piper-rs` + `onnxruntime`); Silero (опционально, Python 3.12 subprocess `ttsd`) |
+| TTS | Piper (in-process, `piper-rs` + `onnxruntime`, по умолчанию); Silero v5 нативный (in-process, ONNX Runtime, крейт [`silero-native`](silero-native/)); Silero через `ttsd` (опциональный Python 3.12 subprocess, fallback) |
 | Аудио | `tauri-plugin-mpv` (libmpv с `scaletempo2`) |
 
 ## Возможности
@@ -34,7 +36,7 @@ Desktop-приложение для озвучивания технически�
 
 - **ОС:** Linux (X11 или Wayland).
 - **Nix:** рекомендуется — всё окружение (Rust, Node, Python, Tauri-deps) собирается из `flake.nix` (dev-shell живёт в `nix/devshell.nix`).
-- **Без Nix:** дистрибутив Linux, в котором есть `webkit2gtk-4.1` (Ubuntu 24.04+, Debian 13+, Fedora 40+, Arch). Подробная пошаговая инструкция по сборке: [docs/install.md](docs/install.md) (на английском). Python 3.12 + `uv` нужны только если хотите Silero (сайдкар `ttsd`).
+- **Без Nix:** дистрибутив Linux, в котором есть `webkit2gtk-4.1` (Ubuntu 24.04+, Debian 13+, Fedora 40+, Arch). Подробная пошаговая инструкция по сборке: [docs/install.md](docs/install.md) (на английском). Python 3.12 + `uv` нужны только для Python-движка Silero (сайдкар `ttsd`) — Piper и нативный движок Silero в них не нуждаются.
 
 ## Dev-окружение
 
@@ -54,16 +56,17 @@ nix develop -c pnpm tauri dev
 ## Сборка production-бинаря
 
 ```bash
-# По-умолчанию (slim) — только Piper, без Python/torch/Silero в closure.
+# По умолчанию (slim) — Piper + нативный Silero, без Python/torch в closure.
 nix build .#ruvox
 ./result/bin/ruvox
 
-# Опционально (full) — со встроенным сайдкаром ttsd, чтобы был доступен Silero.
+# Опционально (full) — дополнительно встраивает сайдкар ttsd, чтобы был
+# доступен Python-движок Silero.
 nix build .#ruvox-with-silero
 ./result/bin/ruvox
 ```
 
-Оба варианта собирают release-бинарь Tauri и оборачивают его через `wrapProgram` (runtime `LD_LIBRARY_PATH` + `GIO_EXTRA_MODULES`); `mpv` в обоих случаях попадает в `PATH`. Вариант `.#ruvox-with-silero` дополнительно кладёт в `PATH` бинарь `ttsd` (Silero subprocess). Slim-вариант его не содержит — на runtime в Settings опция Silero окрашена серым.
+Оба варианта собирают release-бинарь Tauri и оборачивают его через `wrapProgram` (runtime `LD_LIBRARY_PATH` + `GIO_EXTRA_MODULES`); `mpv` в обоих случаях попадает в `PATH`. Вариант `.#ruvox-with-silero` дополнительно кладёт в `PATH` бинарь `ttsd` (Silero Python subprocess). Slim-вариант его не содержит — на runtime в Settings опция Python-движка Silero окрашена серым. Нативный движок Silero работает в обоих вариантах — его бандл ONNX-моделей (~230 МБ) скачивается по запросу из Settings.
 
 > **Первый запуск `nix build`:** derivation `frontend` использует `pnpm.fetchDeps` с `lib.fakeHash` — Nix упадёт с hash mismatch, напишет реальный hash; его нужно подставить в `flake.nix` и повторить build. Это стандартная процедура pnpm2nix.
 
@@ -73,6 +76,7 @@ nix build .#ruvox-with-silero
 pnpm typecheck                                                  # TypeScript
 cargo test --manifest-path src-tauri/Cargo.toml                 # Rust (включая golden-тесты pipeline)
 cargo test --manifest-path src-tauri/Cargo.toml --test golden   # только golden-тесты
+cargo test --manifest-path silero-native/Cargo.toml             # нативный движок Silero (bundle-gated тесты скипаются без SILERO_NATIVE_BUNDLE)
 cd ttsd && uv run python -m pytest                              # Python subprocess
 ```
 
@@ -82,6 +86,7 @@ cd ttsd && uv run python -m pytest                              # Python subproc
 |------|----------|
 | [AGENTS.md](AGENTS.md) | Правила разработки, структура проекта, соглашения |
 | [docs/install.md](docs/install.md) | Сборка из исходников на Linux без Nix (Ubuntu 24.04+, на английском) |
+| [silero-native/](silero-native/) | Крейт нативного движка Silero v5 (ONNX Runtime): архитектура, экспорт бандла, parity-тесты (на английском) |
 | [openspec/specs/](openspec/specs/) | Спецификации поведения (OpenSpec): IPC, хранилище, pipeline, UI, плеер |
 | [CHANGELOG.md](CHANGELOG.md) | Хронология изменений |
 


### PR DESCRIPTION
## Summary

The README still described the pre-#166 engine lineup (Piper + optional Python Silero) and never mentioned a key product property — that narration is fully local. This brings both language versions up to date:

- Three TTS engines: Piper (default), native Silero v5 on ONNX Runtime (`silero-native` crate, ~230 MB bundle downloaded on demand), Python `ttsd` sidecar (fallback)
- Explicit note: all synthesis runs locally, no cloud TTS; network is used only for one-off voice model downloads (verified: no updater/telemetry in the app)
- Slim build `.#ruvox` now ships Piper + native Silero; full `.#ruvox-with-silero` only adds the `ttsd` sidecar
- Test commands include the `silero-native` crate; docs table links it

Docs-only change — no OpenSpec, no behavior impact.