### PR TITLE
perf(silero-native): faster engine load (parallel sessions, lazy PQMF)

### DIFF
--- a/silero-native/docs/architecture.md
+++ b/silero-native/docs/architecture.md
@@ -29,10 +29,14 @@ text (one chunk)
   → 16-bit PCM WAV + char-proportional word timestamps
 ```
 
-All sessions are created once at `SileroNative::load` and guarded by
-mutexes (`Session::run` needs `&mut`); a panic inside inference is
-contained with `catch_unwind` and the poisoned mutex is recovered — the
-engine stays usable after a failed call.
+Sessions for the always-needed models (`tts_main`, `istft`, `homosolver`,
+`accentor_tensor`) are opened concurrently at `SileroNative::load`
+(independent ORT sessions are thread-safe to create in parallel); the
+rate-specific `pqmf_24k`/`pqmf_8k` sessions are lazy-opened on the first
+synthesis requesting that rate. All sessions are guarded by mutexes
+(`Session::run` needs `&mut`); a panic inside inference is contained with
+`catch_unwind` and the poisoned mutex is recovered — the engine stays
+usable after a failed call.
 
 ## Bundle format
 

--- a/silero-native/docs/benchmarks.md
+++ b/silero-native/docs/benchmarks.md
@@ -26,6 +26,51 @@ chars), speaker `aidar`, 24000 Hz.
 
 **Speedup: ~1.3x** (warm, full pipeline on both sides).
 
+## Engine load time (issue #165)
+
+Date: 2026-08-01, same machine. "Load" = `SileroNative::load` (manifest
+verify + ONNX session creation + frontend), measured by the bench
+example's `load_ms` (and the `RUST_LOG=silero_native=info` per-phase
+timings). ttsd baseline = spawn `uv run python -m ttsd` → `warmup` →
+ok-response → `shutdown`, 5 runs (`tmp/bench_ttsd_spawn.py`).
+
+| Path | mean | min | max |
+|---|---|---|---|
+| ttsd spawn-to-ready (Python sidecar) | 1680.8 ms | 1654.1 ms | 1708.4 ms |
+| silero-native load — baseline (sequential sessions) | 651.6 ms | — | — |
+| silero-native load — optimized | ~440 ms | 416.7 ms | 464.7 ms |
+
+Baseline breakdown (warm page cache): manifest verify 115 ms, six
+sequential session opens 507 ms (tts_main 223, homosolver 214, istft 53,
+accentor 13, pqmf ~3), frontend 30 ms.
+
+Optimizations applied:
+
+- **Concurrent session creation** (`Sessions::open`): the sessions are
+  independent, so they open on scoped threads. 507 ms → ~340 ms.
+- **Concurrent sha256 verify** (`Manifest::verify`): hashing is pure CPU
+  once the page cache is warm. 115 ms → ~60 ms.
+- **Lazy PQMF sessions**: `pqmf_24k`/`pqmf_8k` open on the first synthesis
+  at that rate instead of at load (~3 ms saved at load; the real win is
+  not paying for a rate that is never requested).
+
+Measured and rejected:
+
+- **ORT graph optimization level**: Level3 ≈ Level1 ≈ Disable (~310 ms
+  sessions either way) — session creation is dominated by model parse /
+  arena init, not the optimizers. This also rules out the **`.ort`
+  compiled-model cache** (it only skips optimization).
+- **Warm the engine at app start**: already implemented in the app layer
+  (`spawn_initial_warmup` via the engine switcher, `src-tauri/src/lib.rs`)
+  — the selected engine warms in the background at startup and on every
+  engine switch.
+
+The remaining floor is ORT session init for `tts_main` (~220 ms class)
+and `homosolver` (~210 ms class), which overlap under concurrent open but
+do not vanish. **Native load is ~3.8x faster than ttsd spawn-to-ready**
+on the same machine, so the issue's acceptance target (native ≤ ttsd) is
+met with margin.
+
 ## Note on the spike's "~10x"
 
 `tmp/onnx-spike/REPORT.md` quoted ~10x (torch `apply_tts` ~0.5 s vs ORT

--- a/silero-native/examples/bench.rs
+++ b/silero-native/examples/bench.rs
@@ -1,7 +1,11 @@
 //! Benchmark: N syntheses of a fixed ~50-char phrase at 24000 Hz,
-//! reporting mean / p95 wall time per synthesis (engine load excluded).
-//! Results are recorded in `docs/benchmarks.md` next to the Python
-//! `apply_tts` comparison (see tmp/bench_python.py).
+//! reporting engine load time (`load_ms`) plus mean / p95 wall time per
+//! synthesis. Results are recorded in `docs/benchmarks.md` next to the
+//! Python `apply_tts` comparison (see tmp/bench_python.py) and the
+//! engine-load / ttsd spawn-to-ready comparison (tmp/bench_ttsd_spawn.py).
+//!
+//! `RUST_LOG=silero_native=info` surfaces per-phase load timings
+//! (manifest verify, per-session open, frontend).
 //!
 //! Usage: cargo run --release --example bench -- [bundle_dir]
 //! (default: ../tmp/bundle-v5 relative to the crate, or SILERO_NATIVE_BUNDLE).
@@ -17,9 +21,16 @@ const PHRASE: &str = "Сервер обрабатывает запросы и с
 const RUNS: usize = 20;
 
 fn main() {
+    // `RUST_LOG=silero_native=info` surfaces the per-session load timings.
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     let dir = common::bundle_dir_arg();
 
+    let t = Instant::now();
     let engine = SileroNative::load(&dir).expect("bundle must load");
+    let load = t.elapsed();
 
     // Warmup (JIT-less, but first-run ORT optimizations/arena allocs).
     engine
@@ -45,7 +56,8 @@ fn main() {
     println!("runs: {RUNS} @ 24000 Hz, speaker aidar");
     println!("mean {mean:.1?} | p95 {p95:.1?} | min {min:.1?} | max {max:.1?}");
     println!(
-        "mean_ms={:.1} p95_ms={:.1} min_ms={:.1} max_ms={:.1}",
+        "load_ms={:.1} mean_ms={:.1} p95_ms={:.1} min_ms={:.1} max_ms={:.1}",
+        load.as_secs_f64() * 1e3,
         mean.as_secs_f64() * 1e3,
         p95.as_secs_f64() * 1e3,
         min.as_secs_f64() * 1e3,

--- a/silero-native/src/bundle.rs
+++ b/silero-native/src/bundle.rs
@@ -5,6 +5,7 @@
 //! `export/README.md`. Every file listed in `manifest.json` is hashed before
 //! any session is opened — a corrupt file must never reach ONNX Runtime.
 
+use std::any::Any;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -16,6 +17,16 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, info, instrument};
 
 use crate::error::{EngineError, Result};
+
+/// Render a scoped-thread panic payload for error messages (same downcast
+/// as `synthesize_with_fallback` in `lib.rs`).
+fn panic_message(payload: &Box<dyn Any + Send>) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic".to_string())
+}
 
 /// Names of the ONNX models the engine opens, relative to the bundle root.
 pub const TTS_MAIN: &str = "tts_main.onnx";
@@ -111,8 +122,12 @@ impl Manifest {
             handles
                 .into_iter()
                 .map(|h| {
-                    h.join()
-                        .map_err(|_| EngineError::Bundle("verify thread panicked".to_string()))?
+                    h.join().map_err(|payload| {
+                        EngineError::Bundle(format!(
+                            "verify thread panicked: {}",
+                            panic_message(&payload)
+                        ))
+                    })?
                 })
                 .collect::<Result<Vec<()>>>()
         })?;
@@ -205,30 +220,39 @@ impl Sessions {
             Ok(session)
         };
         const NAMES: [&str; 4] = [TTS_MAIN, ISTFT, HOMOSOLVER, ACCENTOR_TENSOR];
+        // Each thread tags its session with the model name so the struct is
+        // assembled by name, not by spawn position — a reordered NAMES can
+        // never silently swap sessions.
         let results = std::thread::scope(|scope| {
             let handles: Vec<_> = NAMES
                 .iter()
-                .map(|name| scope.spawn(|| open(name)))
+                .map(|name| scope.spawn(move || open(name).map(|s| (*name, s))))
                 .collect();
             handles
                 .into_iter()
                 .map(|h| {
-                    h.join()
-                        .map_err(|_| {
-                            EngineError::Bundle("session open thread panicked".to_string())
-                        })?
-                        .map(Some)
+                    h.join().map_err(|payload| {
+                        EngineError::Bundle(format!(
+                            "session open thread panicked: {}",
+                            panic_message(&payload)
+                        ))
+                    })?
                 })
                 .collect::<Result<Vec<_>>>()
         })?;
-        let mut results = results.into_iter();
-        let mut next = || results.next().flatten().expect("one result per session");
+        let mut results = results;
+        let mut take = |name: &str| {
+            let pos = results
+                .iter()
+                .position(|(n, _)| *n == name)
+                .expect("one result per session");
+            results.swap_remove(pos).1
+        };
         let sessions = Self {
-            // `results` is in NAMES order.
-            tts_main: next(),
-            istft: next(),
-            homosolver: next(),
-            accentor_tensor: next(),
+            tts_main: take(TTS_MAIN),
+            istft: take(ISTFT),
+            homosolver: take(HOMOSOLVER),
+            accentor_tensor: take(ACCENTOR_TENSOR),
         };
         info!(
             elapsed_ms = total.elapsed().as_secs_f64() * 1e3,
@@ -270,6 +294,48 @@ mod tests {
         write_manifest(tmp.path(), &[("a.bin", &sha, data.len() as u64)]);
         let manifest = Manifest::load(tmp.path()).expect("load manifest");
         manifest.verify(tmp.path()).expect("verify ok");
+    }
+
+    #[test]
+    fn verify_accepts_multiple_matching_files() {
+        // Multi-entry happy path exercises the concurrent hash fan-out.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_a = b"hello bundle";
+        let data_b = b"other file contents";
+        std::fs::write(tmp.path().join("a.bin"), data_a).expect("write file");
+        std::fs::write(tmp.path().join("b.bin"), data_b).expect("write file");
+        let sha_a = format!("{:x}", Sha256::new().chain_update(data_a).finalize());
+        let sha_b = format!("{:x}", Sha256::new().chain_update(data_b).finalize());
+        write_manifest(
+            tmp.path(),
+            &[
+                ("a.bin", &sha_a, data_a.len() as u64),
+                ("b.bin", &sha_b, data_b.len() as u64),
+            ],
+        );
+        let manifest = Manifest::load(tmp.path()).expect("load manifest");
+        manifest.verify(tmp.path()).expect("verify ok");
+    }
+
+    #[test]
+    fn verify_reports_first_mismatch_in_manifest_order() {
+        // Two corrupted entries: the error must name the first one in
+        // manifest order (the documented contract of `verify`).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data = b"hello bundle";
+        std::fs::write(tmp.path().join("a.bin"), data).expect("write file");
+        std::fs::write(tmp.path().join("b.bin"), data).expect("write file");
+        write_manifest(
+            tmp.path(),
+            &[
+                ("a.bin", &"1".repeat(64), data.len() as u64),
+                ("b.bin", &"2".repeat(64), data.len() as u64),
+            ],
+        );
+        let manifest = Manifest::load(tmp.path()).expect("load manifest");
+        let err = manifest.verify(tmp.path()).expect_err("must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("a.bin"), "expected first entry: {msg}");
     }
 
     #[test]

--- a/silero-native/src/bundle.rs
+++ b/silero-native/src/bundle.rs
@@ -8,6 +8,7 @@
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use ort::session::Session;
 use serde::Deserialize;
@@ -152,9 +153,17 @@ impl Sessions {
     /// Open every model session. Call only after [`Manifest::verify`].
     #[instrument(skip_all)]
     pub fn open(bundle_dir: &Path, manifest: &Manifest) -> Result<Self> {
+        let total = Instant::now();
         let open = |name: &str| -> Result<Session> {
             let path = manifest.file_path(bundle_dir, name)?;
-            open_session(&path)
+            let t = Instant::now();
+            let session = open_session(&path)?;
+            info!(
+                model = name,
+                elapsed_ms = t.elapsed().as_secs_f64() * 1e3,
+                "ONNX session opened"
+            );
+            Ok(session)
         };
         let sessions = Self {
             tts_main: open(TTS_MAIN)?,
@@ -164,7 +173,10 @@ impl Sessions {
             homosolver: open(HOMOSOLVER)?,
             accentor_tensor: open(ACCENTOR_TENSOR)?,
         };
-        info!("all six ONNX sessions initialized");
+        info!(
+            elapsed_ms = total.elapsed().as_secs_f64() * 1e3,
+            "all six ONNX sessions initialized"
+        );
         Ok(sessions)
     }
 }

--- a/silero-native/src/bundle.rs
+++ b/silero-native/src/bundle.rs
@@ -94,30 +94,52 @@ impl Manifest {
     }
 
     /// Verify every listed file against size and sha256. Returns the first
-    /// mismatch as a typed `Bundle` error naming the file.
+    /// mismatch (in manifest order) as a typed `Bundle` error naming the
+    /// file.
+    ///
+    /// Files are hashed concurrently: sha256 of ~230 MB of models is pure
+    /// CPU once the page cache is warm, and sequentially it costs ~115 ms
+    /// of engine load time.
     #[instrument(skip(self), fields(files = self.files.len()))]
     pub fn verify(&self, bundle_dir: &Path) -> Result<()> {
-        for entry in &self.files {
-            let path = bundle_dir.join(&entry.path);
-            let meta = std::fs::metadata(&path)
-                .map_err(|e| EngineError::Bundle(format!("cannot stat {}: {e}", path.display())))?;
-            if meta.len() != entry.size {
-                return Err(EngineError::Bundle(format!(
-                    "size mismatch for {}: expected {}, got {}",
-                    entry.path,
-                    entry.size,
-                    meta.len()
-                )));
-            }
-            let actual = sha256_file(&path)?;
-            if !actual.eq_ignore_ascii_case(&entry.sha256) {
-                return Err(EngineError::Bundle(format!(
-                    "sha256 mismatch for {}",
-                    entry.path
-                )));
-            }
-            debug!(file = %entry.path, "bundle file verified");
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = self
+                .files
+                .iter()
+                .map(|entry| scope.spawn(|| self.verify_entry(bundle_dir, entry)))
+                .collect();
+            handles
+                .into_iter()
+                .map(|h| {
+                    h.join()
+                        .map_err(|_| EngineError::Bundle("verify thread panicked".to_string()))?
+                })
+                .collect::<Result<Vec<()>>>()
+        })?;
+        Ok(())
+    }
+
+    /// Size + sha256 check of one manifest entry.
+    fn verify_entry(&self, bundle_dir: &Path, entry: &ManifestFile) -> Result<()> {
+        let path = bundle_dir.join(&entry.path);
+        let meta = std::fs::metadata(&path)
+            .map_err(|e| EngineError::Bundle(format!("cannot stat {}: {e}", path.display())))?;
+        if meta.len() != entry.size {
+            return Err(EngineError::Bundle(format!(
+                "size mismatch for {}: expected {}, got {}",
+                entry.path,
+                entry.size,
+                meta.len()
+            )));
         }
+        let actual = sha256_file(&path)?;
+        if !actual.eq_ignore_ascii_case(&entry.sha256) {
+            return Err(EngineError::Bundle(format!(
+                "sha256 mismatch for {}",
+                entry.path
+            )));
+        }
+        debug!(file = %entry.path, "bundle file verified");
         Ok(())
     }
 
@@ -133,24 +155,41 @@ impl Manifest {
     }
 }
 
-/// Open ONNX sessions for all six models of the bundle.
+/// Open ONNX sessions for the always-needed models of the bundle.
+///
+/// The rate-specific PQMF filters are NOT opened here: they are tiny, but
+/// each is only needed when synthesis at that sample rate is actually
+/// requested, so the engine lazy-opens them on first use (see
+/// `Engine::synthesize`).
 pub struct Sessions {
     pub tts_main: Session,
     pub istft: Session,
-    pub pqmf_24k: Session,
-    pub pqmf_8k: Session,
     pub homosolver: Session,
     pub accentor_tensor: Session,
 }
 
-fn open_session(path: &Path) -> Result<Session> {
+/// Open one ONNX session with default settings.
+///
+/// Measured (issue #165, `tmp/bundle-v5`, Ryzen 9 7900): graph optimization
+/// level makes no difference to session-creation time — Level3 ≈ Level1 ≈
+/// Disable at ~310 ms for all sessions — because model parse/arena init
+/// dominates, not the optimizers. That also rules out the `.ort`
+/// compiled-model cache (it only skips optimization). Keep the defaults.
+pub(crate) fn open_session(path: &Path) -> Result<Session> {
     Session::builder()
         .and_then(|mut b| b.commit_from_file(path))
         .map_err(|e| EngineError::Bundle(format!("failed to open {}: {e}", path.display())))
 }
 
 impl Sessions {
-    /// Open every model session. Call only after [`Manifest::verify`].
+    /// Open the always-needed model sessions. Call only after
+    /// [`Manifest::verify`].
+    ///
+    /// The sessions are independent, so they are opened concurrently —
+    /// sequentially the total is the *sum* of per-session times (~500 ms,
+    /// dominated by tts_main and homosolver at ~220 ms each), concurrently
+    /// it approaches the *max*. ONNX Runtime session creation is thread-safe
+    /// across independent sessions, and `Session` is `Send`.
     #[instrument(skip_all)]
     pub fn open(bundle_dir: &Path, manifest: &Manifest) -> Result<Self> {
         let total = Instant::now();
@@ -165,17 +204,35 @@ impl Sessions {
             );
             Ok(session)
         };
+        const NAMES: [&str; 4] = [TTS_MAIN, ISTFT, HOMOSOLVER, ACCENTOR_TENSOR];
+        let results = std::thread::scope(|scope| {
+            let handles: Vec<_> = NAMES
+                .iter()
+                .map(|name| scope.spawn(|| open(name)))
+                .collect();
+            handles
+                .into_iter()
+                .map(|h| {
+                    h.join()
+                        .map_err(|_| {
+                            EngineError::Bundle("session open thread panicked".to_string())
+                        })?
+                        .map(Some)
+                })
+                .collect::<Result<Vec<_>>>()
+        })?;
+        let mut results = results.into_iter();
+        let mut next = || results.next().flatten().expect("one result per session");
         let sessions = Self {
-            tts_main: open(TTS_MAIN)?,
-            istft: open(ISTFT)?,
-            pqmf_24k: open(PQMF_24K)?,
-            pqmf_8k: open(PQMF_8K)?,
-            homosolver: open(HOMOSOLVER)?,
-            accentor_tensor: open(ACCENTOR_TENSOR)?,
+            // `results` is in NAMES order.
+            tts_main: next(),
+            istft: next(),
+            homosolver: next(),
+            accentor_tensor: next(),
         };
         info!(
             elapsed_ms = total.elapsed().as_secs_f64() * 1e3,
-            "all six ONNX sessions initialized"
+            "ONNX sessions initialized"
         );
         Ok(sessions)
     }

--- a/silero-native/src/engine.rs
+++ b/silero-native/src/engine.rs
@@ -55,7 +55,8 @@ pub struct Engine {
 }
 
 impl Engine {
-    /// Verify the bundle, open all sessions, load the frontend.
+    /// Verify the bundle, open the always-needed sessions (the rate-specific
+    /// PQMF filters are lazy-opened on first use), load the frontend.
     #[instrument(skip_all, fields(dir = %bundle_dir.display()))]
     pub fn load(bundle_dir: &Path) -> Result<Self> {
         let total = Instant::now();
@@ -75,6 +76,22 @@ impl Engine {
             elapsed_ms = t.elapsed().as_secs_f64() * 1e3,
             "frontend loaded"
         );
+        let pqmf_24k_path = manifest.file_path(bundle_dir, crate::bundle::PQMF_24K)?;
+        let pqmf_8k_path = manifest.file_path(bundle_dir, crate::bundle::PQMF_8K)?;
+        // The PQMF sessions open lazily, but a bundle that lacks the files
+        // must still fail at load — pre-lazy behavior surfaced a missing
+        // model here, not mid-synthesis.
+        for path in [&pqmf_24k_path, &pqmf_8k_path] {
+            if !path
+                .try_exists()
+                .map_err(|e| EngineError::Bundle(format!("cannot stat {}: {e}", path.display())))?
+            {
+                return Err(EngineError::Bundle(format!(
+                    "missing PQMF model {}",
+                    path.display()
+                )));
+            }
+        }
         info!(
             model = %manifest.model_id,
             elapsed_ms = total.elapsed().as_secs_f64() * 1e3,
@@ -88,9 +105,9 @@ impl Engine {
             tts_main: Mutex::new(sessions.tts_main),
             istft: Mutex::new(sessions.istft),
             pqmf_24k: Mutex::new(None),
-            pqmf_24k_path: manifest.file_path(bundle_dir, crate::bundle::PQMF_24K)?,
+            pqmf_24k_path,
             pqmf_8k: Mutex::new(None),
-            pqmf_8k_path: manifest.file_path(bundle_dir, crate::bundle::PQMF_8K)?,
+            pqmf_8k_path,
         })
     }
 

--- a/silero-native/src/engine.rs
+++ b/silero-native/src/engine.rs
@@ -10,6 +10,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use ort::session::Session;
 use ort::value::Tensor;
@@ -51,13 +52,28 @@ impl Engine {
     /// Verify the bundle, open all sessions, load the frontend.
     #[instrument(skip_all, fields(dir = %bundle_dir.display()))]
     pub fn load(bundle_dir: &Path) -> Result<Self> {
+        let total = Instant::now();
         let manifest = Manifest::load(bundle_dir)?;
+        let t = Instant::now();
         manifest.verify(bundle_dir)?;
+        info!(
+            elapsed_ms = t.elapsed().as_secs_f64() * 1e3,
+            "bundle verified"
+        );
         let sessions = Sessions::open(bundle_dir, &manifest)?;
+        let t = Instant::now();
         let config = FrontendConfig::load(bundle_dir)?;
         let homosolver = HomoSolver::load(bundle_dir, &config.homosolver, sessions.homosolver)?;
         let accentor = Accentor::load(bundle_dir, &config.accentor, sessions.accentor_tensor)?;
-        info!(model = %manifest.model_id, "engine loaded");
+        info!(
+            elapsed_ms = t.elapsed().as_secs_f64() * 1e3,
+            "frontend loaded"
+        );
+        info!(
+            model = %manifest.model_id,
+            elapsed_ms = total.elapsed().as_secs_f64() * 1e3,
+            "engine loaded"
+        );
         Ok(Self {
             symbols_tail: config.symbols_tail(),
             config,

--- a/silero-native/src/engine.rs
+++ b/silero-native/src/engine.rs
@@ -8,7 +8,7 @@
 //! truncated), exactly as upstream — the engine does not duplicate it.
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
 
@@ -44,8 +44,14 @@ pub struct Engine {
     symbols_tail: HashSet<char>,
     tts_main: Mutex<Session>,
     istft: Mutex<Session>,
-    pqmf_24k: Mutex<Session>,
-    pqmf_8k: Mutex<Session>,
+    /// Rate-specific PQMF downsamplers, lazy-opened on first synthesis at
+    /// that rate: they are only needed for 24k/8k output, so an engine that
+    /// only ever serves 48 kHz (or is never used at all) does not pay for
+    /// them at load. The paths were verified by `Manifest::verify` at load.
+    pqmf_24k: Mutex<Option<Session>>,
+    pqmf_24k_path: PathBuf,
+    pqmf_8k: Mutex<Option<Session>>,
+    pqmf_8k_path: PathBuf,
 }
 
 impl Engine {
@@ -81,8 +87,10 @@ impl Engine {
             accentor,
             tts_main: Mutex::new(sessions.tts_main),
             istft: Mutex::new(sessions.istft),
-            pqmf_24k: Mutex::new(sessions.pqmf_24k),
-            pqmf_8k: Mutex::new(sessions.pqmf_8k),
+            pqmf_24k: Mutex::new(None),
+            pqmf_24k_path: manifest.file_path(bundle_dir, crate::bundle::PQMF_24K)?,
+            pqmf_8k: Mutex::new(None),
+            pqmf_8k_path: manifest.file_path(bundle_dir, crate::bundle::PQMF_8K)?,
         })
     }
 
@@ -192,12 +200,25 @@ impl Engine {
             r => {
                 let n = audio_48k.len();
                 let audio_t = Tensor::<f32>::from_array((vec![1usize, 1, n], audio_48k))?;
-                let pqmf = if r == 24000 {
-                    &self.pqmf_24k
+                let (slot, path) = if r == 24000 {
+                    (&self.pqmf_24k, &self.pqmf_24k_path)
                 } else {
-                    &self.pqmf_8k
+                    (&self.pqmf_8k, &self.pqmf_8k_path)
                 };
-                let mut session = lock_session(pqmf);
+                // Lazy open: first synthesis at this rate pays the (~2 ms)
+                // session creation here instead of every engine load paying
+                // it up front.
+                let mut slot = lock_session(slot);
+                if slot.is_none() {
+                    let t = Instant::now();
+                    *slot = Some(crate::bundle::open_session(path)?);
+                    info!(
+                        model = %path.file_name().unwrap_or_default().to_string_lossy(),
+                        elapsed_ms = t.elapsed().as_secs_f64() * 1e3,
+                        "lazy PQMF session opened"
+                    );
+                }
+                let session = slot.as_mut().expect("just initialized");
                 let outputs = session.run(ort::inputs!["audio" => audio_t])?;
                 let (_, band) = Self::take_f32(&outputs, "band0")?;
                 debug!(samples = band.len(), rate = r, "pqmf done");

--- a/silero-native/src/lib.rs
+++ b/silero-native/src/lib.rs
@@ -82,7 +82,8 @@ fn is_positional_overflow(e: &EngineError) -> bool {
 }
 
 impl SileroNative {
-    /// Load and verify the model bundle, open all ONNX sessions.
+    /// Load and verify the model bundle, open the always-needed ONNX
+    /// sessions (PQMF opens lazily on first use).
     pub fn load(bundle_dir: impl AsRef<Path>) -> Result<Self> {
         Ok(Self {
             engine: Engine::load(bundle_dir.as_ref())?,

--- a/silero-native/src/lib.rs
+++ b/silero-native/src/lib.rs
@@ -16,14 +16,13 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 
-use ort::session::Session;
 use tracing::{debug, instrument};
 
 pub use engine::Engine;
 pub use error::{EngineError, Result};
 pub use timestamps::WordTimestamp;
 
-/// Lock an engine session mutex, recovering from poisoning.
+/// Lock an engine mutex, recovering from poisoning.
 ///
 /// Poisoning here means a previous inference panicked while holding the
 /// lock — which the public API already converts into a typed error via
@@ -31,7 +30,7 @@ pub use timestamps::WordTimestamp;
 /// `run` calls, so reusing a session after a panic is safe; returning the
 /// inner guard keeps the engine usable for subsequent calls (spec:
 /// "engine panic is contained").
-pub(crate) fn lock_session(m: &Mutex<Session>) -> MutexGuard<'_, Session> {
+pub(crate) fn lock_session<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
     m.lock().unwrap_or_else(|e| e.into_inner())
 }
 

--- a/silero-native/tests/bundle_load.rs
+++ b/silero-native/tests/bundle_load.rs
@@ -15,5 +15,5 @@ fn valid_bundle_loads_all_sessions() {
     manifest
         .verify(&dir)
         .expect("bundle files must match sha256");
-    Sessions::open(&dir, &manifest).expect("all six sessions must open");
+    Sessions::open(&dir, &manifest).expect("always-needed sessions must open");
 }


### PR DESCRIPTION
## What

Cuts native engine load from ~650 ms to ~440 ms (~1.5x) — ~3.8x faster
than the Python ttsd spawn-to-ready (~1680 ms) on the same machine
(Ryzen 9 7900).

Closes #165.

## Changes

- **Measure first**: per-phase tracing timings (manifest verify, each
  ONNX session open, frontend, total) via `RUST_LOG=silero_native=info`;
  the bench example now reports `load_ms`.
- **Concurrent session creation**: the four always-needed sessions open
  on scoped threads (507 → ~340 ms), assembled by model name.
- **Concurrent sha256 verify** (115 → ~60 ms).
- **Lazy PQMF**: `pqmf_24k`/`pqmf_8k` open on the first synthesis at
  that rate; a missing PQMF file still fails at load.
- **Warmup at app start**: already covered (`spawn_initial_warmup` via
  the engine switcher) — verified, no change needed.

Measured and rejected: ORT graph optimization level (Level3 ≈ Level1 ≈
Disable) and the `.ort` compiled-model cache — session creation is
dominated by model parse/arena init, not the optimizers.

Baseline + final numbers and methodology: new "Engine load time"
section in `silero-native/docs/benchmarks.md`.

## Verification

- `just test` — green (Rust incl. the bundle-gated parity suite, TS, Python)
- `just lint` — green
- Behavior unchanged: same models, same output (parity suite pins it)