### PR TITLE
feat(updater): log update-check outcomes to the log file

### DIFF
--- a/openspec/changes/frontend-update-check-logging/.openspec.yaml
+++ b/openspec/changes/frontend-update-check-logging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/frontend-update-check-logging/proposal.md
+++ b/openspec/changes/frontend-update-check-logging/proposal.md
@@ -1,0 +1,22 @@
+# Proposal: frontend-update-check-logging
+
+## Why
+
+The manual "Проверить обновления" outcome is shown only as a toast and the
+startup check is fully silent: `tauri-plugin-updater` logs only endpoint
+errors, so a successful check (or an up-to-date result) leaves no trace in
+the log file. When diagnosing update issues from a user's log we cannot tell
+whether a check even ran.
+
+## What
+
+- The frontend logs every update-check outcome to the same log file via the
+  `tauri-plugin-log` JS API (`@tauri-apps/plugin-log`): "up to date",
+  "update available: <version>", and check failures (including the silent
+  startup path) with the error message.
+
+## Scope
+
+- `src/lib/updater.ts` (both `checkForUpdatesOnStartup` and
+  `checkForUpdatesManual`), plus the `@tauri-apps/plugin-log` dependency.
+- No UI changes; toasts stay as they are.

--- a/openspec/changes/frontend-update-check-logging/specs/logging/spec.md
+++ b/openspec/changes/frontend-update-check-logging/specs/logging/spec.md
@@ -1,0 +1,25 @@
+# Delta: logging
+
+## ADDED Requirements
+
+### Requirement: Update checks are logged
+
+Every update check (startup and manual) SHALL leave a record in the log
+file via the `tauri-plugin-log` JS API: the outcome ("up to date" /
+"update available: <version>") at info level, or the failure reason at
+error level. Startup-check failures SHALL be logged even though they are
+silent in the UI.
+
+#### Scenario: Manual check writes a log entry
+
+- GIVEN the app on Windows
+- WHEN the user presses "Проверить обновления" in Settings
+- THEN the log file contains an `update check (manual)` entry with the
+  outcome, regardless of success or failure
+
+#### Scenario: Failed startup check is logged but silent
+
+- GIVEN the app starts without network access to the update endpoint
+- WHEN the startup update check runs
+- THEN no UI notification is shown AND the log file contains an
+  `update check (startup) failed` entry with the error message

--- a/openspec/changes/frontend-update-check-logging/tasks.md
+++ b/openspec/changes/frontend-update-check-logging/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: frontend-update-check-logging
+
+- [x] Add `@tauri-apps/plugin-log` to the frontend dependencies.
+- [x] Log every update-check outcome (up to date / update available /
+      failure) from `src/lib/updater.ts`, both the startup and the manual
+      path; startup failures go to the log while staying silent in the UI.
+- [x] Mock `@tauri-apps/plugin-log` in `updater.test.ts` and pin the log
+      calls.
+- [ ] Verify on the Win10 VM: after a manual "Проверить обновления", the
+      log file contains an `update check (manual)` entry with the webview
+      target. (Needs a release build — CI uploads no installer artifacts;
+      verify with the v0.3.1 installer.)
+- [ ] Archive the change.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-http": "^2.5.9",
+    "@tauri-apps/plugin-log": "^2.9.0",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tauri-apps/plugin-http':
         specifier: ^2.5.9
         version: 2.5.9
+      '@tauri-apps/plugin-log':
+        specifier: ^2.9.0
+        version: 2.9.0
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.4
         version: 2.5.4
@@ -1151,6 +1154,9 @@ packages:
 
   '@tauri-apps/plugin-http@2.5.9':
     resolution: {integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==}
