### PR TITLE
feat(ui): expose cancel_synthesis in the queue entry menu

### DIFF
--- a/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/proposal.md
+++ b/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: Expose cancel_synthesis in the queue entry menu (#161)
+
+## Summary
+
+The backend `cancel_synthesis(id)` command is fully wired and tested
+(#88, #127), but no UI calls it: the queue entry context menu offers only
+"Воспроизвести", "Перегенерировать аудио", and "Удалить". While a synthesis
+runs, the user cannot abort it from the app.
+
+Add an "Отменить синтез" item to the queue entry context menu, enabled only
+while the entry's status is `processing`, calling
+`commands.cancelSynthesis(entry.id)`.
+
+## Capabilities
+
+- `queue-lifecycle` (modified — Per-entry actions)
+
+## Non-goals
+
+- No backend changes: abort semantics (entry back to `pending`, late
+  completion discarded, ttsd kill) are already settled and tested.
+- No confirmation dialog: cancellation is non-destructive (the entry stays
+  in the queue and can be regenerated), unlike deletion.
+- No local status mutation on click: the backend emits `entry_updated`,
+  which the existing subscription applies.
+
+## Approach
+
+`QueueList.tsx`: new `handleCancelSynthesis` (await
+`commands.cancelSynthesis`, error notification on failure, mirroring
+`handleRegenerate`) and a Menu.Item placed after "Перегенерировать аудио",
+`disabled` unless `menu.entry.status === 'processing'`. Component test
+(mocked `../lib/tauri`) covers: click on a `processing` entry calls
+`cancelSynthesis` with its id; the item is disabled for `ready`/`pending`
+entries.

--- a/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/specs/queue-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/specs/queue-lifecycle/spec.md
@@ -1,0 +1,42 @@
+# Delta: queue-lifecycle
+
+## MODIFIED Requirements
+
+### Requirement: Per-entry actions
+
+Each queue item SHALL offer a Play action (enabled only for `ready` entries)
+that invokes `play_entry`, and a right-click context menu with the items
+"Воспроизвести", "Перегенерировать аудио" (disabled while `processing`),
+"Отменить синтез" (enabled only while `processing`, invoking
+`cancel_synthesis` without a confirmation dialog — cancellation is
+non-destructive: the entry returns to `pending` and can be regenerated),
+and
+"Удалить". The currently playing entry SHALL be visually highlighted while
+playback is active or paused; the highlight clears on stop or finish. When
+the playing entry is scrolled out of view, the system SHALL show a
+"К читаемому" button that selects the playing entry and scrolls it into view.
+
+#### Scenario: Play from the queue
+
+- GIVEN an entry with status `ready`
+- WHEN the user clicks its Play button
+- THEN `play_entry` is invoked and the entry is highlighted as playing
+
+#### Scenario: Cancel a running synthesis from the menu
+
+- GIVEN an entry with status `processing`
+- WHEN the user opens its context menu and clicks "Отменить синтез"
+- THEN `cancel_synthesis` is invoked for that entry
+
+#### Scenario: Cancel item is unavailable outside processing
+
+- GIVEN an entry with any status other than `processing`
+- WHEN the user opens its context menu
+- THEN the "Отменить синтез" item is disabled
+
+#### Scenario: Jump to playing entry
+
+- GIVEN an entry is playing and the user scrolled it out of the viewport
+- WHEN the user clicks "К читаемому"
+- THEN the playing entry becomes selected and is scrolled into the center of
+  the list

--- a/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/tasks.md
+++ b/openspec/changes/archive/2026-08-01-expose-cancel-synthesis-menu/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Expose cancel_synthesis in the queue entry menu
+
+## Implementation
+
+- [x] `src/components/QueueList.tsx` — `handleCancelSynthesis` callback
+  (await `commands.cancelSynthesis(id)`, error notification on failure).
+- [x] `src/components/QueueList.tsx` — "Отменить синтез" Menu.Item after
+  "Перегенерировать аудио", disabled unless status is `processing`.
+
+## Tests
+
+- [x] Component test: click on a `processing` entry's menu item calls
+  `commands.cancelSynthesis` with the entry id.
+- [x] Component test: the item is disabled for `ready` and `pending`
+  entries.
+
+## Validation
+
+- [x] `nix develop -c pnpm test:unit` green.
+- [x] `nix develop -c just lint` green.
+- [x] openspec validate expose-cancel-synthesis-menu --strict green.

--- a/openspec/specs/queue-lifecycle/spec.md
+++ b/openspec/specs/queue-lifecycle/spec.md
@@ -132,7 +132,11 @@ query. When no entry matches, the system SHALL show "Ничего не найд�
 
 Each queue item SHALL offer a Play action (enabled only for `ready` entries)
 that invokes `play_entry`, and a right-click context menu with the items
-"Воспроизвести", "Перегенерировать аудио" (disabled while `processing`), and
+"Воспроизвести", "Перегенерировать аудио" (disabled while `processing`),
+"Отменить синтез" (enabled only while `processing`, invoking
+`cancel_synthesis` without a confirmation dialog — cancellation is
+non-destructive: the entry returns to `pending` and can be regenerated),
+and
 "Удалить". The currently playing entry SHALL be visually highlighted while
 playback is active or paused; the highlight clears on stop or finish. When
 the playing entry is scrolled out of view, the system SHALL show a
@@ -143,6 +147,18 @@ the playing entry is scrolled out of view, the system SHALL show a
 - GIVEN an entry with status `ready`
 - WHEN the user clicks its Play button
 - THEN `play_entry` is invoked and the entry is highlighted as playing
+
+#### Scenario: Cancel a running synthesis from the menu
+
+- GIVEN an entry with status `processing`
+- WHEN the user opens its context menu and clicks "Отменить синтез"
+- THEN `cancel_synthesis` is invoked for that entry
+
+#### Scenario: Cancel item is unavailable outside processing
+
+- GIVEN an entry with any status other than `processing`
+- WHEN the user opens its context menu
+- THEN the "Отменить синтез" item is disabled
 
 #### Scenario: Jump to playing entry
 

--- a/src/components/QueueList.test.tsx
+++ b/src/components/QueueList.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MantineProvider } from '@mantine/core';
+import type { TextEntry } from '../lib/tauri';
+
+const { cancelSynthesis, getEntries, showNotification } = vi.hoisted(() => ({
+  cancelSynthesis: vi.fn().mockResolvedValue(undefined),
+  getEntries: vi.fn(),
+  showNotification: vi.fn(),
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: showNotification },
+}));
+
+vi.mock('../lib/tauri', () => ({
+  commands: {
+    getEntries,
+    cancelSynthesis,
+    playEntry: vi.fn().mockResolvedValue(undefined),
+    regenerateEntry: vi.fn().mockResolvedValue(undefined),
+    deleteEntry: vi.fn().mockResolvedValue(undefined),
+  },
+  events: {
+    entryUpdated: vi.fn().mockResolvedValue(() => {}),
+    entryRemoved: vi.fn().mockResolvedValue(() => {}),
+    playbackStarted: vi.fn().mockResolvedValue(() => {}),
+    playbackStopped: vi.fn().mockResolvedValue(() => {}),
+    playbackFinished: vi.fn().mockResolvedValue(() => {}),
+  },
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+// jsdom has no matchMedia; Mantine's useComputedColorScheme needs it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+// jsdom has no ResizeObserver; Mantine's ScrollArea needs it.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??=
+  ResizeObserverStub;
+
+import { QueueList } from './QueueList';
+
+function makeEntry(status: TextEntry['status']): TextEntry {
+  return {
+    id: 'entry-1',
+    original_text: 'тестовый текст',
+    normalized_text: null,
+    status,
+    format: 'plain',
+    html_source: null,
+    created_at: '2026-07-27T00:00:00Z',
+    audio_generated_at: null,
+    audio_path: null,
+    timestamps_path: null,
+    duration_sec: null,
+    was_regenerated: false,
+    error_message: null,
+  };
+}
+
+describe('QueueList context menu', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    cancelSynthesis.mockClear();
+    showNotification.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  async function renderWith(entry: TextEntry): Promise<void> {
+    getEntries.mockResolvedValue([entry]);
+    await act(async () => {
+      root.render(
+        <MantineProvider>
+          <QueueList />
+        </MantineProvider>,
+      );
+      // Let the getEntries effect resolve and re-render the list.
+      await Promise.resolve();
+    });
+  }
+
+  async function openMenu(): Promise<void> {
+    const item = host.querySelector('[data-entry-id="entry-1"]');
+    expect(item).not.toBeNull();
+    act(() => {
+      item!.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 10,
+          clientY: 10,
+        }),
+      );
+    });
+    // Mantine's Transition mounts the dropdown after two rAF frames and the
+    // transition duration — poll instead of sleeping a fixed delay.
+    await vi.waitFor(() => {
+      expect(
+        document.querySelectorAll('[role="menuitem"]').length,
+      ).toBeGreaterThan(0);
+    });
+  }
+
+  function cancelItem(): HTMLElement {
+    const el = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((e) => e.textContent === 'Отменить синтез');
+    expect(el).toBeDefined();
+    return el!;
+  }
+
+  it('clicking "Отменить синтез" on a processing entry calls cancelSynthesis', async () => {
+    await renderWith(makeEntry('processing'));
+    await openMenu();
+
+    act(() => {
+      cancelItem().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(cancelSynthesis).toHaveBeenCalledTimes(1);
+    expect(cancelSynthesis).toHaveBeenCalledWith('entry-1');
+  });
+
+  it.each(['ready', 'playing', 'pending', 'error'] as const)(
+    '"Отменить синтез" is disabled for a %s entry',
+    async (status) => {
+      await renderWith(makeEntry(status));
+      await openMenu();
+
+      const item = cancelItem();
+      expect(
+        item.hasAttribute('disabled') || item.dataset.disabled !== undefined,
+      ).toBe(true);
+    },
+  );
+
+  it('shows an error notification when cancelSynthesis rejects', async () => {
+    cancelSynthesis.mockRejectedValueOnce(new Error('boom'));
+    await renderWith(makeEntry('processing'));
+    await openMenu();
+
+    await act(async () => {
+      cancelItem().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'red',
+        message: 'Не удалось отменить синтез: boom',
+      }),
+    );
+  });
+});

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -153,9 +153,15 @@ export function QueueList() {
   // Single Menu instance shared by all queue items — cheaper than one per item
   // and avoids stacking many hidden Menu portals that can interfere with other
   // popovers (e.g. the theme dropdown in the header).
-  const [menu, setMenu] = useState<
-    { entry: TextEntry; x: number; y: number } | null
-  >(null);
+  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(
+    null,
+  );
+  // Resolve the live entry at render time: the status may change while the
+  // menu is open (e.g. synthesis finishes), and actions must see the current
+  // state, not the snapshot taken at right-click time.
+  const menuEntry = menu
+    ? (entries.find((e) => e.id === menu.id) ?? null)
+    : null;
 
   const loadEntries = useCallback(async () => {
     const result = await commands.getEntries();
@@ -267,6 +273,19 @@ export function QueueList() {
     }
   }, []);
 
+  const handleCancelSynthesis = useCallback(async (id: string) => {
+    try {
+      await commands.cancelSynthesis(id);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      notifications.show({
+        title: 'Ошибка',
+        message: `Не удалось отменить синтез: ${message}`,
+        color: 'red',
+      });
+    }
+  }, []);
+
   const handleDelete = useCallback(
     (id: string) => {
       modals.openConfirmModal({
@@ -311,7 +330,7 @@ export function QueueList() {
                 isPlaying={playingId === entry.id}
                 onSelect={setSelectedEntry}
                 onPlay={handlePlay}
-                onContextMenu={(e, x, y) => setMenu({ entry: e, x, y })}
+                onContextMenu={(e, x, y) => setMenu({ id: e.id, x, y })}
               />
             ))}
           </Stack>
@@ -361,23 +380,29 @@ export function QueueList() {
         <Menu.Dropdown>
           <Menu.Item
             disabled={
-              menu === null ||
-              (menu.entry.status !== 'ready' && menu.entry.status !== 'playing')
+              menuEntry === null ||
+              (menuEntry.status !== 'ready' && menuEntry.status !== 'playing')
             }
-            onClick={() => menu && handlePlay(menu.entry.id)}
+            onClick={() => menuEntry && handlePlay(menuEntry.id)}
           >
             Воспроизвести
           </Menu.Item>
           <Menu.Item
-            disabled={menu === null || menu.entry.status === 'processing'}
-            onClick={() => menu && handleRegenerate(menu.entry.id)}
+            disabled={menuEntry === null || menuEntry.status === 'processing'}
+            onClick={() => menuEntry && handleRegenerate(menuEntry.id)}
           >
             Перегенерировать аудио
+          </Menu.Item>
+          <Menu.Item
+            disabled={menuEntry === null || menuEntry.status !== 'processing'}
+            onClick={() => menuEntry && handleCancelSynthesis(menuEntry.id)}
+          >
+            Отменить синтез
           </Menu.Item>
           <Menu.Divider />
           <Menu.Item
             color="red"
-            onClick={() => menu && handleDelete(menu.entry.id)}
+            onClick={() => menuEntry && handleDelete(menuEntry.id)}
           >
             Удалить
           </Menu.Item>


### PR DESCRIPTION
## Summary

- Adds a "Отменить синтез" item to the queue entry context menu in `QueueList`, enabled only for `processing` entries, calling the existing `cancel_synthesis` Tauri command (backend landed in #147).
- Failures show a red "Не удалось отменить синтез: …" notification.
- The menu now resolves the entry from live `entries` state instead of the right-click snapshot, so the item can't be triggered against an entry whose status changed while the menu was open (found in review: cancel on a just-finished entry would have silently flipped it back to `pending`).
- OpenSpec change `expose-cancel-synthesis-menu` archived; `queue-lifecycle` spec updated ("Per-entry actions").

## Test plan

- [x] `pnpm test:unit` — 129 passed (new `QueueList` component suite: cancel click dispatches the command, item disabled for ready/playing/pending/error, rejection shows the error notification)
- [x] `just lint` green
- [x] `cargo test` green

## Follow-up (not in this PR)

Backend `cancel_entry` flips status to `pending` unconditionally — worth hardening to a no-op/error unless `processing` (separate issue).

Closes #161