### PR TITLE
fix(release): locate VS CRT redist via vswhere

### DIFF
--- a/scripts/fetch-windows-resources.sh
+++ b/scripts/fetch-windows-resources.sh
@@ -10,10 +10,10 @@
 #                subprocess; lands at <install>/mpv/mpv.exe
 #   onnxruntime  microsoft/onnxruntime release (zip) — DL'd by ort
 #                (load-dynamic); lands next to the exe
-#   VC++ CRT     copied app-local from the runner's Visual Studio
-#                (license allows shipping these DLLs next to the exe).
-#                A clean Windows has no MSVCP140.dll — the first v0.3.0
-#                VM run failed to start without it.
+#   VC++ CRT     copied app-local from the runner's Visual Studio,
+#                located via vswhere (license allows shipping these DLLs
+#                next to the exe). A clean Windows has no MSVCP140.dll —
+#                the first v0.3.0 VM run failed to start without it.
 #
 # espeak-ng-data is NOT here: it is extracted from the espeak-rs-sys build
 # tree after `cargo build` (see release.yml), so it always matches the
@@ -65,10 +65,18 @@ cp "$TMP_DIR/mpv-Copyright" "$RESOURCES_DIR/mpv/Copyright"
 cp "$TMP_DIR/ort/onnxruntime-win-x64-${ORT_VERSION}/lib/onnxruntime.dll" \
   "$RESOURCES_DIR/onnxruntime.dll"
 
-# VC++ 2015-2022 CRT, app-local. Not a download: copied from the runner's
-# Visual Studio install (newest MSVC toolset dir wins). Off-runner (local
-# NixOS) the path does not exist — warn and skip, Linux builds don't need it.
-CRT_SRC=$(ls -d "/c/Program Files/Microsoft Visual Studio/"2022/*/VC/Redist/MSVC/*/x64/Microsoft.VC143.CRT 2>/dev/null | sort -V | tail -1 || true)
+# VC++ 2015+ CRT, app-local. Not a download: copied from the runner's
+# Visual Studio install. Located via vswhere — the VS root moves between
+# runner images (2022 → 18) and hardcoding it already burned one release
+# run. Off-runner (local NixOS) vswhere does not exist — warn and skip.
+VSWHERE="/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+CRT_SRC=""
+if [ -x "$VSWHERE" ]; then
+  VS_UNIX=$(cygpath -u "$("$VSWHERE" -latest -property installationPath | tr -d '\r')" 2>/dev/null || true)
+  if [ -n "${VS_UNIX:-}" ]; then
+    CRT_SRC=$(ls -d "$VS_UNIX"/VC/Redist/MSVC/*/x64/Microsoft.VC*.CRT 2>/dev/null | sort -V | tail -1 || true)
+  fi
+fi
 if [ -n "$CRT_SRC" ]; then
   mkdir -p "$RESOURCES_DIR/crt"
   cp "$CRT_SRC"/*.dll "$RESOURCES_DIR/crt/"


### PR DESCRIPTION
## Summary

Follow-up to #190 — the CRT copy never happened: the runner image moved
Visual Studio from `C:\Program Files\Microsoft Visual Studio\2022\`
to `...\18\` (VS 2026), so the hardcoded glob matched nothing and the
script silently took the warn-skip path (the rebuilt installer was again
shipped without CRT DLLs).

Fix: resolve the VS install root with vswhere (stable across images) and
glob any `Microsoft.VC*.CRT` toolset dir under it.

Verified on a debug dispatch against the runner: vswhere reports
`C:\Program Files\Microsoft Visual Studio\18\Enterprise`.