### PR TITLE
fix(logging): bridge tracing records into the log file

### DIFF
--- a/openspec/specs/logging/spec.md
+++ b/openspec/specs/logging/spec.md
@@ -11,8 +11,10 @@ rotation, level control, and how `tracing` records reach the log
 ### Requirement: Diagnostic log file
 
 The app SHALL write diagnostic logs to a per-user log directory via
-`tauri-plugin-log` (its `tracing` feature SHALL be enabled so existing
-`tracing` records reach the log). The log directory is the Tauri per-app
+`tauri-plugin-log`. Our code logs via `tracing`; since no tracing
+subscriber is installed, the `tracing` crate's `log` feature SHALL be
+enabled so tracing macros fall back to emitting `log` records, which the
+plugin's global logger captures. The log directory is the Tauri per-app
 log dir: `%LOCALAPPDATA%\com.ruvox.app\logs` on Windows,
 `~/.local/share/com.ruvox.app/logs` on Linux, inside the app's
 `Library/Logs` dir on macOS. This is a second data location, separate

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4822,7 +4822,6 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
- "tracing",
 ]
 
 [[package]]
@@ -5393,6 +5392,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,11 +55,14 @@ tauri-plugin-mpv = "0.5"
 # tauri.conf.json. tauri-plugin-process provides relaunch() after install.
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
-# tauri-plugin-log: file logging (LogDir) for support diagnostics. The
-# `tracing` feature bridges our existing tracing::{info,warn,error} call
-# sites into the plugin — without a subscriber they were silent no-ops
-# everywhere (#202).
-tauri-plugin-log = { version = "2", features = ["tracing"] }
+# tauri-plugin-log: file logging (LogDir) for support diagnostics (#202).
+# The plugin installs a global `log` logger; our code logs via `tracing`,
+# so tracing's `log` feature (below) bridges tracing macros into log
+# records — without it, and with no tracing subscriber installed, every
+# tracing::{info,warn,error} call is a silent no-op. (The plugin's own
+# `tracing` feature is the *opposite* direction — emitting into a tracing
+# subscriber — and is not used.)
+tauri-plugin-log = { version = "2" }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -72,7 +75,7 @@ dirs = "6"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "process", "io-util", "sync", "time"] }
 parking_lot = "0.12"
 thiserror = "2"
-tracing = "0.1"
+tracing = { version = "0.1", features = ["log"] }
 arboard = "3"
 libc = "0.2"
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,11 @@ export default defineConfig(() => ({
         }
       : undefined,
     watch: {
-      ignored: ["**/src-tauri/**"],
+      // tmp/ is the repo-local scratch dir (VM disks, xwin caches with
+      // symlink loops, etc.) — watching it once crashed the dev server
+      // with ELOOP on a recursive symlink. src-tauri/ is covered by
+      // cargo's own watcher.
+      ignored: ["**/src-tauri/**", "**/tmp/**"],
     },
   },
 }));


### PR DESCRIPTION
Follow-up to #203 (the #202 fix). VM verification of the rebuilt installer showed the log file only captured `log`-crate records from other plugins (tauri-plugin-mpv, updater) — our ~84 `tracing::` call sites stayed silent: tauri-plugin-log's own `tracing` feature does the *opposite* (emits plugin events into a tracing subscriber, and requires `skip_logger`).

The correct bridge with no tracing subscriber installed is tracing's `log` feature: tracing macros then fall back to emitting `log` records, which the plugin's global fern logger captures.

- `src-tauri/Cargo.toml`: `tracing = { version = "0.1", features = ["log"] }`; the plugin's `tracing` feature dropped.
- `openspec/specs/logging/spec.md`: mechanism description corrected (trivial spec fix, no delta change).

Will re-verify on the Win10 VM (log file gets `ruvox_tauri`/ttsd-targeted entries) after the release rebuild.