### PR TITLE
chore(release): version 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follo
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-08-20
+
+### Added
+- **Update checks are logged** — both the background check and "Проверить обновления" in Settings now write their outcome (up to date / update available / failure reason) to the diagnostic log file (#207).
+
 ## [0.3.0] — 2026-08-19 — Windows support
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvox",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3902,7 +3902,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ruvox-tauri"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruvox-tauri"
-version = "0.3.0"
+version = "0.3.1"
 description = "RuVox — desktop app for reading technical texts aloud"
 authors = []
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "RuVox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.ruvox.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Release prep for v0.3.1: version bump to 0.3.1 (package.json, tauri.conf.json, Cargo.toml/lock) + CHANGELOG entry. Content of the release: update-check logging (#207) — shipped so the Win10 VM verification of the OpenSpec change `frontend-update-check-logging` can run against a real installer (CI uploads no artifacts).

After merge: tag `v0.3.1` on main → release workflow builds the Windows NSIS installer and publishes a draft release; publishing the draft lets the 0.3.0 install auto-update to 0.3.1 for the update-path test.