### PR TITLE
build(nix): keep a local main ref so lefthook pre-push works without an upstream

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -170,3 +170,10 @@ git push -u origin feat/short-description  # push (after approval)
 ```
 
 New features and fixes follow the standard feature-branch flow.
+
+### Git hooks (lefthook)
+
+`lefthook install` runs from the devshell `shellHook`. Fast checks (fmt, ruff) gate the commit; heavy checks (clippy, typecheck, eslint, knip) gate the push.
+
+Known upstream quirk: lefthook v2 computes pre-push files via `git diff HEAD @{push}`, and on the **first push of a branch** (no upstream yet) falls back to diffing against the *local* branch named by `origin/HEAD` — i.e. local `main`. If local `main` is absent (deleted, or checked out in another worktree/clone), every pre-push hook exits 128 and the push is rejected. The devshell `shellHook` keeps a local `main` ref around as a workaround — if you ever run the hooks outside `nix develop` and hit `fatal: ambiguous argument 'main'`, create it manually: `git branch --no-track main origin/main`. Do **not** "fix" this with `--no-verify`.
+

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -241,6 +241,19 @@ pkgs.mkShell {
     # checkout or when lefthook.yml is absent)
     lefthook install > /dev/null 2>&1 || true
 
+    # lefthook v2 computes pre-push files via `git diff --name-only HEAD
+    # @{push}`; on the FIRST push of a branch there is no upstream yet, so it
+    # falls back to diffing against the *local* branch named by
+    # refs/remotes/origin/HEAD (i.e. `main`).  When local `main` is absent
+    # (deleted, or checked out in another clone/worktree), that diff fails
+    # and every pre-push hook exits 128, rejecting the push — only
+    # `--no-verify` helps.  Keep a local `main` ref around so the fallback
+    # never breaks (best-effort, offline-safe, idempotent; staleness is
+    # harmless because our pre-push hooks don't use the file list).
+    git show-ref --verify --quiet refs/heads/main \
+      || git branch --no-track main origin/main > /dev/null 2>&1 \
+      || true
+
     echo "RuVox 2.0 development environment"
     echo "  Rust:   $(rustc --version)"
     echo "  Node:   $(node --version)"


### PR DESCRIPTION
## Summary

- lefthook v2 computes pre-push files via `git diff HEAD @{push}`; on the first push of a branch (no upstream yet) it falls back to diffing against the *local* branch named by `refs/remotes/origin/HEAD` (`main`). When local `main` is absent — deleted, or checked out in another clone/worktree — that diff fails and every pre-push hook (clippy, typecheck, eslint, knip) exits 128, rejecting the push. Verified in the lefthook source (v2.1.5 and current v2.1.10 share the same fallback logic).
- The devshell `shellHook` now keeps a local `main` ref around: `git branch --no-track main origin/main`, best-effort, offline-safe, idempotent. Staleness is harmless — our pre-push hooks don't use the computed file list.
- The quirk (and the manual workaround for running hooks outside `nix develop`) is documented in `docs/development.md`.

## Test plan

- [x] Reproduced the failure before the fix: `git diff --name-only HEAD main` → `fatal: ambiguous argument 'main'`, `lefthook run pre-push` → all hooks exit 128
- [x] After the fix: fresh `nix develop` creates `refs/heads/main`; `lefthook run pre-push` exits 0; this very branch was pushed with no `--no-verify`

Closes #175