### PR TITLE
docs: bring the remaining docs in line with the three TTS engines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - **Shell:** Tauri 2 (Rust-based desktop shell with native webview)
 - **Frontend:** React 18 + TypeScript 5 + Mantine 8
 - **Backend:** Rust (text normalization pipeline, storage, TTS subprocess manager, player wrapper)
-- **TTS engine:** Piper (primary, native Rust) + optional Python subprocess `ttsd` wrapping Silero TTS
+- **TTS engines:** Piper (default, native Rust via `piper-rs`), Silero v5 in-process on ONNX Runtime (`silero-native` crate), optional Python subprocess `ttsd` wrapping Silero TTS (fallback)
 
 **Goal** unchanged: normalize technical text (API, URLs, code identifiers, numbers) before passing it to Silero TTS, which cannot read English or special characters.
 
@@ -102,7 +102,7 @@ retry the call.
 │   └── devshell.nix  # Nix dev environment (Rust + Node + Python), wired into flake.nix
 ├── justfile          # Task runner (single entry point for routine commands)
 ├── lefthook.yml      # Git hooks (fmt/ruff pre-commit, clippy/typecheck pre-push)
-└── flake.nix         # Production build: `.#ruvox` (slim, Piper only) and `.#ruvox-with-silero` (full, Piper + ttsd Python sidecar)
+└── flake.nix         # Production build: `.#ruvox` (slim, Piper + native Silero) and `.#ruvox-with-silero` (full, adds the ttsd Python sidecar)
 ```
 
 ## Spec-driven workflow (OpenSpec)

--- a/ai/rules/conventions.md
+++ b/ai/rules/conventions.md
@@ -49,7 +49,8 @@ Craft rules (layout, test quality, duplication, idiom, correctness) live in
 - **ttsd** (Python sidecar) speaks strictly the stdin/stdout JSON protocol
   (`ttsd/ttsd/protocol.py`, spec `openspec/specs/ttsd-protocol/`): JSON requests
   on stdin, JSON responses on stdout, logs on **stderr only**.
-- **TTS engines:** Piper is the primary engine; Silero via ttsd is opt-in
+- **TTS engines:** Piper is the default engine; Silero v5 runs in-process
+  via the `silero-native` crate; Silero via ttsd is the opt-in fallback
   (flake flag `withSilero`). Slim `.#ruvox` must not pull in ttsd — gated in CI.
 
 ## The TTS constraint (load-bearing)

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,7 +36,7 @@ nix develop -c pnpm tauri dev
 │   ├── src/
 │   │   ├── pipeline/       # Normalization: tracked_text, normalizers/, html_extractor, constants
 │   │   ├── storage/        # JSON history + audio files (schema in storage/schema.rs)
-│   │   ├── tts/            # ttsd subprocess manager
+│   │   ├── tts/            # TTS engines: piper, silero_native, ttsd subprocess manager
 │   │   ├── player/         # tauri-plugin-mpv wrapper (ensure_mpv_alive, seek-suppress)
 │   │   ├── commands/       # Tauri commands (#[tauri::command])
 │   │   ├── tray/           # System tray (close-to-tray, "Выход")
@@ -52,6 +52,7 @@ nix develop -c pnpm tauri dev
 │       ├── timestamps.py   # Word timestamp estimation
 │       ├── protocol.py     # Request/response types
 │       └── main.py         # Main stdin→stdout JSON loop
+├── silero-native/          # Native Silero v5 engine (ONNX Runtime, no Python)
 ├── docs/                   # Documentation (this directory)
 ├── scripts/                # Utilities (launch-prod, rebuild_prod)
 ├── nix/
@@ -84,7 +85,7 @@ nix build .#ruvox
 ./result/bin/ruvox
 ```
 
-`.#ruvox` builds the Tauri release binary, wraps it via `wrapProgram` (runtime `LD_LIBRARY_PATH` + `GIO_EXTRA_MODULES`), and links `ttsd` (the Silero subprocess) and `mpv` into `PATH`.
+`.#ruvox` builds the slim Tauri release binary (Piper + native Silero), wraps it via `wrapProgram` (runtime `LD_LIBRARY_PATH` + `GIO_EXTRA_MODULES`), and puts `mpv` in `PATH`. The `.#ruvox-with-silero` variant additionally links `ttsd` (the Python Silero subprocess) into `PATH`.
 
 > **First `nix build` run:** the `frontend` derivation uses `pnpm.fetchDeps` with `lib.fakeHash` — Nix will fail with a hash mismatch and print the real hash; substitute it into `flake.nix` and rerun the build. This is the standard pnpm2nix procedure.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # RuVox
 
-**RuVox** is a desktop application for voicing technical Russian texts via Silero TTS. It normalizes English terms, abbreviations, code, numbers, and URLs before passing them to the TTS engine, so the synthesizer can correctly read material it wasn't designed for.
+**RuVox** is a desktop application for voicing technical Russian texts with local TTS engines: Piper (default), native Silero v5 on ONNX Runtime (the `silero-native` crate), or Silero via the Python `ttsd` sidecar (fallback). It normalizes English terms, abbreviations, code, numbers, and URLs before passing them to the TTS engine, so the synthesizer can correctly read material it wasn't designed for.
 
 ## Problem → Solution
 
