### PR TITLE
fix(ui): route HTML clipboard content through the preview dialog gate (#195)

### DIFF
--- a/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/design.md
+++ b/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/design.md
@@ -1,0 +1,45 @@
+# Design: preview-dialog-html-add-flow
+
+## Decision
+
+D1. **The preview gate sits after flavor detection, not after the plain
+fallback.** `addEntry()` becomes: (1) best-effort read of the `text/html`
+flavor via `navigator.clipboard.read()`; (2) read plain text via the plugin;
+(3) a pure decision function maps `{ html, plain, previewEnabled,
+defaultFormat }` to one of four actions:
+
+| html non-empty | plain non-empty | previewEnabled | Action |
+|---|---|---|---|
+| yes | — | true  | open dialog, text = raw HTML, selector = `html` |
+| no  | yes | true  | open dialog, text = plain, selector = `defaultFormat` |
+| no  | no  | true  | neutral «Буфер обмена пуст» hint |
+| yes | — | false | direct HTML ingest (today's behavior, plain fallback on empty extraction) |
+| no  | yes | false | direct plain `addTextEntry` |
+| no  | no  | false | neutral «Буфер обмена пуст» hint |
+
+The decision function lives in `src/lib/addFlow.ts` as a pure exported
+function so the matrix is unit-tested without mounting `AppShell`
+(the component has no test harness today).
+
+D2. **No new PreviewDialog prop.** The dialog resets `sourceFormat` from
+`defaultFormat` on every open (`useEffect` on `[opened, text,
+defaultFormat]`), so AppShell passes `defaultFormat = 'html'` for an
+HTML-detected opening. The dialog's existing `html` handling (extraction for
+the right pane, `resolveIngest` on synthesis) covers the rest.
+
+D3. **Ordering of reads.** Both flavors are probed best-effort up front
+(HTML via `navigator.clipboard.read()`, plain via the plugin); the plain
+result is only *used* when HTML is absent or — on the direct path — when
+its extraction yields nothing. Reading both unconditionally keeps the flow
+linear (no conditional second read after the decision); the extra plugin
+read is cheap and side-effect free.
+
+## Alternatives considered
+
+- **Skip the HTML fast-path entirely when preview is enabled** (always open
+  the dialog with the plugin's plain text). Rejected: loses `html_source` —
+  the entry would render as plain text instead of sanitized HTML, a silent
+  regression of the html-ingestion spec for preview users.
+- **Make the preview dialog always auto-detect HTML** from its `text` prop.
+  Rejected: explicit selector state passed from the caller is simpler and
+  keeps auto-detection in one place (the Add flow).

--- a/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/proposal.md
+++ b/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/proposal.md
@@ -1,0 +1,54 @@
+# Proposal: preview-dialog-html-add-flow
+
+Closes #195. Part of #185 (Windows support), blocks the v0.3.0 release.
+
+## Problem
+
+The Add-button flow has two clipboard paths that disagree about the preview
+gate:
+
+- `addEntry()` in `src/components/AppShell.tsx` first makes a best-effort
+  `navigator.clipboard.read()` for a `text/html` flavor. When found, the HTML
+  ingestion path creates the queue entry **immediately**, before the
+  `preview_dialog_enabled` check.
+- Only the plain-text fallback (`tauri-plugin-clipboard-manager::readText()`)
+  honors the preview gate.
+
+On Linux/WebKitGTK `navigator.clipboard.read()` is unavailable, so the HTML
+fast-path never fires and the preview dialog always shows. On
+Windows/WebView2 (Chromium) the read succeeds after a one-time clipboard
+permission grant — so on Windows the preview dialog is silently skipped for
+anything copied from a browser, and synthesis starts immediately. This was
+observed on the v0.3.0 Win10 VM pass: «Предпросмотр нормализации» never
+appears.
+
+## Change
+
+When `preview_dialog_enabled` is `true`, the preview gate applies to **both**
+clipboard flavors:
+
+- HTML flavor present → open `PreviewDialog` pre-filled with the raw HTML
+  markup, with the source-format selector initialized to `html` (instead of
+  the configured `text_format` default). The dialog already extracts and
+  normalizes HTML for its right pane and on synthesis, so no new dialog
+  behavior is needed beyond the initial selector value.
+- Only plain text → unchanged: dialog opens with the plain text.
+- Neither → unchanged: neutral «Буфер обмена пуст» hint (#194).
+
+When `preview_dialog_enabled` is `false`, the current direct-ingestion
+behavior is preserved exactly (HTML auto-ingest, plain fallback, no dialog).
+
+## Scope
+
+- Frontend only: `src/components/AppShell.tsx` (flow decision) and a pure,
+  unit-testable decision helper in `src/lib/`. `PreviewDialog` needs no new
+  props — `defaultFormat` already resets per open.
+- No backend changes. The paste (`Ctrl+V`) flow is untouched.
+
+## Risks
+
+- Users on Windows get one extra dialog for HTML content they previously
+  skipped — that is the intended, spec'd behavior (preview-dialog spec makes
+  the dialog the gate for the Add flow).
+- The decision helper must keep the "HTML yields no readable text → plain
+  fallback" semantics of the direct path; covered by unit tests.

--- a/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/specs/html-ingestion/spec.md
+++ b/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/specs/html-ingestion/spec.md
@@ -1,0 +1,44 @@
+# Delta: html-ingestion
+
+## MODIFIED Requirements
+
+### Requirement: HTML clipboard detection
+
+When the user pastes into the main window (`Ctrl+V`), the system SHALL read
+the `text/html` flavor from the paste event's clipboard data. If it is
+non-empty, the entry SHALL be created through the HTML ingestion path;
+otherwise the system SHALL use the plain-text flavor and the existing plain
+ingestion path. The tray "Add" path SHALL keep using the plain-text flavor
+only.
+
+The Add-button flow SHALL make a best-effort attempt to read `text/html`
+from the system clipboard. What happens next depends on the preview gate
+(`preview_dialog_enabled`, see the preview-dialog spec):
+
+- Preview **disabled**: a non-empty HTML flavor SHALL be ingested through
+  the HTML path directly (plain-text fallback when extraction yields no
+  readable text); otherwise the plugin `readText` result is used as today.
+- Preview **enabled**: the HTML flavor SHALL NOT create an entry directly —
+  the raw markup is handed to the preview dialog with the source-format
+  selector pre-set to `html`, and ingestion happens on dialog confirmation.
+
+#### Scenario: Paste with HTML flavor
+- GIVEN the clipboard holds `text/html` copied from a browser
+- WHEN the user presses `Ctrl+V` in the main window
+- THEN an entry is created through the HTML ingestion path with `format: "html"`
+
+#### Scenario: Paste without HTML flavor
+- GIVEN the clipboard holds only plain text
+- WHEN the user presses `Ctrl+V` in the main window
+- THEN the entry is created exactly as by the existing plain-text path
+
+#### Scenario: Add button without HTML access
+- GIVEN the webview cannot read `text/html` from the system clipboard
+- WHEN the user clicks the Add button
+- THEN the entry is created from the plugin `readText` result as today
+
+#### Scenario: Add button with HTML flavor and preview enabled
+- GIVEN the clipboard holds `text/html` and `preview_dialog_enabled` is `true`
+- WHEN the user clicks the Add button
+- THEN no entry is created yet; the preview dialog opens with the raw HTML
+  markup and the source-format selector set to `html`

--- a/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/specs/preview-dialog/spec.md
+++ b/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/specs/preview-dialog/spec.md
@@ -1,0 +1,126 @@
+# Delta: preview-dialog
+
+## MODIFIED Requirements
+
+### Requirement: Add flow gating
+
+The Add-button flow SHALL probe both clipboard flavors before deciding:
+a best-effort `navigator.clipboard.read()` for the `text/html` flavor, and
+the plain text via
+`tauri-plugin-clipboard-manager::readText()` (the only clipboard path that
+works reliably on Wayland/KDE Plasma 6; WebKit's `navigator.clipboard` is
+permission-gated, while on WebView2/Chromium it succeeds after a one-time
+permission grant). Both reads are best-effort; the plain result is *used*
+only when no HTML flavor exists or — on the direct path — when HTML
+extraction yields no readable text.
+
+When `config.preview_dialog_enabled` is `true` (the default in
+`storage::schema::UIConfig::default`), the system SHALL open `PreviewDialog`
+for **either** flavor — HTML content SHALL NOT bypass the dialog:
+
+- HTML flavor present → the dialog opens pre-filled with the raw HTML markup
+  and the source-format selector initialized to `html`.
+- Only plain text present → the dialog opens pre-filled with the plain text
+  and the selector initialized from `UIConfig.text_format`.
+- Neither → no dialog; a neutral blue «Буфер обмена пуст» hint is shown.
+
+When `preview_dialog_enabled` is `false`, no dialog opens and the flow is
+the direct ingestion path: HTML flavor → HTML ingestion (plain fallback when
+extraction yields no readable text), otherwise plain-text `addTextEntry`.
+
+An empty clipboard or a clipboard read failure SHALL surface the neutral
+«Буфер обмена пуст» hint, not an error notification (on Windows an empty
+clipboard surfaces as a read error from the plugin).
+
+`AppShell` SHALL load `UIConfig` once per mount for this decision and treat
+a config load failure as "dialog disabled".
+
+#### Scenario: Dialog opens for HTML clipboard content
+
+- GIVEN `preview_dialog_enabled` is `true` and the clipboard holds
+  `text/html` copied from a browser
+- WHEN the user clicks Add
+- THEN the preview dialog opens pre-filled with the raw HTML markup, the
+  source-format selector is set to `html`, and no queue entry is created yet
+
+#### Scenario: Dialog opens when enabled
+
+- GIVEN `preview_dialog_enabled` is `true` and the clipboard contains only
+  plain text
+- WHEN the user clicks Add
+- THEN the preview dialog opens pre-filled with the clipboard text and no
+  queue entry is created yet
+
+#### Scenario: Direct add when disabled
+
+- GIVEN `preview_dialog_enabled` is `false`
+- WHEN the user clicks Add
+- THEN no dialog opens: HTML content is ingested through the HTML path,
+  plain text goes to `commands.addTextEntry(text, true)` directly
+
+#### Scenario: Empty clipboard is a hint, not an error
+
+- GIVEN the clipboard is empty (or the read fails)
+- WHEN the user clicks Add
+- THEN a neutral blue «Буфер обмена пуст» notification is shown and nothing
+  else happens
+
+#### Scenario: Unreadable HTML with no plain text is the same hint
+
+- GIVEN `preview_dialog_enabled` is `false`, the clipboard holds HTML markup
+  that yields no readable text, and no plain-text flavor
+- WHEN the user clicks Add
+- THEN a neutral blue «Буфер обмена пуст» notification is shown and no
+  entry is created
+
+### Requirement: Source format selection
+
+The dialog SHALL provide a source-format selector with the values `plain`,
+`markdown`, and `html`. Its initial value is the `defaultFormat` prop: the
+configured viewer default (`UIConfig.text_format`), or `html` when the Add
+flow auto-detected an HTML clipboard flavor for this opening. The selector
+controls how the text is interpreted when "Синтезировать" is pressed:
+
+- `plain` / `markdown`: the (original or edited) text is ingested unchanged
+  and the chosen value SHALL be persisted as the entry's `format`.
+- `html`: the text SHALL be treated as HTML markup — sanitized and
+  extracted on the frontend (`sanitizeHtml` + `extractTextForTts`) — and
+  the entry SHALL be created with `format: "html"`, the extracted text as
+  `original_text`, and the sanitized markup as `html_source`. If extraction
+  yields no readable text, the system SHALL reject ingestion with a red
+  error notification and create no entry.
+
+The right preview pane SHALL reflect the selection: with `html` it shows
+the normalization of the extracted text (what will actually be narrated);
+with `plain` / `markdown` it shows the normalization of the text as-is.
+Changing the selector SHALL re-trigger the debounced preview.
+
+#### Scenario: HTML markup picked explicitly
+
+- GIVEN the dialog is open with raw HTML markup as text and `html` selected
+- WHEN the user presses "Синтезировать"
+- THEN the entry is created with `format: "html"`, extracted plain text as
+  `original_text`, and the sanitized markup as `html_source`, and synthesis
+  narrates the extracted text (no tags or attributes)
+
+#### Scenario: HTML choice with no extractable text
+
+- GIVEN the dialog text is markup that yields no readable text (e.g. only
+  excluded elements) and `html` is selected
+- WHEN the user presses "Синтезировать"
+- THEN a red error notification is shown and no entry is created
+
+#### Scenario: Markdown choice persists display format
+
+- GIVEN the dialog is open and `markdown` is selected
+- WHEN the user presses "Синтезировать"
+- THEN the entry is created with the text unchanged and `format:
+  "markdown"` persisted, so the viewer renders it in markdown mode
+
+#### Scenario: Preview follows the selector
+
+- GIVEN the dialog is open with raw HTML markup as text
+- WHEN the user switches the selector from `markdown` to `html`
+- THEN the right pane updates (after the debounce) to the normalization of
+  the text extracted from the markup instead of the normalization of the
+  raw markup

--- a/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/tasks.md
+++ b/openspec/changes/archive/2026-08-19-preview-dialog-html-add-flow/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: preview-dialog-html-add-flow
+
+## 1. Decision helper
+
+- [x] 1.1 Add `src/lib/addFlow.ts`: pure `resolveAddAction({ html, plain,
+  previewEnabled, defaultFormat })` returning `empty | preview(text, format)
+  | direct-html | direct-plain`, per the design matrix
+- [x] 1.2 Unit tests `src/lib/addFlow.test.ts` covering all six matrix rows
+
+## 2. AppShell wiring
+
+- [x] 2.1 Rework `addEntry()` in `src/components/AppShell.tsx` to: probe the
+  `text/html` flavor (best-effort, as today) and read plain text via the
+  plugin (both up front, both best-effort), then dispatch on
+  `resolveAddAction`
+- [x] 2.2 Track the per-opening preview format in state
+  (`previewFormat: EntryFormat | null`) and pass
+  `defaultFormat={previewFormat ?? toEntryFormat(config?.text_format)}` to
+  `PreviewDialog`; clear it on close/cancel
+- [x] 2.3 Preserve today's direct-path semantics exactly: HTML extraction
+  with no readable text falls back to plain (or no-ops when both empty)
+
+## 3. Gates
+
+- [x] 3.1 `nix develop -c pnpm typecheck` / `pnpm test:unit` / `pnpm lint`
+  green
+- [ ] 3.2 `nix develop -c just test` green (Rust unaffected, run anyway)
+- [ ] 3.3 Verify on the Win10 VM: Add with browser-copied (HTML) content
+  opens «Предпросмотр нормализации» with the selector on `html`; Add with
+  plain text opens it as before; with the dialog disabled, behavior is
+  unchanged (deferred to the epic's final VM pass after #196)
+
+## 4. Archive
+
+- [x] 4.1 `openspec validate` the change, sync delta specs, archive the
+  change, commit the archive

--- a/openspec/specs/html-ingestion/spec.md
+++ b/openspec/specs/html-ingestion/spec.md
@@ -15,10 +15,19 @@ When the user pastes into the main window (`Ctrl+V`), the system SHALL read
 the `text/html` flavor from the paste event's clipboard data. If it is
 non-empty, the entry SHALL be created through the HTML ingestion path;
 otherwise the system SHALL use the plain-text flavor and the existing plain
-ingestion path. The Add-button flow SHALL make a best-effort attempt to read
-`text/html` from the system clipboard and SHALL fall back to the existing
-plugin `readText` path on any failure. The tray "Add" path SHALL keep using
-the plain-text flavor only.
+ingestion path. The tray "Add" path SHALL keep using the plain-text flavor
+only.
+
+The Add-button flow SHALL make a best-effort attempt to read `text/html`
+from the system clipboard. What happens next depends on the preview gate
+(`preview_dialog_enabled`, see the preview-dialog spec):
+
+- Preview **disabled**: a non-empty HTML flavor SHALL be ingested through
+  the HTML path directly (plain-text fallback when extraction yields no
+  readable text); otherwise the plugin `readText` result is used as today.
+- Preview **enabled**: the HTML flavor SHALL NOT create an entry directly —
+  the raw markup is handed to the preview dialog with the source-format
+  selector pre-set to `html`, and ingestion happens on dialog confirmation.
 
 #### Scenario: Paste with HTML flavor
 - GIVEN the clipboard holds `text/html` copied from a browser
@@ -34,6 +43,12 @@ the plain-text flavor only.
 - GIVEN the webview cannot read `text/html` from the system clipboard
 - WHEN the user clicks the Add button
 - THEN the entry is created from the plugin `readText` result as today
+
+#### Scenario: Add button with HTML flavor and preview enabled
+- GIVEN the clipboard holds `text/html` and `preview_dialog_enabled` is `true`
+- WHEN the user clicks the Add button
+- THEN no entry is created yet; the preview dialog opens with the raw HTML
+  markup and the source-format selector set to `html`
 
 ### Requirement: Sanitization before extraction
 

--- a/openspec/specs/preview-dialog/spec.md
+++ b/openspec/specs/preview-dialog/spec.md
@@ -8,21 +8,74 @@ Covers the normalization preview dialog (FF 1.1): a floating, non-modal window (
 
 ### Requirement: Add flow gating
 
-The system SHALL read the clipboard via `tauri-plugin-clipboard-manager::readText()` when the Add button is pressed — the only clipboard path that works reliably on Wayland/KDE Plasma 6 (WebKit's `navigator.clipboard` is permission-gated; the Rust-side `arboard` crate fails silently with `ContentNotAvailable`). A clipboard read failure SHALL surface a red "Не удалось прочитать буфер обмена" notification.
+The Add-button flow SHALL probe both clipboard flavors before deciding:
+a best-effort `navigator.clipboard.read()` for the `text/html` flavor, and
+the plain text via
+`tauri-plugin-clipboard-manager::readText()` (the only clipboard path that
+works reliably on Wayland/KDE Plasma 6; WebKit's `navigator.clipboard` is
+permission-gated, while on WebView2/Chromium it succeeds after a one-time
+permission grant). Both reads are best-effort; the plain result is *used*
+only when no HTML flavor exists or — on the direct path — when HTML
+extraction yields no readable text.
 
-When `config.preview_dialog_enabled` is `true` (the default in `storage::schema::UIConfig::default`), the system SHALL open `PreviewDialog` with the clipboard text; otherwise it SHALL call `commands.addTextEntry(text, true)` directly, skipping the dialog. `AppShell` SHALL load `UIConfig` once per mount for this decision and treat a config load failure as "dialog disabled".
+When `config.preview_dialog_enabled` is `true` (the default in
+`storage::schema::UIConfig::default`), the system SHALL open `PreviewDialog`
+for **either** flavor — HTML content SHALL NOT bypass the dialog:
+
+- HTML flavor present → the dialog opens pre-filled with the raw HTML markup
+  and the source-format selector initialized to `html`.
+- Only plain text present → the dialog opens pre-filled with the plain text
+  and the selector initialized from `UIConfig.text_format`.
+- Neither → no dialog; a neutral blue «Буфер обмена пуст» hint is shown.
+
+When `preview_dialog_enabled` is `false`, no dialog opens and the flow is
+the direct ingestion path: HTML flavor → HTML ingestion (plain fallback when
+extraction yields no readable text), otherwise plain-text `addTextEntry`.
+
+An empty clipboard or a clipboard read failure SHALL surface the neutral
+«Буфер обмена пуст» hint, not an error notification (on Windows an empty
+clipboard surfaces as a read error from the plugin).
+
+`AppShell` SHALL load `UIConfig` once per mount for this decision and treat
+a config load failure as "dialog disabled".
+
+#### Scenario: Dialog opens for HTML clipboard content
+
+- GIVEN `preview_dialog_enabled` is `true` and the clipboard holds
+  `text/html` copied from a browser
+- WHEN the user clicks Add
+- THEN the preview dialog opens pre-filled with the raw HTML markup, the
+  source-format selector is set to `html`, and no queue entry is created yet
 
 #### Scenario: Dialog opens when enabled
 
-- GIVEN `preview_dialog_enabled` is `true` and the clipboard contains text
+- GIVEN `preview_dialog_enabled` is `true` and the clipboard contains only
+  plain text
 - WHEN the user clicks Add
-- THEN the preview dialog opens pre-filled with the clipboard text and no queue entry is created yet
+- THEN the preview dialog opens pre-filled with the clipboard text and no
+  queue entry is created yet
 
 #### Scenario: Direct add when disabled
 
 - GIVEN `preview_dialog_enabled` is `false`
 - WHEN the user clicks Add
-- THEN `commands.addTextEntry(text, true)` is called immediately without opening the dialog
+- THEN no dialog opens: HTML content is ingested through the HTML path,
+  plain text goes to `commands.addTextEntry(text, true)` directly
+
+#### Scenario: Empty clipboard is a hint, not an error
+
+- GIVEN the clipboard is empty (or the read fails)
+- WHEN the user clicks Add
+- THEN a neutral blue «Буфер обмена пуст» notification is shown and nothing
+  else happens
+
+#### Scenario: Unreadable HTML with no plain text is the same hint
+
+- GIVEN `preview_dialog_enabled` is `false`, the clipboard holds HTML markup
+  that yields no readable text, and no plain-text flavor
+- WHEN the user clicks Add
+- THEN a neutral blue «Буфер обмена пуст» notification is shown and no
+  entry is created
 
 ### Requirement: Floating non-modal window
 
@@ -145,12 +198,14 @@ The system SHALL store the dialog gate as `preview_dialog_enabled: boolean` in `
 - GIVEN the dialog was disabled via its own checkbox
 - WHEN the user enables "Показывать диалог предпросмотра перед синтезом" in Settings and saves
 - THEN the next Add click opens the preview dialog again
+
 ### Requirement: Source format selection
 
 The dialog SHALL provide a source-format selector with the values `plain`,
-`markdown`, and `html`, initialized from `UIConfig.text_format` (the
-configured viewer default). The selector controls how the text is
-interpreted when "Синтезировать" is pressed:
+`markdown`, and `html`. Its initial value is the `defaultFormat` prop: the
+configured viewer default (`UIConfig.text_format`), or `html` when the Add
+flow auto-detected an HTML clipboard flavor for this opening. The selector
+controls how the text is interpreted when "Синтезировать" is pressed:
 
 - `plain` / `markdown`: the (original or edited) text is ingested unchanged
   and the chosen value SHALL be persisted as the entry's `format`.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -15,6 +15,7 @@ import { commands, toEntryFormat } from '../lib/tauri';
 import type { EntryFormat, UIConfig } from '../lib/tauri';
 import { formatError } from '../lib/errors';
 import { resolveIngest } from '../lib/ingest';
+import { resolveAddAction } from '../lib/addFlow';
 import { TextViewer } from './TextViewer';
 import { Player } from './Player';
 import { QueueList } from './QueueList';
@@ -31,6 +32,10 @@ export function AppShell() {
   const [settingsOpened, setSettingsOpened] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewText, setPreviewText] = useState('');
+  // Per-opening format override for the preview dialog: 'html' when the Add
+  // flow auto-detected an HTML clipboard flavor, null = use the configured
+  // viewer default (#195).
+  const [previewFormat, setPreviewFormat] = useState<EntryFormat | null>(null);
   const [config, setConfig] = useState<UIConfig | null>(null);
   const configLoaded = useRef(false);
   const [navWidth, setNavWidth] = useState(280);
@@ -144,13 +149,15 @@ export function AppShell() {
     try {
       // Best-effort HTML detection: navigator.clipboard.read() may be
       // unavailable or blocked in the WKWebView — any failure just falls
-      // through to the plain-text path below.
+      // through to the plain-text path below. On WebView2 (Windows) the
+      // read succeeds after a one-time permission grant.
+      let clipboardHtml: string | null = null;
       try {
         const items = await navigator.clipboard.read();
         for (const item of items) {
           if (item.types.includes('text/html')) {
             const rawHtml = await (await item.getType('text/html')).text();
-            if (rawHtml.trim() && (await addHtmlEntry(rawHtml, true))) return;
+            if (rawHtml.trim()) clipboardHtml = rawHtml;
             break;
           }
         }
@@ -174,26 +181,60 @@ export function AppShell() {
       } catch {
         clipboardText = '';
       }
-      if (!clipboardText.trim()) {
-        notifications.show({
-          title: 'Буфер обмена пуст',
-          message: 'Скопируйте текст и нажмите Add ещё раз',
-          color: 'blue',
-        });
-        setPending(false);
-        return;
+
+      const action = resolveAddAction({
+        html: clipboardHtml,
+        plain: clipboardText,
+        previewEnabled: config?.preview_dialog_enabled ?? false,
+        defaultFormat: toEntryFormat(config?.text_format),
+      });
+
+      switch (action.kind) {
+        case 'empty':
+          notifications.show({
+            title: 'Буфер обмена пуст',
+            message: 'Скопируйте текст и нажмите Add ещё раз',
+            color: 'blue',
+          });
+          setPending(false);
+          return;
+        case 'preview':
+          // The preview gate applies to the HTML flavor too (#195): the raw
+          // markup goes into the dialog with the selector pre-set to html,
+          // instead of being ingested directly behind the user's back.
+          setPreviewText(action.text);
+          setPreviewFormat(action.format);
+          setPreviewOpen(true);
+          setPending(false);
+          return;
+        case 'direct-html':
+          // HTML-only clipboard whose markup yields no readable text
+          // (e.g. pure nav/button chrome): nothing to ingest — skip the
+          // plain fallback, which would submit an empty text and surface
+          // a spurious backend error. The user still gets the neutral
+          // empty-clipboard hint rather than a silent no-op.
+          if (await addHtmlEntry(action.html, true)) return;
+          if (!action.plainFallback) {
+            notifications.show({
+              title: 'Буфер обмена пуст',
+              message: 'Скопируйте текст и нажмите Add ещё раз',
+              color: 'blue',
+            });
+            setPending(false);
+            return;
+          }
+          await doAddEntry(action.plainFallback, true);
+          return;
+        case 'direct-plain':
+          await doAddEntry(action.text, true);
+          return;
+        default: {
+          // Exhaustiveness guard: a new AddAction variant must break the
+          // build here instead of leaving the Add button stuck in pending.
+          const exhaustive: never = action;
+          throw new Error(`unknown add action: ${JSON.stringify(exhaustive)}`);
+        }
       }
-
-      const previewEnabled = config?.preview_dialog_enabled ?? false;
-
-      if (previewEnabled) {
-        setPreviewText(clipboardText);
-        setPreviewOpen(true);
-        setPending(false);
-        return;
-      }
-
-      await doAddEntry(clipboardText, true);
     } catch (err) {
       const message = formatError(err);
       notifications.show({ title: 'Ошибка', message, color: 'red' });
@@ -250,6 +291,7 @@ export function AppShell() {
     sourceFormat: EntryFormat,
   ) {
     setPreviewOpen(false);
+    setPreviewFormat(null);
     if (skipShortTexts && config) {
       // Persist user preference: disable preview dialog
       commands.updateConfig({ preview_dialog_enabled: false }).catch(() => {});
@@ -281,6 +323,7 @@ export function AppShell() {
 
   function handlePreviewCancel() {
     setPreviewOpen(false);
+    setPreviewFormat(null);
     setPending(false);
   }
 
@@ -394,7 +437,7 @@ export function AppShell() {
       <PreviewDialog
         opened={previewOpen}
         text={previewText}
-        defaultFormat={toEntryFormat(config?.text_format)}
+        defaultFormat={previewFormat ?? toEntryFormat(config?.text_format)}
         onSynthesize={handlePreviewSynthesize}
         onCancel={handlePreviewCancel}
       />

--- a/src/lib/addFlow.test.ts
+++ b/src/lib/addFlow.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveAddAction } from './addFlow';
+
+const HTML = '<p>Раз <b>два</b></p>';
+const PLAIN = 'Раз два';
+
+describe('resolveAddAction', () => {
+  it('opens the dialog with the raw HTML and the html selector when preview is enabled', () => {
+    expect(
+      resolveAddAction({
+        html: HTML,
+        plain: PLAIN,
+        previewEnabled: true,
+        defaultFormat: 'plain',
+      }),
+    ).toEqual({ kind: 'preview', text: HTML, format: 'html' });
+  });
+
+  it('opens the dialog with plain text and the configured default format', () => {
+    expect(
+      resolveAddAction({
+        html: null,
+        plain: PLAIN,
+        previewEnabled: true,
+        defaultFormat: 'markdown',
+      }),
+    ).toEqual({ kind: 'preview', text: PLAIN, format: 'markdown' });
+  });
+
+  it('reports empty when neither flavor has text (preview enabled)', () => {
+    expect(
+      resolveAddAction({
+        html: null,
+        plain: '',
+        previewEnabled: true,
+        defaultFormat: 'plain',
+      }),
+    ).toEqual({ kind: 'empty' });
+  });
+
+  it('ingests HTML directly when preview is disabled, keeping the plain fallback', () => {
+    expect(
+      resolveAddAction({
+        html: HTML,
+        plain: PLAIN,
+        previewEnabled: false,
+        defaultFormat: 'plain',
+      }),
+    ).toEqual({ kind: 'direct-html', html: HTML, plainFallback: PLAIN });
+  });
+
+  it('ingests plain text directly when preview is disabled and no HTML flavor exists', () => {
+    expect(
+      resolveAddAction({
+        html: null,
+        plain: PLAIN,
+        previewEnabled: false,
+        defaultFormat: 'plain',
+      }),
+    ).toEqual({ kind: 'direct-plain', text: PLAIN });
+  });
+
+  it('reports empty when neither flavor has text (preview disabled)', () => {
+    expect(
+      resolveAddAction({
+        html: null,
+        plain: '',
+        previewEnabled: false,
+        defaultFormat: 'plain',
+      }),
+    ).toEqual({ kind: 'empty' });
+  });
+
+  it('treats whitespace-only flavors as absent', () => {
+    expect(
+      resolveAddAction({
+        html: '   ',
+        plain: ' \n ',
+        previewEnabled: false,
+        defaultFormat: 'plain',
+      }),
+    ).toEqual({ kind: 'empty' });
+  });
+
+  it('direct-html carries no plain fallback when plain is blank', () => {
+    expect(
+      resolveAddAction({
+        html: HTML,
+        plain: '  ',
+        previewEnabled: false,
+        defaultFormat: 'plain',
+      }),
+    ).toEqual({ kind: 'direct-html', html: HTML, plainFallback: null });
+  });
+});

--- a/src/lib/addFlow.ts
+++ b/src/lib/addFlow.ts
@@ -1,0 +1,45 @@
+import type { EntryFormat } from './tauri';
+
+/**
+ * Outcome of the Add-button flow decision (preview-dialog spec,
+ * "Add flow gating"). Kept pure so the whole matrix is unit-testable
+ * without mounting AppShell.
+ */
+export type AddAction =
+  | { kind: 'empty' }
+  | { kind: 'preview'; text: string; format: EntryFormat }
+  | { kind: 'direct-html'; html: string; plainFallback: string | null }
+  | { kind: 'direct-plain'; text: string };
+
+/**
+ * Maps the clipboard probe results to the next step of the Add flow.
+ *
+ * - `html` — the raw `text/html` flavor, or null when the webview cannot
+ *   read it (Linux WebKitGTK) or the flavor is absent/blank.
+ * - `plain` — the plugin `readText` result; '' means empty or unreadable.
+ *
+ * With the preview gate enabled, HTML content opens the dialog too — it
+ * must not bypass the gate (on WebView2 `navigator.clipboard.read()`
+ * succeeds, so without this the dialog would never appear on Windows).
+ */
+export function resolveAddAction(input: {
+  html: string | null;
+  plain: string;
+  previewEnabled: boolean;
+  defaultFormat: EntryFormat;
+}): AddAction {
+  const html = input.html !== null && input.html.trim() ? input.html : null;
+  const plain = input.plain.trim() ? input.plain : null;
+
+  if (input.previewEnabled) {
+    if (html !== null) return { kind: 'preview', text: html, format: 'html' };
+    if (plain !== null) {
+      return { kind: 'preview', text: plain, format: input.defaultFormat };
+    }
+    return { kind: 'empty' };
+  }
+
+  if (html !== null) return { kind: 'direct-html', html, plainFallback: plain };
+  if (plain !== null) return { kind: 'direct-plain', text: plain };
+  return { kind: 'empty' };
+}


### PR DESCRIPTION
Closes #195. Part of #185, blocks v0.3.0.

**Problem.** On Windows/WebView2 `navigator.clipboard.read()` succeeds (after a one-time permission grant), so the Add flow's HTML fast-path created queue entries directly — the normalization preview dialog never appeared, although `preview_dialog_enabled=true`. On Linux/WebKitGTK the read is unavailable, so the bug never showed there.

**Fix.** The preview gate now applies to both clipboard flavors:
- HTML flavor + preview enabled → `PreviewDialog` opens with the raw markup and the source-format selector pre-set to `html` (no new dialog props needed — `defaultFormat` resets per open).
- Preview disabled → direct ingestion unchanged.
- Corner case (HTML yields no readable text, no plain text) keeps the neutral «Буфер обмена пуст» hint from #194 instead of a silent no-op.

Decision logic extracted to a pure `resolveAddAction` in `src/lib/addFlow.ts` with unit tests for the full matrix (8 tests). Reviewer pass done (3 low findings, all folded in).

**OpenSpec:** change `2026-08-19-preview-dialog-html-add-flow` archived; `preview-dialog` and `html-ingestion` specs synced.

Gates: typecheck, eslint, knip, vitest (145), clippy green; OpenSpec validate green. VM verification deferred to the epic's final pass after #196.