### PR TITLE
fix(player): kill mpv before and during install so it can't lock $INSTDIR (#211)

### DIFF
--- a/openspec/changes/installer-kills-orphan-mpv/.openspec.yaml
+++ b/openspec/changes/installer-kills-orphan-mpv/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/installer-kills-orphan-mpv/proposal.md
+++ b/openspec/changes/installer-kills-orphan-mpv/proposal.md
@@ -1,0 +1,25 @@
+# Proposal: installer-kills-orphan-mpv
+
+## Why
+
+Issue #211. On Windows the mpv subprocess (spawned via tauri-plugin-mpv)
+outlives the app whenever the app is force-killed instead of exiting
+gracefully — which is exactly what the updater-launched NSIS installer
+does. The orphaned mpv.exe keeps `$INSTDIR\mpv\mpv.exe` locked, so the
+install fails with "Error opening file for writing" and the user has to
+retry after killing mpv by hand. Observed on the 0.3.0 → 0.3.1
+auto-update and on manual reinstall of a running app.
+
+## What
+
+Two complementary fixes:
+
+- **App side (deterministic for the auto-update flow):** the frontend
+  destroys the mpv subprocess (new `shutdown_player_for_update` command)
+  right before `Update.downloadAndInstall()` — before the installer can
+  force-kill the app.
+- **Installer side (covers manual reinstall and uninstall of a running
+  app):** NSIS installer hooks (`NSIS_HOOK_PREINSTALL`,
+  `NSIS_HOOK_PREUNINSTALL`) kill mpv.exe processes whose executable path
+  is under `$INSTDIR`, leaving any standalone mpv the user may have
+  alone.