+
+  '@tauri-apps/plugin-log@2.9.0':
+    resolution: {integrity: sha512-Ql8okrnsguk0eDq1GvRfttFV5KaeW/7vcao6bdbkXCRJ1+2sWE15ZJvJVEKVANrOKy1mRngqC3IFIAP+wP5qSw==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -3425,6 +3431,10 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-http@2.5.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-log@2.9.0':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -20,11 +20,16 @@ vi.mock('@tauri-apps/plugin-updater', () => ({
 vi.mock('@tauri-apps/plugin-process', () => ({
   relaunch: vi.fn(),
 }));
+vi.mock('@tauri-apps/plugin-log', () => ({
+  info: vi.fn(),
+  error: vi.fn(),
+}));
 
 import { notifications } from '@mantine/notifications';
 import { modals } from '@mantine/modals';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
+import { error as logError, info as logInfo } from '@tauri-apps/plugin-log';
 import { checkForUpdatesManual, checkForUpdatesOnStartup, UPDATER_ENABLED } from './updater';
 
 const checkMock = vi.mocked(check);
@@ -32,6 +37,8 @@ const showMock = vi.mocked(notifications.show);
 const updateMock = vi.mocked(notifications.update);
 const modalMock = vi.mocked(modals.openConfirmModal);
 const relaunchMock = vi.mocked(relaunch);
+const logInfoMock = vi.mocked(logInfo);
+const logErrorMock = vi.mocked(logError);
 
 function fakeUpdate() {
   return {
@@ -62,6 +69,7 @@ describe('checkForUpdatesManual', () => {
       expect.objectContaining({ title: 'Обновлений нет', color: 'green' }),
     );
     expect(modalMock).not.toHaveBeenCalled();
+    expect(logInfoMock).toHaveBeenCalledWith('update check (manual): up to date');
   });
 
   it('opens the confirm modal when an update is available', async () => {
@@ -70,6 +78,7 @@ describe('checkForUpdatesManual', () => {
     expect(modalMock).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Доступна новая версия 9.9.9' }),
     );
+    expect(logInfoMock).toHaveBeenCalledWith('update check (manual): update available: 9.9.9');
   });
 
   it('shows a red toast when the check fails (manual = not silent)', async () => {
@@ -77,6 +86,9 @@ describe('checkForUpdatesManual', () => {
     await checkForUpdatesManual();
     expect(showMock).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Не удалось проверить обновления', color: 'red' }),
+    );
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining('update check (manual) failed'),
     );
   });
 });

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,5 +1,6 @@
 import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
+import { error as logError, info as logInfo } from '@tauri-apps/plugin-log';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { formatError } from './errors';
@@ -87,9 +88,16 @@ export async function checkForUpdatesOnStartup() {
   if (!UPDATER_ENABLED) return;
   try {
     const update = await check();
-    if (update) promptInstall(update);
-  } catch {
-    // Offline / endpoint missing / draft-only releases — stay silent.
+    if (update) {
+      await logInfo(`update check (startup): update available: ${update.version}`);
+      promptInstall(update);
+    } else {
+      await logInfo('update check (startup): up to date');
+    }
+  } catch (err) {
+    // Offline / endpoint missing / draft-only releases — stay silent in the UI,
+    // but keep the reason in the log file for diagnostics.
+    await logError(`update check (startup) failed: ${formatError(err)}`);
   }
 }
 
@@ -98,8 +106,10 @@ export async function checkForUpdatesManual() {
   try {
     const update = await check();
     if (update) {
+      await logInfo(`update check (manual): update available: ${update.version}`);
       promptInstall(update);
     } else {
+      await logInfo('update check (manual): up to date');
       notifications.show({
         title: 'Обновлений нет',
         message: 'У вас последняя версия.',
@@ -107,6 +117,7 @@ export async function checkForUpdatesManual() {
       });
     }
   } catch (err) {
+    await logError(`update check (manual) failed: ${formatError(err)}`);
     notifications.show({
       title: 'Не удалось проверить обновления',
       message: formatError(err),


### PR DESCRIPTION
## Summary

- Log every update-check outcome (startup and manual "Проверить обновления") to the diagnostic log file via the `tauri-plugin-log` JS API — previously only endpoint errors were logged by `tauri-plugin-updater`, so a successful or up-to-date check left no trace.
- Startup-check failures stay silent in the UI but are now logged with the error message.

OpenSpec change `frontend-update-check-logging` is included; archiving is deferred until the Win10 VM verification, which needs a release build (CI uploads no installer artifacts) — will happen with v0.3.1.

## Test plan

- [x] `pnpm test:unit` / typecheck / eslint green (log calls pinned in `updater.test.ts`)
- [ ] Win10 VM: manual check writes an `update check (manual)` entry to the log file (deferred to the v0.3.1 build)