### PR TITLE
perf(silero-native): profile and optimize the native engine (fixes #164)

### DIFF
--- a/silero-native/Cargo.toml
+++ b/silero-native/Cargo.toml
@@ -36,3 +36,11 @@ unicode_categories = "0.1"
 [dev-dependencies]
 tempfile = "3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Line tables in the release profile so `perf` / flamegraph attribute
+# samples to Rust source lines when profiling the bench example (issue
+# #164; commands in docs/architecture.md "Debugging guide"). Ignored when
+# the crate is built as a dependency of src-tauri — cargo takes profiles
+# from the top-level manifest only, so production binaries are unaffected.
+[profile.release]
+debug = "line-tables-only"

--- a/silero-native/docs/architecture.md
+++ b/silero-native/docs/architecture.md
@@ -64,6 +64,20 @@ unsupported sample rate), `synthesis_failed`.
   (regenerate with `tmp/gen_parity_fixtures.py`-style scripts — always
   after `unpack_q_model()`, or homograph resolution differs; this is a
   documented trap).
+- **Profile a synthesis (issue #164).** The bench example reports a
+  per-stage breakdown (frontend / tts_main / istft / pqmf / wav encode)
+  per sample rate:
+  `nix develop -c cargo run --release --manifest-path silero-native/Cargo.toml --example bench`.
+  The crate's `[profile.release]` carries `debug = "line-tables-only"`,
+  so `perf` attributes samples to source lines:
+  `nix develop -c bash -c 'cargo build --release --manifest-path silero-native/Cargo.toml --example bench && perf record -g --call-graph dwarf ./silero-native/target/release/examples/bench && perf report'`.
+  For a flamegraph swap `perf report` for
+  `nix shell nixpkgs#flamegraph -c bash -c 'perf script | stackcollapse-perf.pl | flamegraph.pl > tmp/flamegraph.svg'`
+  (or `nix shell nixpkgs#flamegraph -c cargo flamegraph --example bench`,
+  which wraps the same pipeline).
+  If `perf record` fails with a permissions error, check
+  `kernel.perf_event_paranoid` (`-1`/`1` allows user-space profiling) and
+  `kernel.kptr_restrict` — do not change system settings silently.
 - **Inspect intermediate tensors.** `tts_main.onnx` exposes `dur_hat`
   (per-symbol frame durations, frame = 12.5 ms) as its 4th output;
   `EngineOutput.spoken_text` carries the accented text the frontend

--- a/silero-native/docs/benchmarks.md
+++ b/silero-native/docs/benchmarks.md
@@ -1,6 +1,8 @@
 # Benchmarks
 
-Date: 2026-07-27. CPU: AMD Ryzen 9 7900 (12 cores / 24 threads).
+Date: 2026-08-01 (headline numbers re-measured after the issue #164
+optimization; previous 2026-07-27 baseline kept in the per-stage section
+below). CPU: AMD Ryzen 9 7900 (12 cores / 24 threads).
 Toolchain: Rust engine via `ort` 2.0.0-rc.12 + nixpkgs onnxruntime
 1.26.0 (`load-dynamic`); Python reference = torch CPU `apply_tts` from
 `silero-native/export/.venv` on the same `v5_ru.pt` (after
@@ -22,10 +24,12 @@ chars), speaker `aidar`, 24000 Hz.
 
 | Engine | mean | p95 | min | max |
 |---|---|---|---|---|
-| silero-native (release) | 108.8 ms | 125.5 ms | 71.9 ms | 128.4 ms |
-| Python torch `apply_tts` | 144.4 ms | — | 142.5 ms | 146.0 ms |
+| silero-native (release) | 36.6 ms | 42.6 ms | 33.7 ms | 43.6 ms |
+| Python torch `apply_tts` | 145.0 ms | — | 142.5 ms | 151.3 ms |
 
-**Speedup: ~1.3x** (warm, full pipeline on both sides).
+**Speedup: ~4.0x** (warm, full pipeline on both sides). Pre-#164 it was
+~1.3x (108.8 ms native) — the win is the pinned ORT intra-op thread
+count, see the per-stage section below.
 
 ## Per-stage breakdown (issue #164)
 
@@ -60,6 +64,56 @@ Findings:
   the first-measured rate (24k: 85.4 vs 48k: 71.4) — CPU frequency ramp
   over the run order. Treat cross-rate deltas of rate-independent stages
   as noise; the headline methodology number stays 24k, same as before.
+
+### Optimization: ORT intra-op threads = 8
+
+The profile said the win must come from ORT itself. A/B of
+`intra_op_num_threads` (bench mean at 24k, full pipeline):
+
+| intra-op threads | mean ms | worst parity-suite case |
+|---|---|---|
+| ORT default (per logical core) | 104.1 | 9.8e-4 (pre-existing) |
+| 4 | 40.0 | **1.5e-3 — over budget** |
+| 6 | 34.0 | **2.2e-3 — over budget** |
+| **8 (chosen)** | **34.6** | **9.8e-4 — inside budget** |
+| 12 | 55.3 | — |
+| 16 | 80.0 | — |
+| 24 | 115.1 | — |
+
+ORT defaults to one thread per logical core; these graphs are chains of
+many small ops, so per-op fork/join sync across 24 threads costs more
+than the compute. Parallel execution mode made it *worse* (42.6 ms at
+intra=6), inter-op threads made no positive difference.
+
+The thread count also constrains correctness: changing it changes float
+reduction order, which drifts the waveform off the Python-ONNX parity
+fixtures (generated at ORT defaults). The `stress_marker` case is the
+canary — 1.5e-3 at 4 threads, 2.2e-3 at 6, both over the suite's 1e-3
+budget; **8 is the only reduced count that keeps all 31 cases inside the
+budget** (worst 9.8e-4, same class as the pre-existing default-thread
+baseline) and ties 6 for speed within noise. So
+`bundle.rs::open_session` pins `with_intra_threads(8)` for every session.
+
+Post-optimization breakdown (24k): tts_main 25.0 ms (68.4%), istft
+9.2 ms (25.0%), pqmf 1.1 ms, wav_encode 0.8 ms, frontend < 1%.
+Totals: **24k mean 36.6 ms / p95 42.6**; 48k mean 30.2 / p95 31.0; 8k
+mean 33.2 / p95 33.7. Side effect: engine load 437 → ~345 ms (fewer
+pool threads to spawn at session creation).
+
+Measured and rejected after the optimization:
+
+- **Allocation/copy churn** (`take_f32` `.to_vec()`, chunk concat): all
+  copies sit inside the ORT-stage timings and total well under a
+  millisecond (~1 MB of tensor buffers); `concat_timestamps` reads
+  0.05 ms, `(unaccounted)` 0.01 ms. Nothing to win.
+- **Bulk WAV encode** (hound per-sample `write_sample`): 0.8 ms at 24k
+  (2.2%). Not worth churning a parity-sensitive path (upstream
+  truncates, we round) for a sub-millisecond effect.
+
+The remaining ~34 ms is ORT inference inside the exported graphs
+themselves (tts_main ~25 ms, istft ~9 ms) — irreducible from the Rust
+client side without touching the graphs/exporter, which is out of scope
+here (parity fixtures would have to be regenerated).
 
 ## Engine load time (issue #165)
 

--- a/silero-native/docs/benchmarks.md
+++ b/silero-native/docs/benchmarks.md
@@ -12,8 +12,9 @@ Phrase: `Сервер обрабатывает запросы и сохраня�
 chars), speaker `aidar`, 24000 Hz.
 
 - **Native**: `cargo run --release --example bench` — 1 warmup + 20 timed
-  runs of `SileroNative::synthesize` (full pipeline: frontend → tts_main →
-  istft → pqmf_24k → WAV encode), engine load excluded.
+  runs of `SileroNative::synthesize` per sample rate (full pipeline:
+  frontend → tts_main → istft → pqmf → WAV encode), engine load excluded.
+  The headline comparison number is the 24000 Hz run.
 - **Python**: `tmp/bench_python.py` — 1 warmup + 5 timed runs of
   `pack.apply_tts` on the same phrase/rate.
 
@@ -25,6 +26,40 @@ chars), speaker `aidar`, 24000 Hz.
 | Python torch `apply_tts` | 144.4 ms | — | 142.5 ms | 146.0 ms |
 
 **Speedup: ~1.3x** (warm, full pipeline on both sides).
+
+## Per-stage breakdown (issue #164)
+
+Date: 2026-08-01, same machine. Bench example now reports per-stage means
+(`StageTimings` in the engine, summed over chunks) at each sample rate,
+same phrase/speaker, 1 warmup + 20 timed runs per rate. Baseline below is
+**before any optimization**, same commit that introduced the breakdown.
+
+| stage | mean ms (24k) | % |
+|---|---|---|
+| frontend_text | 0.01 | 0.0% |
+| homosolver | 0.00 | 0.0% |
+| accentor | 0.29 | 0.3% |
+| build_sequence | 0.01 | 0.0% |
+| tts_main | 85.4 | 80.3% |
+| istft | 16.5 | 15.5% |
+| pqmf | 3.5 | 3.3% |
+| wav_encode | 0.67 | 0.6% |
+| concat_timestamps | 0.03 | 0.0% |
+
+Totals per rate: 24k mean 106.4 ms / p95 122.3; 48k mean 88.8 ms / p95
+98.7; 8k mean 103.6 ms / p95 123.3. Engine load ~437 ms (unchanged).
+
+Findings:
+
+- **tts_main dominates (~80%)**, istft is ~16%, everything else is noise.
+  The text frontend (homosolver BERT + ngram accentor) is < 0.5% —
+  frontend optimization is off the table.
+- **48k PQMF path cost: zero** (48k bypasses PQMF; `pqmf` stage reads
+  0.00). PQMF downsample to 24k costs ~3.5 ms, to 8k ~2.2 ms.
+- tts_main/istft run the *same* graphs at every rate, yet read slower at
+  the first-measured rate (24k: 85.4 vs 48k: 71.4) — CPU frequency ramp
+  over the run order. Treat cross-rate deltas of rate-independent stages
+  as noise; the headline methodology number stays 24k, same as before.
 
 ## Engine load time (issue #165)
 

--- a/silero-native/examples/bench.rs
+++ b/silero-native/examples/bench.rs
@@ -1,6 +1,7 @@
-//! Benchmark: N syntheses of a fixed ~50-char phrase at 24000 Hz,
-//! reporting engine load time (`load_ms`) plus mean / p95 wall time per
-//! synthesis. Results are recorded in `docs/benchmarks.md` next to the
+//! Benchmark: N syntheses of a fixed ~50-char phrase at each supported
+//! sample rate, reporting engine load time (`load_ms`), mean / p95 wall
+//! time per synthesis and a per-stage time breakdown (issue #164).
+//! Results are recorded in `docs/benchmarks.md` next to the
 //! Python `apply_tts` comparison (see tmp/bench_python.py) and the
 //! engine-load / ttsd spawn-to-ready comparison (tmp/bench_ttsd_spawn.py).
 //!
@@ -10,15 +11,91 @@
 //! Usage: cargo run --release --example bench -- [bundle_dir]
 //! (default: ../tmp/bundle-v5 relative to the crate, or SILERO_NATIVE_BUNDLE).
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use silero_native::SileroNative;
+use silero_native::{SileroNative, StageTimings};
 
 mod common;
 
 /// ~50 chars, mirrors the Python bench phrase in tmp/bench_python.py.
 const PHRASE: &str = "Сервер обрабатывает запросы и сохраняет данные в базу.";
 const RUNS: usize = 20;
+const RATES: [u32; 3] = [24000, 48000, 8000];
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1e3
+}
+
+/// Print the per-stage mean breakdown: each stage's share of the mean total
+/// wall time. Stages sum to less than the total — the remainder is per-call
+/// overhead outside the instrumented stages (tensor construction, strip /
+/// chunking, validation).
+fn print_stage_breakdown(totals: &StageTimings, mean_total_ms: f64) {
+    let stages: [(&str, Duration); 9] = [
+        ("frontend_text", totals.frontend_text),
+        ("homosolver", totals.homosolver),
+        ("accentor", totals.accentor),
+        ("build_sequence", totals.build_sequence),
+        ("tts_main", totals.tts_main),
+        ("istft", totals.istft),
+        ("pqmf", totals.pqmf),
+        ("wav_encode", totals.wav_encode),
+        ("concat_timestamps", totals.concat_timestamps),
+    ];
+    println!("  {:<18} {:>10} {:>6}", "stage", "mean_ms", "%");
+    let mut accounted = 0.0;
+    for (name, total) in stages {
+        let mean_ms = ms(total) / RUNS as f64;
+        accounted += mean_ms;
+        println!(
+            "  {name:<18} {mean_ms:>10.2} {:>5.1}%",
+            mean_ms / mean_total_ms * 100.0
+        );
+    }
+    println!(
+        "  {:<18} {:>10.2} {:>5.1}%",
+        "(unaccounted)",
+        mean_total_ms - accounted,
+        (mean_total_ms - accounted) / mean_total_ms * 100.0
+    );
+}
+
+fn run_rate(engine: &SileroNative, rate: u32) {
+    // Warmup (JIT-less, but first-run ORT optimizations/arena allocs, and
+    // the lazy PQMF session open for this rate).
+    engine
+        .synthesize(PHRASE, "aidar", rate)
+        .expect("warmup synthesis must succeed");
+
+    let mut times = Vec::with_capacity(RUNS);
+    let mut stage_totals = StageTimings::default();
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let result = engine
+            .synthesize(PHRASE, "aidar", rate)
+            .expect("synthesis must succeed");
+        times.push(t.elapsed());
+        stage_totals += result.stage_timings;
+    }
+    times.sort();
+
+    let mean = times.iter().sum::<Duration>() / RUNS as u32;
+    // Nearest-rank p95.
+    let p95 = times[((RUNS as f64) * 0.95).ceil() as usize - 1];
+    let min = times[0];
+    let max = times[RUNS - 1];
+    println!("== {rate} Hz ==");
+    println!("mean {mean:.1?} | p95 {p95:.1?} | min {min:.1?} | max {max:.1?}");
+    println!(
+        "mean_ms={:.1} p95_ms={:.1} min_ms={:.1} max_ms={:.1}",
+        ms(mean),
+        ms(p95),
+        ms(min),
+        ms(max),
+    );
+    print_stage_breakdown(&stage_totals, ms(mean));
+    println!();
+}
 
 fn main() {
     // `RUST_LOG=silero_native=info` surfaces the per-session load timings.
@@ -32,35 +109,12 @@ fn main() {
     let engine = SileroNative::load(&dir).expect("bundle must load");
     let load = t.elapsed();
 
-    // Warmup (JIT-less, but first-run ORT optimizations/arena allocs).
-    engine
-        .synthesize(PHRASE, "aidar", 24000)
-        .expect("warmup synthesis must succeed");
-
-    let mut times = Vec::with_capacity(RUNS);
-    for _ in 0..RUNS {
-        let t = Instant::now();
-        engine
-            .synthesize(PHRASE, "aidar", 24000)
-            .expect("synthesis must succeed");
-        times.push(t.elapsed());
-    }
-    times.sort();
-
-    let mean = times.iter().sum::<std::time::Duration>() / RUNS as u32;
-    // Nearest-rank p95.
-    let p95 = times[((RUNS as f64) * 0.95).ceil() as usize - 1];
-    let min = times[0];
-    let max = times[RUNS - 1];
     println!("phrase: {PHRASE:?} ({} chars)", PHRASE.chars().count());
-    println!("runs: {RUNS} @ 24000 Hz, speaker aidar");
-    println!("mean {mean:.1?} | p95 {p95:.1?} | min {min:.1?} | max {max:.1?}");
-    println!(
-        "load_ms={:.1} mean_ms={:.1} p95_ms={:.1} min_ms={:.1} max_ms={:.1}",
-        load.as_secs_f64() * 1e3,
-        mean.as_secs_f64() * 1e3,
-        p95.as_secs_f64() * 1e3,
-        min.as_secs_f64() * 1e3,
-        max.as_secs_f64() * 1e3,
-    );
+    println!("runs: {RUNS} per rate, speaker aidar");
+    println!("load_ms={:.1}", ms(load));
+    println!();
+
+    for rate in RATES {
+        run_rate(&engine, rate);
+    }
 }

--- a/silero-native/src/bundle.rs
+++ b/silero-native/src/bundle.rs
@@ -183,16 +183,8 @@ pub struct Sessions {
     pub accentor_tensor: Session,
 }
 
-/// Open one ONNX session.
-///
-/// Measured (issue #165, `tmp/bundle-v5`, Ryzen 9 7900): graph optimization
-/// level makes no difference to session-creation time — Level3 ≈ Level1 ≈
-/// Disable at ~310 ms for all sessions — because model parse/arena init
-/// dominates, not the optimizers. That also rules out the `.ort`
-/// compiled-model cache (it only skips optimization). Keep the defaults.
-///
-/// Intra-op thread count is pinned to 8 (issue #164). ORT's default (one
-/// thread per logical core) is catastrophically slow for these models:
+/// Intra-op thread count for every ORT session (issue #164). ORT's default
+/// (one thread per logical core) is catastrophically slow for these models:
 /// the graphs are chains of many small ops, so per-op fork/join sync across
 /// 24 threads costs more than the compute. Bench mean at 24k, full pipeline:
 /// default ≈ 104 ms, 4 threads 40 ms, 6 threads 34 ms, **8 threads 35 ms**,
@@ -205,11 +197,30 @@ pub struct Sessions {
 /// suite: 1.5e-3 at 4 threads, 2.2e-3 at 6, **9.8e-4 at 8** — 8 is the
 /// only reduced count that keeps every case inside the 1e-3 budget, and
 /// it ties 6 for speed within noise.
+///
+/// The count is deliberately NOT derived from `available_parallelism()`:
+/// the parity constraint above requires a fixed reduction order, so the
+/// value must not vary across machines. On lower-core machines ORT simply
+/// oversubscribes, which is far cheaper than the many-threads default.
+const INTRA_OP_THREADS: usize = 8;
+
+/// Open one ONNX session.
+///
+/// Measured (issue #165, `tmp/bundle-v5`, Ryzen 9 7900): graph optimization
+/// level makes no difference to session-creation time — Level3 ≈ Level1 ≈
+/// Disable at ~310 ms for all sessions — because model parse/arena init
+/// dominates, not the optimizers. That also rules out the `.ort`
+/// compiled-model cache (it only skips optimization). Keep the defaults.
 pub(crate) fn open_session(path: &Path) -> Result<Session> {
     let mut builder = Session::builder()
         .map_err(|e| EngineError::Bundle(format!("session builder: {}", e.message())))?
-        .with_intra_threads(8)
-        .map_err(|e| EngineError::Bundle(format!("with_intra_threads(8): {}", e.message())))?;
+        .with_intra_threads(INTRA_OP_THREADS)
+        .map_err(|e| {
+            EngineError::Bundle(format!(
+                "with_intra_threads({INTRA_OP_THREADS}): {}",
+                e.message()
+            ))
+        })?;
     builder
         .commit_from_file(path)
         .map_err(|e| EngineError::Bundle(format!("failed to open {}: {e}", path.display())))

--- a/silero-native/src/bundle.rs
+++ b/silero-native/src/bundle.rs
@@ -183,16 +183,35 @@ pub struct Sessions {
     pub accentor_tensor: Session,
 }
 
-/// Open one ONNX session with default settings.
+/// Open one ONNX session.
 ///
 /// Measured (issue #165, `tmp/bundle-v5`, Ryzen 9 7900): graph optimization
 /// level makes no difference to session-creation time — Level3 ≈ Level1 ≈
 /// Disable at ~310 ms for all sessions — because model parse/arena init
 /// dominates, not the optimizers. That also rules out the `.ort`
 /// compiled-model cache (it only skips optimization). Keep the defaults.
+///
+/// Intra-op thread count is pinned to 8 (issue #164). ORT's default (one
+/// thread per logical core) is catastrophically slow for these models:
+/// the graphs are chains of many small ops, so per-op fork/join sync across
+/// 24 threads costs more than the compute. Bench mean at 24k, full pipeline:
+/// default ≈ 104 ms, 4 threads 40 ms, 6 threads 34 ms, **8 threads 35 ms**,
+/// 12 threads 55 ms, 24 threads 115 ms; parallel execution mode and inter-op
+/// threads made no positive difference.
+///
+/// Why 8 and not 4–6: changing the thread count changes float reduction
+/// order, which drifts the waveform off the Python-ONNX parity fixtures
+/// (generated at ORT defaults). Measured worst case across the 31-case
+/// suite: 1.5e-3 at 4 threads, 2.2e-3 at 6, **9.8e-4 at 8** — 8 is the
+/// only reduced count that keeps every case inside the 1e-3 budget, and
+/// it ties 6 for speed within noise.
 pub(crate) fn open_session(path: &Path) -> Result<Session> {
-    Session::builder()
-        .and_then(|mut b| b.commit_from_file(path))
+    let mut builder = Session::builder()
+        .map_err(|e| EngineError::Bundle(format!("session builder: {}", e.message())))?
+        .with_intra_threads(8)
+        .map_err(|e| EngineError::Bundle(format!("with_intra_threads(8): {}", e.message())))?;
+    builder
+        .commit_from_file(path)
         .map_err(|e| EngineError::Bundle(format!("failed to open {}: {e}", path.display())))
 }
 

--- a/silero-native/src/engine.rs
+++ b/silero-native/src/engine.rs
@@ -27,7 +27,7 @@ use crate::lock_session;
 
 /// Per-stage wall times of one synthesis, collected with `Instant` around
 /// each pipeline stage (a handful of clock reads per call — negligible
-/// against an ~100 ms synthesis). Drives the per-stage breakdown printed by
+/// against a ~35 ms synthesis). Drives the per-stage breakdown printed by
 /// `examples/bench.rs` and recorded in `docs/benchmarks.md` (issue #164).
 ///
 /// `wav_encode` / `concat_timestamps` live outside [`Engine`] (in
@@ -266,7 +266,6 @@ impl Engine {
         debug!(samples_48k = audio_48k.len(), "istft done");
 
         // PQMF downsample for 24k/8k; 48k passes through.
-        let t = Instant::now();
         let (samples, out_rate) = match sample_rate {
             r if r == self.config.native_sample_rate => (audio_48k, r),
             r => {
@@ -291,13 +290,16 @@ impl Engine {
                     );
                 }
                 let session = slot.as_mut().expect("just initialized");
+                // Timer placement matches the other ORT stages: around
+                // run + output extraction, after input tensor construction.
+                let t = Instant::now();
                 let outputs = session.run(ort::inputs!["audio" => audio_t])?;
                 let (_, band) = Self::take_f32(&outputs, "band0")?;
+                timings.pqmf += t.elapsed();
                 debug!(samples = band.len(), rate = r, "pqmf done");
                 (band, r)
             }
         };
-        timings.pqmf += t.elapsed();
 
         Ok(EngineOutput {
             duration_sec: samples.len() as f32 / out_rate as f32,
@@ -306,5 +308,40 @@ impl Engine {
             spoken_text,
             stage_timings: timings,
         })
+    }
+}
+
+#[cfg(test)]
+mod stage_timings_tests {
+    use super::*;
+
+    /// Full-literal field coverage: adding a stage to `StageTimings` fails
+    /// compilation here, forcing the author to also extend `AddAssign` and
+    /// the bench breakdown array — otherwise the new stage would silently
+    /// vanish into the bench's "(unaccounted)" row.
+    #[test]
+    fn add_assign_covers_every_field() {
+        let a = StageTimings {
+            frontend_text: Duration::from_millis(1),
+            homosolver: Duration::from_millis(2),
+            accentor: Duration::from_millis(3),
+            build_sequence: Duration::from_millis(4),
+            tts_main: Duration::from_millis(5),
+            istft: Duration::from_millis(6),
+            pqmf: Duration::from_millis(7),
+            wav_encode: Duration::from_millis(8),
+            concat_timestamps: Duration::from_millis(9),
+        };
+        let mut acc = a;
+        acc += a;
+        assert_eq!(acc.frontend_text, Duration::from_millis(2));
+        assert_eq!(acc.homosolver, Duration::from_millis(4));
+        assert_eq!(acc.accentor, Duration::from_millis(6));
+        assert_eq!(acc.build_sequence, Duration::from_millis(8));
+        assert_eq!(acc.tts_main, Duration::from_millis(10));
+        assert_eq!(acc.istft, Duration::from_millis(12));
+        assert_eq!(acc.pqmf, Duration::from_millis(14));
+        assert_eq!(acc.wav_encode, Duration::from_millis(16));
+        assert_eq!(acc.concat_timestamps, Duration::from_millis(18));
     }
 }

--- a/silero-native/src/engine.rs
+++ b/silero-native/src/engine.rs
@@ -8,9 +8,10 @@
 //! truncated), exactly as upstream — the engine does not duplicate it.
 
 use std::collections::HashSet;
+use std::ops::AddAssign;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ort::session::Session;
 use ort::value::Tensor;
@@ -24,6 +25,44 @@ use crate::frontend::homosolver::HomoSolver;
 use crate::frontend::text::{build_sequence, prepare_text_input};
 use crate::lock_session;
 
+/// Per-stage wall times of one synthesis, collected with `Instant` around
+/// each pipeline stage (a handful of clock reads per call — negligible
+/// against an ~100 ms synthesis). Drives the per-stage breakdown printed by
+/// `examples/bench.rs` and recorded in `docs/benchmarks.md` (issue #164).
+///
+/// `wav_encode` / `concat_timestamps` live outside [`Engine`] (in
+/// `SileroNative::synthesize`), so they stay zero here.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StageTimings {
+    /// `prepare_text_input` (normalize + symbol filter).
+    pub frontend_text: Duration,
+    pub homosolver: Duration,
+    pub accentor: Duration,
+    pub build_sequence: Duration,
+    pub tts_main: Duration,
+    pub istft: Duration,
+    /// PQMF downsample (24k/8k only; zero for 48k pass-through).
+    pub pqmf: Duration,
+    /// 16-bit PCM WAV encode of the concatenated samples.
+    pub wav_encode: Duration,
+    /// Chunk concat + word-timestamp estimation.
+    pub concat_timestamps: Duration,
+}
+
+impl AddAssign for StageTimings {
+    fn add_assign(&mut self, rhs: Self) {
+        self.frontend_text += rhs.frontend_text;
+        self.homosolver += rhs.homosolver;
+        self.accentor += rhs.accentor;
+        self.build_sequence += rhs.build_sequence;
+        self.tts_main += rhs.tts_main;
+        self.istft += rhs.istft;
+        self.pqmf += rhs.pqmf;
+        self.wav_encode += rhs.wav_encode;
+        self.concat_timestamps += rhs.concat_timestamps;
+    }
+}
+
 /// Raw synthesis output (pre-WAV).
 pub struct EngineOutput {
     /// f32 samples in [-1, 1] at `sample_rate`.
@@ -32,6 +71,8 @@ pub struct EngineOutput {
     pub duration_sec: f32,
     /// Text after the full frontend (what was actually spoken).
     pub spoken_text: String,
+    /// Per-stage wall times of this chunk's synthesis.
+    pub stage_timings: StageTimings,
 }
 
 /// The in-process Silero v5 engine.
@@ -120,25 +161,33 @@ impl Engine {
     /// timestamps are in stripped-text coordinates, so a second strip here
     /// would be both redundant and contractually confusing). Direct
     /// `Engine` callers with markup-bearing text must strip first.
-    fn prepare(&self, text: &str) -> Result<(Vec<i64>, String)> {
+    fn prepare(&self, text: &str, timings: &mut StageTimings) -> Result<(Vec<i64>, String)> {
         // ttsd parity (`sanitize_for_silero`): the pipeline keeps `\n\n` in
         // the normalized text, and the symbol filter below would drop `\n`
         // silently, gluing the surrounding words into one.
         let sanitized = crate::chunking::sanitize_for_silero(text);
+        let t = Instant::now();
         let prepared = prepare_text_input(&sanitized, &self.symbols_tail);
+        timings.frontend_text += t.elapsed();
         if !prepared.has_text {
             return Err(EngineError::BadInput(
                 "text has no speakable content after normalization".to_string(),
             ));
         }
+        let t = Instant::now();
         let homosolved = self.homosolver.resolve(&prepared.sentence)?;
+        timings.homosolver += t.elapsed();
+        let t = Instant::now();
         let accented = self.accentor.accentuate(&homosolved)?;
+        timings.accentor += t.elapsed();
+        let t = Instant::now();
         let sequence = build_sequence(
             &accented,
             &self.config.symbol_to_id,
             &self.config.sos_token,
             &self.config.eos_token,
         )?;
+        timings.build_sequence += t.elapsed();
         Ok((sequence, accented))
     }
 
@@ -179,7 +228,8 @@ impl Engine {
         if text.trim().is_empty() {
             return Err(EngineError::BadInput("empty text".to_string()));
         }
-        let (sequence, spoken_text) = self.prepare(text)?;
+        let mut timings = StageTimings::default();
+        let (sequence, spoken_text) = self.prepare(text, &mut timings)?;
 
         // tts_main: sequence + speaker + neutral dur/pitch → mag/x/y.
         let len = sequence.len();
@@ -187,6 +237,7 @@ impl Engine {
         let spk_t = Tensor::<i64>::from_array((vec![1usize], vec![speaker_id]))?;
         let durs_t = Tensor::<f32>::from_array((vec![1usize, len], vec![1.0f32; len]))?;
         let pitch_t = Tensor::<f32>::from_array((vec![1usize, len], vec![1.0f32; len]))?;
+        let t = Instant::now();
         let (mag_shape, mag, x, y) = {
             let mut session = lock_session(&self.tts_main);
             let outputs = session.run(
@@ -197,21 +248,25 @@ impl Engine {
             let (_, y) = Self::take_f32(&outputs, "y")?;
             (mag_shape, mag, x, y)
         };
+        timings.tts_main += t.elapsed();
         debug!(mel_shape = ?mag_shape, "tts_main done");
 
         // istft: mag/x/y → 48 kHz waveform.
         let mag_t = Tensor::<f32>::from_array((mag_shape.clone(), mag))?;
         let x_t = Tensor::<f32>::from_array((mag_shape.clone(), x))?;
         let y_t = Tensor::<f32>::from_array((mag_shape, y))?;
+        let t = Instant::now();
         let audio_48k = {
             let mut session = lock_session(&self.istft);
             let outputs = session.run(ort::inputs!["mag" => mag_t, "x" => x_t, "y" => y_t])?;
             let (_, audio) = Self::take_f32(&outputs, "audio")?;
             audio
         };
+        timings.istft += t.elapsed();
         debug!(samples_48k = audio_48k.len(), "istft done");
 
         // PQMF downsample for 24k/8k; 48k passes through.
+        let t = Instant::now();
         let (samples, out_rate) = match sample_rate {
             r if r == self.config.native_sample_rate => (audio_48k, r),
             r => {
@@ -242,12 +297,14 @@ impl Engine {
                 (band, r)
             }
         };
+        timings.pqmf += t.elapsed();
 
         Ok(EngineOutput {
             duration_sec: samples.len() as f32 / out_rate as f32,
             samples,
             sample_rate: out_rate,
             spoken_text,
+            stage_timings: timings,
         })
     }
 }

--- a/silero-native/src/lib.rs
+++ b/silero-native/src/lib.rs
@@ -15,10 +15,11 @@ pub mod timestamps;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
+use std::time::Instant;
 
 use tracing::{debug, instrument};
 
-pub use engine::Engine;
+pub use engine::{Engine, StageTimings};
 pub use error::{EngineError, Result};
 pub use timestamps::WordTimestamp;
 
@@ -41,6 +42,8 @@ pub struct SynthesisResult {
     pub wav: Vec<u8>,
     pub timestamps: Vec<WordTimestamp>,
     pub duration_sec: f32,
+    /// Per-stage wall times, summed over chunks (issue #164 profiling).
+    pub stage_timings: StageTimings,
 }
 
 impl std::fmt::Debug for SynthesisResult {
@@ -186,6 +189,8 @@ impl SileroNative {
             )?;
         }
 
+        let mut timings_total = StageTimings::default();
+        let t = Instant::now();
         let mut samples: Vec<f32> = Vec::new();
         let mut timings: Vec<(&str, usize, f32)> = Vec::with_capacity(outputs.len());
         for co in &outputs {
@@ -194,15 +199,20 @@ impl SileroNative {
             debug_assert_eq!(co.output.sample_rate, sample_rate);
             timings.push((co.text.as_str(), co.offset, co.output.duration_sec));
             samples.extend_from_slice(&co.output.samples);
+            timings_total += co.output.stage_timings;
         }
+        let timestamps = timestamps::estimate_timestamps_chunked(&timings);
+        timings_total.concat_timestamps += t.elapsed();
 
         let duration_sec = samples.len() as f32 / sample_rate as f32;
+        let t = Instant::now();
         let wav = encode_wav(&samples, sample_rate)?;
-        let timestamps = timestamps::estimate_timestamps_chunked(&timings);
+        timings_total.wav_encode += t.elapsed();
         Ok(SynthesisResult {
             wav,
             timestamps,
             duration_sec,
+            stage_timings: timings_total,
         })
     }
 }


### PR DESCRIPTION
## Summary
- Per-stage timing instrumentation (`StageTimings` in `Engine`/`SileroNative`,
  bench breakdown at 24k/48k/8k) — closes the "no per-stage attribution" gap.
- Pinned ORT `intra_op_num_threads` to 8: 24k full-pipeline mean 104 → 36.6 ms;
  warm full-pipeline speedup vs Python torch `apply_tts` goes from ~1.3x to
  **~4.0x** (acceptance: ≥ 2x).
- Engine load 437 → ~345 ms as a side effect (fewer pool threads to spawn).
- Allocation/copy churn and bulk WAV encode measured and rejected (< 2.2%
  each); the remaining ~34 ms is ORT inference inside the exported graphs —
  irreducible client-side without touching the graphs/exporter.

## Why 8 threads (parity constraint)
Changing the thread count changes float reduction order. 4/6 threads push the
`stress_marker` parity case over the 1e-3 budget (1.5e-3 / 2.2e-3); 8 is the
only reduced count keeping all 31 cases inside (worst 9.8e-4) and ties 6 for
speed within noise. The count is deliberately not derived from
`available_parallelism()` — the reduction order must stay fixed for parity.

## Docs
- `silero-native/docs/benchmarks.md`: per-stage breakdown (acceptance #1),
  thread A/B record, new headline numbers, honest Python comparison re-run
  (145.0 ms, same methodology).
- `silero-native/docs/architecture.md`: exact perf/flamegraph commands in the
  debugging guide.

## Gates
- silero-native tests incl. bundle-gated parity: green (worst 9.8e-4 ≤ 1e-3)
- exporter self-check: 16/16 PASSED
- src-tauri tests + `just lint`: green
- manual app check: synthesis noticeably faster, quality unchanged

Fixes #164