### PR TITLE
fix(tts): reject cancel_synthesis for terminal entry statuses

### DIFF
--- a/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/proposal.md
+++ b/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/proposal.md
@@ -1,0 +1,35 @@
+# Proposal: Harden cancel_entry against non-processing entries
+
+## Why
+
+`cancel_entry` (`src-tauri/src/commands/mod.rs`) flips the entry status to
+`pending` unconditionally. The queue-lifecycle spec sanctions only the
+`processing → pending` transition. If `cancel_synthesis` is invoked for an
+entry that is no longer `processing` (a race: synthesis finished while the
+UI context menu was open — the frontend side was fixed in #174, but the
+command remains callable over IPC), a `ready`/`error`/`playing` entry
+silently regresses to `pending`, orphaning its audio from the state
+machine (playback requires `ready`; the entry would be re-synthesized on
+the next trigger).
+
+## What changes
+
+- `cancel_entry` becomes status-aware: for a `ready`, `playing`, or
+  `error` entry it fails with `synthesis_error` and changes nothing —
+  mirroring the existing error style of `play_entry` ("entry is not
+  ready" → `playback_error`). `pending` stays allowed: cancellation is
+  idempotent for a queued/idle entry (existing #129 semantics), and a
+  just-added entry briefly sits in `pending` with its synthesis task
+  already registered — cancelling must still abort it.
+- The `processing` path is unchanged: abort the task, remove registry
+  keys, flip to `pending`.
+- Spec: the Synthesis Cancellation Command requirement in `ipc-commands`
+  gains the guard clause and a scenario per non-processing status.
+
+## Non-goals
+
+- No UI changes (the menu already disables the item outside `processing`
+  since #174).
+- No changes to the stale-completion guard or ttsd kill logic.
+
+Issue: #176

--- a/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/specs/ipc-commands/spec.md
+++ b/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/specs/ipc-commands/spec.md
@@ -1,0 +1,83 @@
+# Delta: ipc-commands
+
+## MODIFIED Requirements
+
+### Requirement: Synthesis Cancellation Command
+
+The system SHALL provide `cancel_synthesis(id)` which actually stops the
+entry's synthesis work and sets the entry status back to `pending`, emitting
+`entry_updated`. Cancellation SHALL abort the entry's spawned synthesis task
+via a per-entry abort registry. If the cancelled entry had already entered
+the TTS stage, the system SHALL additionally terminate the current ttsd
+subprocess; recovery then follows the ttsd-protocol auto-restart procedure,
+and requests belonging to other entries are retried transparently. If the
+active engine was switched while the cancelled entry's synthesis was in
+flight, cancellation SHALL also terminate the previous engine's ttsd
+subprocess — the engine that is actually running the entry's request — so
+the orphaned process does not keep consuming CPU. A late
+completion or failure belonging to a cancelled entry SHALL be discarded: the
+entry MUST NOT flip to `ready` or `error`, any audio/timestamp files written
+by the late completion SHALL be removed, no further `entry_updated` for that
+completion is emitted, and no autoplay starts. A missing entry fails with
+`not_found`. Cancelling a `pending` entry SHALL succeed idempotently (the
+entry is queued or idle; a just-added entry may already have its synthesis
+task registered while still in `pending`, and cancellation must abort it).
+An entry whose status is `ready`, `playing`, or `error` SHALL be rejected
+with `synthesis_error` without changing its status or touching the
+synthesis registries.
+
+#### Scenario: cancel a queued synthesis
+
+- GIVEN an entry with status `processing` whose request has not yet reached
+  ttsd
+- WHEN `cancel_synthesis` is invoked
+- THEN the synthesis task is aborted, the entry status becomes `pending`,
+  `entry_updated` is emitted, and the ttsd subprocess keeps running (no
+  restart)
+
+#### Scenario: cancel an in-flight synthesis
+
+- GIVEN an entry with status `processing` whose request is being synthesized
+  by ttsd
+- WHEN `cancel_synthesis` is invoked
+- THEN the synthesis task is aborted, the ttsd subprocess is terminated, the
+  supervisor restarts it per the auto-restart procedure, and the entry
+  status becomes `pending`
+
+#### Scenario: cancel after an engine switch
+
+- GIVEN an entry with status `processing` whose request is being synthesized
+  by ttsd on the Silero engine
+- WHEN the active engine is switched to Piper and `cancel_synthesis` is then
+  invoked for that entry
+- THEN the synthesis task is aborted, the entry status becomes `pending`,
+  and the swapped-out Silero engine's ttsd subprocess is terminated
+
+#### Scenario: late completion is discarded
+
+- GIVEN an entry that was cancelled back to `pending` while its request was
+  in flight
+- WHEN the orphaned request completes
+- THEN the entry remains `pending`, the generated audio/timestamp files are
+  removed, no `entry_updated` with `ready` is emitted, and no autoplay
+  starts
+
+#### Scenario: cancel a missing entry
+
+- GIVEN no entry with the given id
+- WHEN `cancel_synthesis` is invoked
+- THEN the command fails with `not_found`
+
+#### Scenario: cancel an idle entry
+
+- GIVEN an entry with status `pending` and no synthesis in flight
+- WHEN `cancel_synthesis` is invoked
+- THEN the command succeeds, the entry remains `pending`, and
+  `entry_updated` is emitted
+
+#### Scenario: cancel a terminal entry
+
+- GIVEN an entry with status `ready`, `playing`, or `error`
+- WHEN `cancel_synthesis` is invoked
+- THEN the command fails with `synthesis_error`, the entry status is left
+  unchanged, and no `entry_updated` is emitted

--- a/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/tasks.md
+++ b/openspec/changes/archive/2026-08-01-harden-cancel-entry-status-guard/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Harden cancel_entry against non-processing entries
+
+## Implementation
+
+- [x] `src-tauri/src/commands/mod.rs` `cancel_entry` — return
+  `CommandError::SynthesisError` ("entry {id} cannot be cancelled
+  (status: …)") for `ready` / `playing` / `error`, before touching the
+  registries or storage; `pending` stays allowed (idempotent cancel, #129
+  semantics; a just-added entry sits in `pending` with its task already
+  registered); keep the `processing` path unchanged.
+
+## Tests
+
+- [x] Unit test per terminal status (`ready`, `error`; `playing` is
+  unreachable through storage): fails with `SynthesisError`, stored status
+  unchanged, registries untouched.
+- [x] Unit test: `pending` entry with a registered task — cancel succeeds
+  and the task is aborted.
+- [x] Existing `processing` tests still pass unchanged.
+
+## Validation
+
+- [x] `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml` green.
+- [x] `nix develop -c just lint` green.
+- [x] `openspec validate harden-cancel-entry-status-guard --strict` green.

--- a/openspec/specs/ipc-commands/spec.md
+++ b/openspec/specs/ipc-commands/spec.md
@@ -326,7 +326,12 @@ completion or failure belonging to a cancelled entry SHALL be discarded: the
 entry MUST NOT flip to `ready` or `error`, any audio/timestamp files written
 by the late completion SHALL be removed, no further `entry_updated` for that
 completion is emitted, and no autoplay starts. A missing entry fails with
-`not_found`.
+`not_found`. Cancelling a `pending` entry SHALL succeed idempotently (the
+entry is queued or idle; a just-added entry may already have its synthesis
+task registered while still in `pending`, and cancellation must abort it).
+An entry whose status is `ready`, `playing`, or `error` SHALL be rejected
+with `synthesis_error` without changing its status or touching the
+synthesis registries.
 
 #### Scenario: cancel a queued synthesis
 
@@ -369,6 +374,20 @@ completion is emitted, and no autoplay starts. A missing entry fails with
 - GIVEN no entry with the given id
 - WHEN `cancel_synthesis` is invoked
 - THEN the command fails with `not_found`
+
+#### Scenario: cancel an idle entry
+
+- GIVEN an entry with status `pending` and no synthesis in flight
+- WHEN `cancel_synthesis` is invoked
+- THEN the command succeeds, the entry remains `pending`, and
+  `entry_updated` is emitted
+
+#### Scenario: cancel a terminal entry
+
+- GIVEN an entry with status `ready`, `playing`, or `error`
+- WHEN `cancel_synthesis` is invoked
+- THEN the command fails with `synthesis_error`, the entry status is left
+  unchanged, and no `entry_updated` is emitted
 
 ### Requirement: Playback Control Commands
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -957,6 +957,15 @@ pub async fn regenerate_entry<R: Runtime>(
 /// synthesis task (if registered) and flip the entry back to `pending`.
 /// Returns the updated entry plus whether the task had entered the TTS
 /// stage — the caller kills ttsd only in that case.
+///
+/// Only a `processing` or `pending` entry may be cancelled: the spec
+/// sanctions just the `processing → pending` transition, and silently
+/// regressing a `ready` / `error` entry to `pending` would orphan its
+/// audio from the state machine (playback requires `ready`). `pending`
+/// is allowed: cancellation is idempotent for a queued/idle entry, and a
+/// just-added entry briefly sits in `pending` with its synthesis task
+/// already registered — cancelling must still abort it. `ready`,
+/// `playing` and `error` fail with `synthesis_error` and change nothing.
 fn cancel_entry(
     storage: &StorageService,
     synthesis_tasks: &Mutex<HashMap<EntryId, AbortHandle>>,
@@ -965,6 +974,15 @@ fn cancel_entry(
 ) -> CmdResult<(TextEntry, bool)> {
     let mut entry = require_entry(storage, id)?;
     let uuid = entry.id;
+
+    if !matches!(entry.status, EntryStatus::Processing | EntryStatus::Pending) {
+        return Err(CommandError::SynthesisError {
+            message: format!(
+                "entry {id} cannot be cancelled (status: {:?})",
+                entry.status
+            ),
+        });
+    }
 
     // An aborted task is destroyed at its next yield point and never runs
     // its own registry cleanup, so both keys are removed here. Aborting an
@@ -1616,6 +1634,71 @@ mod synthesis_tests {
             CommandError::NotFound { message } => assert!(message.contains("entry not found")),
             other => panic!("expected NotFound, got {other:?}"),
         }
+    }
+
+    /// Cancelling a `ready` or `error` entry fails with `synthesis_error`
+    /// and changes nothing: the stored status is untouched and the
+    /// registries keep their keys. (`playing` can't be exercised here —
+    /// storage normalizes it to `ready` on save; the guard covers it the
+    /// same way.)
+    #[tokio::test]
+    async fn cancel_entry_rejects_terminal_statuses() {
+        for status in [EntryStatus::Ready, EntryStatus::Error] {
+            let (storage, _dir) = make_service();
+            let entry = storage.add_entry("текст".to_string()).unwrap();
+            set_status(&storage, &entry, status);
+            let id = entry.id;
+
+            let tasks: Mutex<HashMap<EntryId, AbortHandle>> = Mutex::new(HashMap::new());
+            let entered: Mutex<HashSet<EntryId>> = Mutex::new(HashSet::new());
+            let sleeper = tokio::spawn(async {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            });
+            tasks.lock().insert(id, sleeper.abort_handle());
+            entered.lock().insert(id);
+
+            let err = cancel_entry(&storage, &tasks, &entered, &id.to_string()).unwrap_err();
+            match err {
+                CommandError::SynthesisError { message } => {
+                    assert!(
+                        message.contains("cannot be cancelled"),
+                        "{status:?}: {message}"
+                    );
+                }
+                other => panic!("{status:?}: expected SynthesisError, got {other:?}"),
+            }
+            assert_eq!(storage.get_entry(&id).unwrap().status, status);
+            assert!(tasks.lock().contains_key(&id));
+            assert!(entered.lock().contains(&id));
+
+            sleeper.abort();
+        }
+    }
+
+    /// Cancelling a `pending` entry is allowed and idempotent: a just-added
+    /// entry briefly sits in `pending` with its synthesis task already
+    /// registered, and cancelling must still abort that task.
+    #[tokio::test]
+    async fn cancel_entry_pending_entry_aborts_registered_task() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap(); // pending
+        let id = entry.id;
+
+        let tasks: Mutex<HashMap<EntryId, AbortHandle>> = Mutex::new(HashMap::new());
+        let entered: Mutex<HashSet<EntryId>> = Mutex::new(HashSet::new());
+        let sleeper = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+        tasks.lock().insert(id, sleeper.abort_handle());
+
+        let (updated, entered_tts) =
+            cancel_entry(&storage, &tasks, &entered, &id.to_string()).unwrap();
+
+        assert_eq!(updated.status, EntryStatus::Pending);
+        assert!(!entered_tts);
+        assert!(tasks.lock().is_empty());
+        let join_err = sleeper.await.unwrap_err();
+        assert!(join_err.is_cancelled());
     }
 
     /// Cancel flips the entry to `pending`, removes both registry keys, and


### PR DESCRIPTION
## Summary

- `cancel_entry` previously flipped **any** entry to `pending` unconditionally. A cancel arriving after the entry left `processing` (the race fixed frontend-side in #174: synthesis finishes while the context menu is open) silently regressed a `ready`/`error` entry and orphaned its audio from the state machine (playback requires `ready`; the entry would be re-synthesized on the next trigger).
- Now `ready`/`playing`/`error` are rejected with `synthesis_error` before touching the registries or storage — same error style as `play_entry`'s "entry is not ready".
- `pending` stays allowed **deliberately**: cancel is idempotent for idle entries (existing #129 orchestration test pins this), and a just-added entry briefly sits in `pending` with its synthesis task already registered — rejecting it would break that window.
- OpenSpec change `harden-cancel-entry-status-guard` archived; `ipc-commands` spec updated (idle-cancel allowed, terminal-entry rejection, new scenarios).

## Test plan

- [x] `cargo test` — 974 passed (new: reject `ready`/`error` with registries untouched; `pending` with a registered task still aborts it)
- [x] `just lint` green
- [x] `openspec validate --specs --strict` green

## Follow-up (not in this PR)

A µs-scale read-decide-write race remains between `require_entry` and `update_entry` (guard reads a clone, synthesis can complete before the write). Closing it needs a storage-level compare-and-set, which would also harden `apply_ready_if_current`/`apply_error_if_current` — will be filed as a separate tech-debt issue.

Closes #176