--- a/openspec/changes/installer-kills-orphan-mpv/specs/auto-update/spec.md
+++ b/openspec/changes/installer-kills-orphan-mpv/specs/auto-update/spec.md
@@ -1,0 +1,30 @@
+# Delta: auto-update
+
+## ADDED Requirements
+
+### Requirement: Player is shut down before update installation
+
+Before calling `Update.downloadAndInstall()`, the app SHALL destroy the
+mpv subprocess (the `shutdown_player_for_update` command): mark the
+player destroyed so in-flight commands short-circuit, then best-effort
+destroy the mpv instance — a missing instance (already destroyed when
+the main window closed) MUST NOT abort the update.
+
+Rationale: the updater-launched installer force-kills the app, so
+`RunEvent::Exit` never fires; without this, the orphaned mpv.exe locks
+the install dir (#211).
+
+#### Scenario: Update with a live mpv
+
+- GIVEN the app with a running mpv subprocess
+- WHEN the user confirms an update
+- THEN mpv is destroyed before the installer starts AND the install
+  proceeds without a "file in use" error
+
+#### Scenario: Update with mpv already destroyed
+
+- GIVEN the app whose mpv instance was already destroyed (e.g. the main
+  window was closed to tray and the plugin tore mpv down)
+- WHEN the user confirms an update
+- THEN the destroy attempt fails silently in the log and the update
+  proceeds normally

--- a/openspec/changes/installer-kills-orphan-mpv/specs/windows-installer/spec.md
+++ b/openspec/changes/installer-kills-orphan-mpv/specs/windows-installer/spec.md
@@ -1,0 +1,29 @@
+# Delta: windows-installer
+
+## ADDED Requirements
+
+### Requirement: Installer kills the app's orphaned mpv
+
+The NSIS installer SHALL, before copying or removing files
+(`NSIS_HOOK_PREINSTALL` / `NSIS_HOOK_PREUNINSTALL`), terminate any
+`mpv.exe` process whose executable path is under the install directory.
+Processes outside the install directory (e.g. a standalone mpv player)
+MUST NOT be touched.
+
+Rationale: the app spawns mpv via tauri-plugin-mpv; when the installer
+force-kills the app, the exit-time mpv cleanup never runs and the orphan
+locks `mpv\mpv.exe`, failing the install (#211).
+
+#### Scenario: Update install with a running mpv
+
+- GIVEN RuVox is installed and its mpv subprocess is running
+- WHEN the installer (auto-update or manual reinstall) runs
+- THEN the in-dir mpv.exe is terminated before file copying AND the
+  install completes without a "file in use" error
+
+#### Scenario: Standalone mpv is left alone
+
+- GIVEN a mpv.exe process running from a directory outside the install
+  dir
+- WHEN the installer runs
+- THEN that process is still running afterwards

--- a/openspec/changes/installer-kills-orphan-mpv/tasks.md
+++ b/openspec/changes/installer-kills-orphan-mpv/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: installer-kills-orphan-mpv
+
+- [x] Add the `shutdown_player_for_update` command (mark destroyed +
+      best-effort `mpv().destroy()`, mirroring the `RunEvent::Exit`
+      cleanup) and register it.
+- [x] Call it from `installAndRelaunch` before `downloadAndInstall()`;
+      pin the call in `updater.test.ts`.
+- [x] Add `src-tauri/windows/hooks.nsh` with `NSIS_HOOK_PREINSTALL` /
+      `NSIS_HOOK_PREUNINSTALL` killing mpv.exe path-filtered by
+      `$INSTDIR`; wire `bundle.windows.nsis.installerHooks` in
+      `tauri.conf.json`.
+- [ ] Verify on the Win10 VM with a release build: auto-update no longer
+      hits "Error opening file for writing" for mpv.exe (needs a
+      release build — CI uploads no installer artifacts).
+- [ ] Archive the change.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tauri::{AppHandle, Emitter, Runtime, State};
+use tauri_plugin_mpv::MpvExt;
 use tokio::task::AbortHandle;
 use tracing::{info, warn};
 
@@ -1097,6 +1098,27 @@ pub async fn stop_playback(state: State<'_, AppState>) -> CmdResult<()> {
         .map_err(|e| CommandError::PlaybackError {
             message: e.to_string(),
         })
+}
+
+/// Destroy the mpv subprocess before the updater launches the installer
+/// (#211). The updater-launched NSIS installer force-kills this process,
+/// so `RunEvent::Exit` (which normally destroys mpv) never fires and the
+/// orphaned mpv.exe keeps `$INSTDIR\mpv\mpv.exe` locked, failing the
+/// install. Called by the frontend right before `downloadAndInstall()`.
+/// Mirrors the `RunEvent::Exit` cleanup in `lib.rs`: mark first so
+/// in-flight player commands short-circuit, then destroy.
+#[tauri::command]
+pub async fn shutdown_player_for_update<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+) -> CmdResult<()> {
+    state.player.mark_destroyed();
+    // Best-effort: a missing mpv instance (already destroyed when the main
+    // window closed) must not abort the update.
+    if let Err(e) = app.mpv().destroy(crate::player::WINDOW_LABEL) {
+        warn!("mpv destroy before update failed (continuing): {e}");
+    }
+    Ok(())
 }
 
 /// Seek to an absolute position in the current audio.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -411,6 +411,7 @@ pub(crate) fn invoke_handler<R: Runtime>()
         pause_playback,
         resume_playback,
         stop_playback,
+        shutdown_player_for_update,
         seek_to,
         set_speed,
         set_volume,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,9 @@
     "windows": {
       "webviewInstallMode": {
         "type": "embedBootstrapper"
+      },
+      "nsis": {
+        "installerHooks": "./windows/hooks.nsh"
       }
     },
     "createUpdaterArtifacts": true,

--- a/src-tauri/windows/hooks.nsh
+++ b/src-tauri/windows/hooks.nsh
@@ -1,0 +1,26 @@
+; RuVox NSIS installer hooks (#211).
+;
+; The app spawns mpv.exe via tauri-plugin-mpv. When the installer (an
+; auto-update, a manual reinstall, or an uninstall of a running app)
+; force-kills ruvox-tauri.exe, the exit-time mpv cleanup never runs and
+; the orphaned mpv keeps $INSTDIR\mpv\mpv.exe locked — the install then
+; fails with "Error opening file for writing". Kill only OUR mpv
+; (path-filtered by $INSTDIR): a user's standalone mpv player, if any,
+; must not be touched.
+;
+; NSIS expands $INSTDIR in the backtick string; $$ is a literal dollar,
+; so PowerShell's $_ survives as $_.
+
+!macro NSIS_HOOK_KILL_MPV
+  nsExec::ExecToStack `powershell -NoProfile -NonInteractive -Command "Get-Process mpv -ErrorAction SilentlyContinue | Where-Object { $$_.Path -like '$INSTDIR*' } | Stop-Process -Force"`
+  Pop $0 ; exit code (ignored: best-effort cleanup)
+  Pop $1 ; output (ignored)
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro NSIS_HOOK_KILL_MPV
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro NSIS_HOOK_KILL_MPV
+!macroend

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -163,6 +163,12 @@ export const commands = {
   stopPlayback: (): Promise<void> =>
     tauriInvoke('stop_playback'),
 
+  /** Destroy the mpv subprocess before the updater runs the installer
+   * (#211): the installer force-kills the app, so the exit-time cleanup
+   * never runs and the orphaned mpv.exe would lock the install dir. */
+  shutdownPlayerForUpdate: (): Promise<void> =>
+    tauriInvoke('shutdown_player_for_update'),
+
   seekTo: (position_sec: number): Promise<void> =>
     tauriInvoke('seek_to', { positionSec: position_sec }),
 

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -24,12 +24,16 @@ vi.mock('@tauri-apps/plugin-log', () => ({
   info: vi.fn(),
   error: vi.fn(),
 }));
+vi.mock('./tauri', () => ({
+  commands: { shutdownPlayerForUpdate: vi.fn().mockResolvedValue(undefined) },
+}));
 
 import { notifications } from '@mantine/notifications';
 import { modals } from '@mantine/modals';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { error as logError, info as logInfo } from '@tauri-apps/plugin-log';
+import { commands } from './tauri';
 import { checkForUpdatesManual, checkForUpdatesOnStartup, UPDATER_ENABLED } from './updater';
 
 const checkMock = vi.mocked(check);
@@ -109,6 +113,9 @@ describe('install flow (confirm → downloadAndInstall → relaunch)', () => {
     expect(showMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'app-update', loading: true }),
     );
+    // #211: mpv is destroyed before the installer starts so the orphaned
+    // process cannot lock the install dir.
+    expect(commands.shutdownPlayerForUpdate).toHaveBeenCalled();
     expect(update.downloadAndInstall).toHaveBeenCalled();
   });
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4,6 +4,7 @@ import { error as logError, info as logInfo } from '@tauri-apps/plugin-log';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { formatError } from './errors';
+import { commands } from './tauri';
 
 /**
  * Auto-update front end (tauri-plugin-updater).
@@ -30,6 +31,10 @@ async function installAndRelaunch(update: Update) {
     autoClose: false,
   });
   let downloaded = 0;
+  // #211: the updater-launched installer force-kills the app, so the
+  // exit-time mpv cleanup never runs and the orphaned mpv.exe would lock
+  // $INSTDIR — destroy it up front, before the download even starts.
+  await commands.shutdownPlayerForUpdate();
   await update.downloadAndInstall((event) => {
     if (event.event === 'Started' && event.data.contentLength) {
       notifications.update({


### PR DESCRIPTION
## Summary

Fixes #211. On Windows the mpv subprocess outlives the app when the app is force-killed — exactly what the updater-launched NSIS installer does — and the orphan locks `$INSTDIR\mpv\mpv.exe`, failing the install with "Error opening file for writing" (seen on the 0.3.0 → 0.3.1 auto-update on the Win10 VM).

- App side: the update flow destroys mpv (new `shutdown_player_for_update` command) before `downloadAndInstall()`.
- Installer side: NSIS hooks (`NSIS_HOOK_PREINSTALL` / `PREUNINSTALL`, `src-tauri/windows/hooks.nsh`) kill mpv.exe path-filtered by `$INSTDIR` — covers manual reinstall/uninstall of a running app; a standalone mpv player is left alone.

OpenSpec change `installer-kills-orphan-mpv` included; archiving is deferred until the Win10 VM verification, which needs a release build (CI uploads no installer artifacts).

## Test plan

- [x] cargo clippy/fmt, `pnpm test:unit` (new pin: update flow calls `shutdownPlayerForUpdate` before install), typecheck, eslint
- [ ] Win10 VM: auto-update completes without "Error opening file for writing" for mpv.exe (deferred to the next release build)