### PR TITLE
fix(release): use Tauri v2 NSIS updater artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,14 +104,17 @@ jobs:
           tag="${{ inputs.tag || github.ref_name }}"
           version="${tag#v}"
           nsis_dir=src-tauri/target/release/bundle/nsis
-          zip=$(ls "$nsis_dir"/*_x64-setup.nsis.zip | head -1)
-          sig=$(cat "$zip.sig")
+          # Tauri v2 signs the plain NSIS installer as the updater
+          # artifact; the .nsis.zip is the v1-compatible format and is
+          # not produced by default (createUpdaterArtifacts: true).
+          exe=$(ls "$nsis_dir"/*_x64-setup.exe | head -1)
+          sig=$(cat "$exe.sig")
           jq -n \
             --arg v "$version" \
             --arg tag "$tag" \
             --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg sig "$sig" \
-            --arg url "https://github.com/${{ github.repository }}/releases/download/$tag/$(basename "$zip")" \
+            --arg url "https://github.com/${{ github.repository }}/releases/download/$tag/$(basename "$exe")" \
             '{version: $v, notes: "https://github.com/${{ github.repository }}/releases/tag/\($tag)", pub_date: $date, platforms: {"windows-x86_64": {signature: $sig, url: $url}}}' \
             > latest.json
           cat latest.json
@@ -124,6 +127,5 @@ jobs:
           generate_release_notes: true
           files: |
             src-tauri/target/release/bundle/nsis/*_x64-setup.exe
-            src-tauri/target/release/bundle/nsis/*_x64-setup.nsis.zip
-            src-tauri/target/release/bundle/nsis/*_x64-setup.nsis.zip.sig
+            src-tauri/target/release/bundle/nsis/*_x64-setup.exe.sig
             latest.json

--- a/openspec/changes/archive/2026-08-18-windows-installer-and-release/vm-checklist.md
+++ b/openspec/changes/archive/2026-08-18-windows-installer-and-release/vm-checklist.md
@@ -52,5 +52,5 @@ quickemu --vm windows-10-22H2.conf   # the .conf quickget generated
    - [ ] «Установка и удаление программ» → uninstall works, no errors.
 5. **Release pipeline**
    - [ ] Tag push produced a **draft** release with: `*-setup.exe`,
-     `*-setup.nsis.zip`, `*.sig`, `latest.json`.
+     `*-setup.exe.sig`, `latest.json`.
    - [ ] Publish the draft only after this checklist passes.


### PR DESCRIPTION
## Summary

Release job for v0.3.0 failed at "Generate latest.json": it looked for
`*_x64-setup.nsis.zip`, but Tauri v2 (createUpdaterArtifacts: true)
signs the plain NSIS installer — the zip is the v1-compatible format.

- latest.json now points at RuVox_*_x64-setup.exe (signature from .exe.sig)
- draft release uploads .exe + .exe.sig + latest.json
- vm-checklist artifact list updated

After merge: re-run via workflow_dispatch with tag v0.3.0 (no tag move
needed — dispatch checks out main, the version guard passes).