### PR TITLE
fix(ui): neutral hint instead of red error when clipboard is empty on Add (#194)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -164,14 +164,21 @@ export function AppShell() {
       // silently fails with `ContentNotAvailable` on KDE Plasma 6, and
       // unlike `navigator.clipboard.readText` which is gated by WebKit
       // permission policies in the WKWebView.
+      // An empty clipboard must not look like an app failure (#194): the Add
+      // button doubles as "read what I just copied", so both an empty result
+      // and a read failure (Windows reports an empty clipboard as an error)
+      // surface as a neutral hint instead of a red error.
       let clipboardText: string;
       try {
         clipboardText = (await readClipboardText()) ?? '';
       } catch {
+        clipboardText = '';
+      }
+      if (!clipboardText.trim()) {
         notifications.show({
-          title: 'Ошибка',
-          message: 'Не удалось прочитать буфер обмена',
-          color: 'red',
+          title: 'Буфер обмена пуст',
+          message: 'Скопируйте текст и нажмите Add ещё раз',
+          color: 'blue',
         });
         setPending(false);
         return;


### PR DESCRIPTION
Closes #194.

Pressing **Add** with an empty clipboard showed a red «Не удалось прочитать буфер обмена» error, which reads like an app failure. On Windows an empty clipboard actually surfaces as a read error from `tauri-plugin-clipboard-manager`, so the catch path now maps to the same neutral handling.

Now both an empty result and a read failure show a neutral blue hint: «Буфер обмена пуст. Скопируйте текст и нажмите Add ещё раз». Also guards the preview-dialog path from opening with empty text.

Diff is small (<50 lines), reviewer gate skipped per AGENTS.md. Gates: typecheck, eslint, knip, cargo-clippy, TS unit tests (137) — all green.