### PR TITLE
ci(release): share windows rust cache between CI and release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "src-tauri\nsilero-native"
+          # Shared with the release.yml windows-installer job: without this the
+          # cache key includes the job id, so the release rebuilt all ~600 deps
+          # from scratch on every run (~8.5 min lost).
+          shared-key: win-msvc
       - run: pnpm install --frozen-lockfile
       - run: pnpm tauri build --no-bundle
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "src-tauri\nsilero-native"
+          # Shared with the ci.yml windows-build job (same key, same cache).
+          shared-key: win-msvc
 
       - run: pnpm install --frozen-lockfile
 
@@ -68,10 +70,15 @@ jobs:
 
       # espeak-ng-data is produced BY the build (espeak-rs-sys vendors and
       # compiles espeak-ng) — so build first, then copy the data out of the
-      # build tree, then bundle. The second cargo invocation inside
-      # `tauri build` is a cache hit.
-      - name: cargo build (produces espeak-ng-data)
-        run: cargo build --release --manifest-path src-tauri/Cargo.toml
+      # build tree, then bundle. Must go through `tauri build --no-bundle`
+      # (not plain `cargo build`): the Tauri CLI enables the
+      # `tauri/custom-protocol` feature for production builds, and a plain
+      # cargo build with a different feature set forces the second cargo
+      # invocation inside `tauri build` to recompile tauri + all plugins +
+      # the app crate (~3.5 min). With the same feature set that invocation
+      # is a real cache hit and only NSIS bundling runs.
+      - name: tauri build --no-bundle (produces espeak-ng-data)
+        run: pnpm tauri build --no-bundle
 
       - name: Extract espeak-ng-data into bundle resources
         shell: bash


### PR DESCRIPTION
## Why
Release builds took ~16 min. Two avoidable costs found in run logs:

1. Swatinem/rust-cache includes the job id in the cache key, so
   `windows-installer` (release.yml) never hit the cache written by
   `windows-build` (ci.yml) — every release recompiled all ~600
   dependencies from scratch (~8.5 min).
2. release.yml warmed the build with plain `cargo build`, but the
   Tauri CLI enables `tauri/custom-protocol` for production builds;
   the different feature set made the cargo invocation inside the
   final `tauri build` recompile tauri + all plugins + the app crate
   (~3.5 min), despite the comment claiming a cache hit.

## What
- Same `shared-key: win-msvc` in both jobs → one shared windows rust
  cache; a release on a commit whose CI already ran gets a full hit.
- release.yml warm-up step now runs `pnpm tauri build --no-bundle`
  (same feature set as the final build) → the second cargo run is a
  real no-op, only NSIS bundling remains.

Expected: release ~16 min → ~5–6 min on a cache-hit run.

CI/tooling change — no OpenSpec change per repo workflow.