### PR TITLE
fix(release): bundle VC++ CRT app-local (MSVCP140.dll missing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,8 @@ src-tauri/resources/mpv/*
 !src-tauri/resources/mpv/PLACEHOLDER
 src-tauri/resources/espeak-ng-data/*
 !src-tauri/resources/espeak-ng-data/PLACEHOLDER
+src-tauri/resources/crt/*
+!src-tauri/resources/crt/PLACEHOLDER.dll
 
 # pnpm
 .pnpm-debug.log

--- a/scripts/fetch-windows-resources.sh
+++ b/scripts/fetch-windows-resources.sh
@@ -10,6 +10,10 @@
 #                subprocess; lands at <install>/mpv/mpv.exe
 #   onnxruntime  microsoft/onnxruntime release (zip) — DL'd by ort
 #                (load-dynamic); lands next to the exe
+#   VC++ CRT     copied app-local from the runner's Visual Studio
+#                (license allows shipping these DLLs next to the exe).
+#                A clean Windows has no MSVCP140.dll — the first v0.3.0
+#                VM run failed to start without it.
 #
 # espeak-ng-data is NOT here: it is extracted from the espeak-rs-sys build
 # tree after `cargo build` (see release.yml), so it always matches the
@@ -60,5 +64,20 @@ cp "$TMP_DIR/mpv-Copyright" "$RESOURCES_DIR/mpv/Copyright"
   "onnxruntime-win-x64-${ORT_VERSION}/lib/onnxruntime.dll" >/dev/null
 cp "$TMP_DIR/ort/onnxruntime-win-x64-${ORT_VERSION}/lib/onnxruntime.dll" \
   "$RESOURCES_DIR/onnxruntime.dll"
+
+# VC++ 2015-2022 CRT, app-local. Not a download: copied from the runner's
+# Visual Studio install (newest MSVC toolset dir wins). Off-runner (local
+# NixOS) the path does not exist — warn and skip, Linux builds don't need it.
+CRT_SRC=$(ls -d "/c/Program Files/Microsoft Visual Studio/"2022/*/VC/Redist/MSVC/*/x64/Microsoft.VC143.CRT 2>/dev/null | sort -V | tail -1 || true)
+if [ -n "$CRT_SRC" ]; then
+  mkdir -p "$RESOURCES_DIR/crt"
+  cp "$CRT_SRC"/*.dll "$RESOURCES_DIR/crt/"
+  # The committed placeholder only exists to satisfy tauri-build's
+  # compile-time glob check; it must NOT reach the installer.
+  rm -f "$RESOURCES_DIR/crt/PLACEHOLDER.dll"
+  echo ">> CRT bundled app-local from $CRT_SRC"
+else
+  echo ">> WARN: VS CRT redist not found (expected off-runner); skipping app-local CRT"
+fi
 
 echo "OK: resources ready in $RESOURCES_DIR"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,8 @@
     "resources": {
       "resources/mpv": "mpv",
       "resources/espeak-ng-data": "espeak-ng-data",
-      "resources/onnxruntime.dll": "onnxruntime.dll"
+      "resources/onnxruntime.dll": "onnxruntime.dll",
+      "resources/crt/*.dll": "./"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

First VM run of the v0.3.0 installer: the app installed fine but failed
to start on clean Windows 10 — `MSVCP140.dll was not found`. CI runners
carry the VC++ runtime via Visual Studio, so the gap only shows on a
pristine machine. `onnxruntime.dll` needs the CRT too, so crt-static on
our exe alone would not have been enough.

Fix: copy the VC++ 2015-2022 CRT DLLs (~1.5 MB) from the runner's VS
redist into `resources/crt/` at build time and bundle them app-local,
next to the exe. Microsoft's license explicitly allows app-local
deployment. No web download at install time, no system-wide redist
install, no admin/reboot surface.

- fetch-windows-resources.sh: new CRT section (warn+skip off-runner)
- tauri.conf.json: `resources/crt/*.dll` → install root
- .gitignore + zero-byte `PLACEHOLDER.dll`: satisfies tauri-build's
  compile-time glob check; the fetch script deletes it after copying
  the real DLLs so it never reaches the installer

After merge: re-run release.yml via workflow_dispatch with tag v0.3.0,
then re-run the VM checklist on the new installer.