-Silero TTS cannot correctly pronounce:
+A bare Russian TTS engine cannot correctly pronounce:
 - English words and IT terms (`feature` → silence or distortion)
 - Abbreviations (`API`, `HTTP`, `JSON`)
 - URLs, emails, IP addresses, paths
@@ -32,7 +32,7 @@ Silero TTS cannot correctly pronounce:
 | Shell | [Tauri 2](https://tauri.app/) (Rust + native webview) |
 | Frontend | React 18 + TypeScript 5 + [Mantine 8](https://mantine.dev/) |
 | Backend | Rust (normalization pipeline, storage, TTS manager, player wrapper) |
-| TTS | Python 3.12 subprocess `ttsd`, a wrapper around [Silero TTS](https://github.com/snakers4/silero-models) |
+| TTS | Piper (in-process, `piper-rs`, default); native Silero v5 (in-process, ONNX Runtime, `silero-native` crate); Silero via Python 3.12 subprocess `ttsd` (fallback) |
 | Audio | [`tauri-plugin-mpv`](https://crates.io/crates/tauri-plugin-mpv) (libmpv with `scaletempo2`) |
 | Build environment | Nix (`flake.nix`; dev shell in `nix/devshell.nix`) |
 
@@ -40,17 +40,15 @@ Silero TTS cannot correctly pronounce:
 
 ### Architecture and history
 
-- [RewriteNotes.md](../RewriteNotes.md) — architectural decisions and the rationale behind the stack choice.
-- [RewriteTaskPlan.md](../RewriteTaskPlan.md) — detailed rewrite task plan, dependency graph.
-- [task_history.md](../task_history.md) — task execution log.
 - [CHANGELOG.md](../CHANGELOG.md) — version chronology.
+- [openspec/changes/archive/](../openspec/changes/archive/) — archived change proposals (the audit history of behavior changes).
 
 ### Behavior specs (OpenSpec)
 
 Current behavior is specified in [openspec/specs/](../openspec/specs/) — the single source of truth:
 
-- **Backend:** `text-pipeline`, `position-mapping`, `storage`, `ipc-commands`, `ttsd-protocol`
-- **Frontend / UX:** `ui`, `preview-dialog`, `queue-lifecycle`, `playback`, `text-display`, `word-highlight`, `tray`
+- **Backend:** `text-pipeline`, `position-mapping`, `storage`, `ipc-commands`, `ttsd-protocol`, `silero-native-engine`
+- **Frontend / UX:** `ui`, `preview-dialog`, `queue-lifecycle`, `playback`, `text-display`, `word-highlight`, `tray`, `html-ingestion`, `viewer-copy-actions`
 
 ### Development
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,11 +96,12 @@ sudo apt install -y nodejs
 corepack enable pnpm
 ```
 
-## 5. (Optional) Python 3.12 + uv — for Silero
+## 5. (Optional) Python 3.12 + uv — for the Python Silero engine (`ttsd`)
 
-Skip this whole section if you only want Piper (the default engine);
-the Settings dialog will simply grey out the Silero option, and Piper
-handles every narration in-process.
+Skip this whole section if you only want Piper (the default engine) or
+the native Silero engine — both synthesize in-process without Python;
+the Settings dialog will simply grey out the Python Silero option, and
+the other engines handle every narration locally.
 
 ```bash
 sudo apt install -y python3.12 python3.12-venv

--- a/justfile
+++ b/justfile
@@ -49,10 +49,10 @@ lint:
 validate:
     pnpm dlx @fission-ai/openspec@1.6.0 validate --specs --strict
 
-# Production build, slim (Piper only)
+# Production build, slim (Piper + native Silero)
 build:
     nix build .#ruvox
 
-# Production build, full (Piper + Silero sidecar)
+# Production build, full (adds the Python Silero sidecar)
 build-full:
     nix build .#ruvox-with-silero


### PR DESCRIPTION
## Summary

Follow-up to #170 — the README was updated to the three-engine lineup, but the same stale "Piper + optional Python Silero" description remained in other docs:

- `docs/index.md` — intro and stack table now list all three engines; removed dead links to `RewriteNotes.md` / `RewriteTaskPlan.md` / `task_history.md` (files no longer exist); spec list synced with the actual `openspec/specs/` contents
- `AGENTS.md` — overview lists Piper (default), `silero-native` (in-process ONNX Runtime), `ttsd` (fallback); slim/full build description corrected
- `ai/rules/conventions.md` — engine roles updated
- `docs/development.md` — `tts/` covers all engines, `silero-native/` added to the layout tree, slim build no longer described as linking `ttsd`
- `docs/install.md` — Python section is explicitly only for the `ttsd` engine
- `justfile` — slim/full build comments

Docs-only change.