### PR TITLE
fix(audio): resample off-list WAV rates to nearest Opus-native rate

### DIFF
--- a/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/design.md
+++ b/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/design.md
@@ -1,0 +1,37 @@
+# Design: opus-resample-off-list-rates
+
+## Why resample instead of widening the whitelist
+
+The issue suggested two options: add 22050 to the accepted-rate whitelist, or
+resample to 24000. **Adding 22050 was rejected**: `libopus` only accepts the
+five native rates as an *encoder input rate* (`opus_encoder_create` errors on
+anything else, RFC 6716 §2). Encoding happens at the resampled native rate
+regardless, so widening the whitelist would just move the failure from the
+pre-check into `Encoder::new`. Resampling is the only correct fix.
+
+## Why "nearest native rate", not a fixed target
+
+Resampling to a single fixed rate (e.g. always 48 kHz) would upscale 22050 →
+48000 (more than 2×) and downscale 44100 → 48000, both farther from the source
+than necessary. Choosing the *nearest* native rate keeps the rate change
+minimal (22050 → 24000 is a 1.09× stretch; 44100 → 48000 is 1.09×), so any
+resampling artefact is negligible at 32 kbps VOIP. `nearest_supported_rate`
+picks by absolute Hz distance.
+
+## Resampler choice
+
+Linear interpolation was chosen over a windowed/Sinc resampler: the output is
+already low-bitrate speech (32 kbps VOIP), the off-list rates are within ~9%
+of a native rate, and the clips are short. A full Sinc filter would add a
+dependency and complexity for inaudible gain. The linear pass is ~15 lines and
+needs no new crate. Endpoints past the last input sample are held constant so
+a trailing frame stays well-formed.
+
+## Frame-writing refactor
+
+`encode_wav_to_opus` previously computed `total_frames` from `reader.duration()`
+to mark the final Ogg page `EndStream`. With resampling the output length isn't
+known up front, so frame writing moved into `write_frames`, which buffers the
+most recently completed frame and flushes it as `NormalPacket` when the next
+arrives (or as the terminal `EndStream` page at end of input). Behavior is
+identical for the native path (verified by the per-rate round-trip tests).

--- a/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/proposal.md
+++ b/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/proposal.md
@@ -1,0 +1,43 @@
+# Proposal: opus-resample-off-list-rates
+
+Fixes #206 (targeted at v0.3.0).
+
+## Why
+
+`crate::audio::encode_wav_to_opus` only accepts the five Opus-native sample
+rates (8 / 12 / 16 / 24 / 48 kHz, RFC 6716 §2) and rejects anything else with
+`unsupported wav format: expected sample rate in [...] Hz, got 22050`. Piper
+voices emit at their own rate — `ruslan` outputs 22050 Hz — so every Piper
+entry hits the rejection path, the WAV-to-Opus transcode is skipped, and the
+entry keeps the much larger `.wav` instead of an `.opus`. The startup
+migration sweep (`storage::service::migrate_wav_audio_to_opus`) logs the same
+error for legacy 22050 Hz WAVs and leaves them as `.wav` forever.
+
+## What Changes
+
+Resample any off-list WAV rate to the **nearest** Opus-native rate before
+encoding, instead of rejecting it:
+
+- Native rates (8/12/16/24/48 kHz) pass through untouched — Silero `ttsd`'s
+  48 kHz path stays streaming and unchanged.
+- Off-list rates are linear-resampled to the closest native rate: 22050 →
+  24000, 44100 → 48000, 32000 → 24000, 11025 → 12000, etc.
+- `OpusHead` records the rate the encoder actually used (the native,
+  resampled rate), never the original off-list rate.
+
+The resampler is a small linear-interpolation pass (one buffer, only needed
+for off-list inputs — Piper clips are seconds long, so buffering is cheap).
+The native path still streams frame-by-frame from the WAV reader, so memory
+stays constant for the common case.
+
+## Non-goals
+
+- Changing Piper's own output rate, or forcing Piper to emit a native rate —
+  that is the TTS engine's choice; we adapt on the Rust side.
+- Picking an arbitrary fixed target rate (e.g. always 48 kHz) — we resample to
+  the *nearest* native rate to minimize rate change and keep 44.1 kHz content
+  at 48 kHz rather than downscaling it.
+- Downmixing stereo or converting integer PCM — those inputs are still
+  rejected up front; only the off-list *sample rate* is now handled.
+- Touching `UIConfig.sample_rate` semantics — it still selects the Silero
+  output rate; Piper voices ignore it and we resample whatever they produce.

--- a/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/specs/storage/spec.md
+++ b/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/specs/storage/spec.md
@@ -1,0 +1,102 @@
+# Delta: storage
+
+## MODIFIED Requirements
+
+### Requirement: Audio File Storage
+
+The system SHALL store synthesized audio per entry as `audio/{uuid}.opus`, where `{uuid}` is the entry's `EntryId`. The file SHALL be an Ogg-Opus stream:
+
+| Property | Value |
+|----------|-------|
+| Container | Ogg |
+| Codec | Opus (RFC 6716, RFC 7845) |
+| Channels | 1 (mono) |
+| Sample rate | One of 8 / 12 / 16 / 24 / 48 kHz — the rates libopus accepts natively (RFC 6716 §2). The TTS subprocess SHOULD write one of these; if it writes any other rate (e.g. a Piper voice at 22050 Hz, or 44100 Hz), the Rust side SHALL resample it to the nearest native rate before encoding. `OpusHead` SHALL record the native (resampled) rate the encoder actually used, not the original off-list rate |
+| Bitrate | 32 000 bps (VOIP application) |
+| Frame size | 20 ms |
+| Pre-skip | Queried from `libopus`'s lookahead, scaled to 48 kHz output ticks |
+
+The encoding pipeline is: the TTS subprocess writes a mono 32-bit-float WAV; the Rust side transcodes it to Opus and removes the source WAV. If the WAV's sample rate is not one of the Opus-native rates, the Rust side SHALL resample it to the nearest native rate first. On encode failure the source `.wav` SHALL be left in place as a playback fallback. `save_audio` SHALL return the relative filename for `TextEntry.audio_path`.
+
+#### Scenario: Saving audio returns the relative filename
+- GIVEN an entry with id `550e8400-e29b-41d4-a716-446655440000`
+- WHEN audio bytes are saved for the entry
+- THEN the file `audio/550e8400-e29b-41d4-a716-446655440000.opus` exists and the returned filename is `550e8400-e29b-41d4-a716-446655440000.opus`
+
+#### Scenario: Transcode failure keeps the WAV fallback
+- GIVEN a synthesized `.wav` that fails Opus encoding
+- WHEN the transcode step runs
+- THEN the source `.wav` remains on disk so playback can still use it
+
+#### Scenario: Off-list sample rate is resampled to the nearest native rate
+- GIVEN a synthesized mono 32-bit-float WAV at an off-list rate (e.g. 22050 Hz from a Piper voice)
+- WHEN the Rust side transcodes it to Opus
+- THEN the entry is stored as `.opus` (the source `.wav` is removed), `OpusHead` records 24000 Hz, and no "unsupported wav format" error is logged
+
+#### Scenario: Native sample rate passes through without resampling
+- GIVEN a synthesized mono 32-bit-float WAV at a native rate (e.g. 48000 Hz)
+- WHEN the Rust side transcodes it to Opus
+- THEN the entry is stored as `.opus` and `OpusHead` records 48000 Hz, with no resampling step
+
+### Requirement: Legacy WAV to Opus Migration
+
+On every app launch the system SHALL run a one-shot migration sweep over the loaded entries: any entry whose `audio_path` ends in `.wav` SHALL be transcoded to `.opus`, the entry's `audio_path` updated to the new filename, and the source `.wav` removed. The sweep SHALL be idempotent (already-`.opus` entries are not considered) and SHALL NOT abort on per-entry failures — encode errors and missing source files are logged and counted while the app keeps starting normally. Legacy `.wav` references in `history.json` SHALL continue to parse indefinitely. Off-list WAV rates (e.g. 22050 Hz Piper clips) SHALL be resampled to the nearest native rate during the transcode, not rejected.
+
+#### Scenario: Legacy entry is migrated
+- GIVEN an entry whose `audio_path` points at an existing `{uuid}.wav`
+- WHEN the migration sweep runs
+- THEN the entry's `audio_path` ends in `.opus`, the `.opus` file exists, and the source `.wav` is removed
+
+#### Scenario: Legacy off-list-rate WAV is migrated
+- GIVEN an entry whose `audio_path` points at an existing `{uuid}.wav` at an off-list rate (e.g. 22050 Hz)
+- WHEN the migration sweep runs
+- THEN the entry is migrated to `.opus` (resampled to the nearest native rate) and the source `.wav` is removed
+
+#### Scenario: Migration is idempotent
+- GIVEN all entries already reference `.opus` files
+- WHEN the migration sweep runs
+- THEN no entries are considered and no files are touched
+
+#### Scenario: Missing source file does not abort the sweep
+- GIVEN one entry referencing a missing `.wav` and another referencing an existing `.wav`
+- WHEN the migration sweep runs
+- THEN the missing one is skipped with a warning and the existing one is migrated
+
+### Requirement: Config File Schema
+
+The system SHALL persist application configuration to `config.json` as a `UIConfig` JSON object:
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `speaker` | string | `"aidar"` | Silero speaker name |
+| `sample_rate` | number | `24000` | TTS output rate for the native engines; the native Opus rates 8000 / 12000 / 16000 / 24000 / 48000 round-trip without resampling, and any other rate is resampled to the nearest native one before encoding |
+| `speech_rate` | number | `1.0` | Playback speed multiplier (0.5–2.0) |
+| `notify_on_ready` | boolean | `true` | Show notification when synthesis completes |
+| `notify_on_error` | boolean | `true` | Show notification on synthesis error |
+| `text_format` | string | `"plain"` | Default viewer format: `"plain"` / `"markdown"` / `"html"` |
+| `max_cache_size_mb` | number | `500` | Soft limit on audio cache size in MB; drives startup eviction (0 = disabled) |
+| `code_block_mode` | string | `"read"` | How to handle Markdown code blocks: `"skip"` / `"read"` |
+| `read_operators` | boolean | `true` | Whether to speak mathematical/code operators |
+| `theme` | string | `"auto"` | Color scheme: `"light"` / `"dark"` / `"auto"` |
+| `player_hotkeys` | object | 10-key map (`play_pause` → `"Space"`, `forward_5` → `"Right"`, `backward_5` → `"Left"`, `forward_30` → `"Shift+Right"`, `backward_30` → `"Shift+Left"`, `speed_up` → `"]"`, `speed_down` → `"["`, `next_entry` → `"n"`, `prev_entry` → `"p"`, `repeat_sentence` → `"r"`) | Local player hotkeys |
+| `window_geometry` | `[x, y, width, height]` or null | `null` | Saved window geometry |
+| `preview_dialog_enabled` | boolean | `true` | Show normalization preview dialog before synthesis |
+| `engine` | string | `"silero_native"` | Active TTS engine: `"piper"` / `"silero"` / `"silero_native"` |
+| `piper_voice` | string | `"ruslan"` | Active Piper voice id |
+
+Every field SHALL default when absent from the JSON, so configs written by older builds parse cleanly and silently adopt current defaults (e.g. pre-engine configs switch to `"silero_native"`). Unknown JSON keys SHALL be ignored on read. When `config.json` does not exist, the service SHALL return the default configuration. Partial updates SHALL be expressed as a patch object in which omitted fields keep their current value.
+
+#### Scenario: Missing config returns defaults
+- GIVEN no `config.json` in the cache directory
+- WHEN the configuration is loaded
+- THEN the default configuration is returned (`speaker` `"aidar"`, `sample_rate` `24000`, `engine` `"silero_native"`, `piper_voice` `"ruslan"`)
+
+#### Scenario: Older config without engine keys
+- GIVEN a `config.json` that contains only `speaker`, `sample_rate`, and `speech_rate`
+- WHEN the configuration is loaded
+- THEN it parses successfully with `engine` defaulted to `"silero_native"` and `piper_voice` defaulted to `"ruslan"`
+
+#### Scenario: Config round-trips
+- GIVEN a configuration with `speaker` `"xenia"` and `sample_rate` `48000`
+- WHEN the configuration is saved and loaded again
+- THEN the loaded values match the saved ones

--- a/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/tasks.md
+++ b/openspec/changes/archive/2026-08-20-opus-resample-off-list-rates/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: opus-resample-off-list-rates
+
+- [x] In `src-tauri/src/audio/mod.rs`, replace the sample-rate pre-check in
+  `encode_wav_to_opus` with a "nearest native rate" decision: native rates pass
+  through, off-list rates are resampled via a new `resample_linear` helper to
+  the rate chosen by `nearest_supported_rate`; record the resampled rate in
+  `OpusHead`.
+- [x] Factor frame writing into a `write_frames` helper that buffers the last
+  frame to mark `EndStream` without knowing the output length up front (so it
+  works for both streaming native input and buffered resampled input).
+- [x] Update `audio` unit tests: drop the "22050 is rejected" case, add
+  `resamples_off_list_rate_to_nearest_native` (22050 → 24000) and
+  `resamples_44100_to_48000` (44100 → 48000) checks on `OpusHead` rate.
+- [x] Add `migrate_22050_wav_audio_to_opus` to `storage::service` tests (legacy
+  22050 Hz WAV migrates to `.opus`, source removed).
+- [x] `just test` (Rust `audio` + `storage::service` suites) green.
+- [x] `just lint` (clippy + rustfmt) green.
+- [x] Archive the change (sync delta specs into `openspec/specs/`).

--- a/openspec/specs/storage/spec.md
+++ b/openspec/specs/storage/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 Covers the on-disk persistence layer of RuVox (`src-tauri/src/storage/`): the per-user cache directory layout, the `history.json` entry store, the `config.json` application configuration, synthesized audio files (`{uuid}.opus`), word-level timestamp files (`{uuid}.timestamps.json`), the legacy WAV-to-Opus migration, and cache hygiene (orphan sweep and size-based eviction).
+
 ## Requirements
+
 ### Requirement: Cache Directory Layout
 
 The system SHALL store all persistent data under a per-user cache root, with the following layout:
@@ -167,12 +169,12 @@ The system SHALL store synthesized audio per entry as `audio/{uuid}.opus`, where
 | Container | Ogg |
 | Codec | Opus (RFC 6716, RFC 7845) |
 | Channels | 1 (mono) |
-| Sample rate | One of 8 / 12 / 16 / 24 / 48 kHz — matches `UIConfig.sample_rate` (default 48 kHz); recorded verbatim in `OpusHead` |
+| Sample rate | One of 8 / 12 / 16 / 24 / 48 kHz — the rates libopus accepts natively (RFC 6716 §2). The TTS subprocess SHOULD write one of these; if it writes any other rate (e.g. a Piper voice at 22050 Hz, or 44100 Hz), the Rust side SHALL resample it to the nearest native rate before encoding. `OpusHead` SHALL record the native (resampled) rate the encoder actually used, not the original off-list rate |
 | Bitrate | 32 000 bps (VOIP application) |
 | Frame size | 20 ms |
 | Pre-skip | Queried from `libopus`'s lookahead, scaled to 48 kHz output ticks |
 
-The encoding pipeline is: the TTS subprocess writes a mono 32-bit-float WAV at `UIConfig.sample_rate`; the Rust side transcodes it to Opus and removes the source WAV. On encode failure the source `.wav` SHALL be left in place as a playback fallback. `save_audio` SHALL return the relative filename for `TextEntry.audio_path`.
+The encoding pipeline is: the TTS subprocess writes a mono 32-bit-float WAV; the Rust side transcodes it to Opus and removes the source WAV. If the WAV's sample rate is not one of the Opus-native rates, the Rust side SHALL resample it to the nearest native rate first. On encode failure the source `.wav` SHALL be left in place as a playback fallback. `save_audio` SHALL return the relative filename for `TextEntry.audio_path`.
 
 #### Scenario: Saving audio returns the relative filename
 - GIVEN an entry with id `550e8400-e29b-41d4-a716-446655440000`
@@ -184,14 +186,29 @@ The encoding pipeline is: the TTS subprocess writes a mono 32-bit-float WAV at `
 - WHEN the transcode step runs
 - THEN the source `.wav` remains on disk so playback can still use it
 
+#### Scenario: Off-list sample rate is resampled to the nearest native rate
+- GIVEN a synthesized mono 32-bit-float WAV at an off-list rate (e.g. 22050 Hz from a Piper voice)
+- WHEN the Rust side transcodes it to Opus
+- THEN the entry is stored as `.opus` (the source `.wav` is removed), `OpusHead` records 24000 Hz, and no "unsupported wav format" error is logged
+
+#### Scenario: Native sample rate passes through without resampling
+- GIVEN a synthesized mono 32-bit-float WAV at a native rate (e.g. 48000 Hz)
+- WHEN the Rust side transcodes it to Opus
+- THEN the entry is stored as `.opus` and `OpusHead` records 48000 Hz, with no resampling step
+
 ### Requirement: Legacy WAV to Opus Migration
 
-On every app launch the system SHALL run a one-shot migration sweep over the loaded entries: any entry whose `audio_path` ends in `.wav` SHALL be transcoded to `.opus`, the entry's `audio_path` updated to the new filename, and the source `.wav` removed. The sweep SHALL be idempotent (already-`.opus` entries are not considered) and SHALL NOT abort on per-entry failures — encode errors and missing source files are logged and counted while the app keeps starting normally. Legacy `.wav` references in `history.json` SHALL continue to parse indefinitely.
+On every app launch the system SHALL run a one-shot migration sweep over the loaded entries: any entry whose `audio_path` ends in `.wav` SHALL be transcoded to `.opus`, the entry's `audio_path` updated to the new filename, and the source `.wav` removed. The sweep SHALL be idempotent (already-`.opus` entries are not considered) and SHALL NOT abort on per-entry failures — encode errors and missing source files are logged and counted while the app keeps starting normally. Legacy `.wav` references in `history.json` SHALL continue to parse indefinitely. Off-list WAV rates (e.g. 22050 Hz Piper clips) SHALL be resampled to the nearest native rate during the transcode, not rejected.
 
 #### Scenario: Legacy entry is migrated
 - GIVEN an entry whose `audio_path` points at an existing `{uuid}.wav`
 - WHEN the migration sweep runs
 - THEN the entry's `audio_path` ends in `.opus`, the `.opus` file exists, and the source `.wav` is removed
+
+#### Scenario: Legacy off-list-rate WAV is migrated
+- GIVEN an entry whose `audio_path` points at an existing `{uuid}.wav` at an off-list rate (e.g. 22050 Hz)
+- WHEN the migration sweep runs
+- THEN the entry is migrated to `.opus` (resampled to the nearest native rate) and the source `.wav` is removed
 
 #### Scenario: Migration is idempotent
 - GIVEN all entries already reference `.opus` files
@@ -239,7 +256,7 @@ The system SHALL persist application configuration to `config.json` as a `UIConf
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|
 | `speaker` | string | `"aidar"` | Silero speaker name |
-| `sample_rate` | number | `24000` | TTS output rate; any of 8000 / 12000 / 16000 / 24000 / 48000 round-trips through the Opus encoder without resampling |
+| `sample_rate` | number | `24000` | TTS output rate for the native engines; the native Opus rates 8000 / 12000 / 16000 / 24000 / 48000 round-trip without resampling, and any other rate is resampled to the nearest native one before encoding |
 | `speech_rate` | number | `1.0` | Playback speed multiplier (0.5–2.0) |
 | `notify_on_ready` | boolean | `true` | Show notification when synthesis completes |
 | `notify_on_error` | boolean | `true` | Show notification on synthesis error |
@@ -359,4 +376,3 @@ The on-disk format originated in the earlier PyQt implementation of RuVox, and e
 - GIVEN a `config.json` containing keys not present in the current `UIConfig` schema
 - WHEN the configuration is loaded
 - THEN it parses successfully and the unknown keys are dropped
-

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,10 +1,15 @@
 //! WAV → Ogg-Opus streaming encoder.
 //!
-//! Inputs are 48 kHz mono 32-bit float WAV files (the format ttsd writes via
-//! Silero). Output is a valid Ogg-Opus stream at 32 kbps VOIP, 20 ms frames.
-//! The implementation is streaming — samples are read from the WAV in 960-
-//! sample chunks and fed straight to the encoder, so memory use stays
-//! constant regardless of audio length.
+//! Inputs are mono 32-bit-float WAV files. Output is a valid Ogg-Opus stream
+//! at 32 kbps VOIP, 20 ms frames. The implementation is streaming — samples
+//! are read from the WAV in frame-sized chunks and fed straight to the
+//! encoder, so memory use stays constant regardless of audio length.
+//!
+//! libopus only accepts the five Opus-native rates (RFC 6716 §2: 8/12/16/24/48
+//! kHz) as an encoder input rate, so a WAV at any other rate (e.g. Piper's
+//! 22050 Hz, or 44100 Hz) is linear-resampled to the nearest native rate
+//! before encoding. The native path (Silero ttsd's 48 kHz) is passed through
+//! untouched, keeping that common case streaming.
 //!
 //! See `tmp/opus_compare/` for the prototype this was ported from and the
 //! benchmarks that motivated the choice of `opus = "0.3"` (FFI to C libopus)
@@ -27,7 +32,8 @@ const SERIAL: u32 = 0x5275_564f;
 // (`opus_encode` returns at most this for a single 20 ms frame at any bitrate).
 const MAX_PACKET_BYTES: usize = 4000;
 // Sample rates Opus accepts natively (RFC 6716 §2). The encoder is wired up
-// for whichever of these the input WAV uses.
+// for whichever of these the input WAV uses. Anything outside this set is
+// resampled to the nearest entry (see `nearest_supported_rate`) before encoding.
 const SUPPORTED_SAMPLE_RATES: [u32; 5] = [8_000, 12_000, 16_000, 24_000, 48_000];
 // Granule position (RFC 7845 §4.1) is always reported in 48 kHz output ticks
 // regardless of the input rate, so one 20 ms frame advances the granule by
@@ -56,19 +62,17 @@ pub enum AudioError {
 
 pub type Result<T> = std::result::Result<T, AudioError>;
 
-/// Encode a mono 32-bit-float WAV at `wav_path` (sample rate must be one of
-/// 8/12/16/24/48 kHz — the rates Opus supports natively) to an Ogg-Opus file
-/// at `opus_path`. Streaming — memory use is bounded regardless of audio length.
+/// Encode a mono 32-bit-float WAV at `wav_path` to an Ogg-Opus file at
+/// `opus_path`. Streaming — memory use is bounded regardless of audio length.
+///
+/// The WAV's sample rate must be one Opus accepts natively (8/12/16/24/48 kHz)
+/// or, if it is off-list (e.g. Piper's 22050 Hz), it is resampled to the
+/// nearest native rate first. The resampled (native) rate is what gets
+/// recorded in `OpusHead`, so a 22050 Hz clip ends up as a 24 kHz Opus stream.
 pub fn encode_wav_to_opus(wav_path: &Path, opus_path: &Path) -> Result<()> {
     let mut reader = hound::WavReader::open(wav_path)?;
     let spec = reader.spec();
 
-    if !SUPPORTED_SAMPLE_RATES.contains(&spec.sample_rate) {
-        return Err(AudioError::UnsupportedFormat(format!(
-            "expected sample rate in {:?} Hz, got {}",
-            SUPPORTED_SAMPLE_RATES, spec.sample_rate
-        )));
-    }
     if spec.channels != 1 {
         return Err(AudioError::UnsupportedFormat(format!(
             "expected mono (1 channel), got {} channels",
@@ -82,10 +86,16 @@ pub fn encode_wav_to_opus(wav_path: &Path, opus_path: &Path) -> Result<()> {
         )));
     }
 
-    let sample_rate = spec.sample_rate;
-    let frame_samples = frame_samples(sample_rate);
+    let in_rate = spec.sample_rate;
+    // libopus only takes native rates; anything else is resampled to the
+    // nearest one before encoding (see module docs).
+    let encode_rate = if SUPPORTED_SAMPLE_RATES.contains(&in_rate) {
+        in_rate
+    } else {
+        nearest_supported_rate(in_rate)
+    };
 
-    let mut encoder = Encoder::new(sample_rate, Channels::Mono, Application::Voip)?;
+    let mut encoder = Encoder::new(encode_rate, Channels::Mono, Application::Voip)?;
     encoder.set_bitrate(Bitrate::Bits(BITRATE_BPS))?;
 
     // Pre-skip is the leading-sample count decoders must discard, expressed in
@@ -96,63 +106,136 @@ pub fn encode_wav_to_opus(wav_path: &Path, opus_path: &Path) -> Result<()> {
     let pre_skip_48k: u32 = encoder
         .get_lookahead()
         .ok()
-        .map(|n| (n as u32).saturating_mul(48_000) / sample_rate)
+        .map(|n| (n as u32).saturating_mul(48_000) / encode_rate)
         .unwrap_or(DEFAULT_PRE_SKIP_48K);
     let pre_skip: u16 = pre_skip_48k.min(u16::MAX as u32) as u16;
-
-    let total_samples = reader.duration() as usize;
-    let total_frames = total_samples.div_ceil(frame_samples);
 
     let file = BufWriter::new(File::create(opus_path)?);
     let mut writer = PacketWriter::new(file);
 
     writer.write_packet(
-        build_opus_head(sample_rate, pre_skip),
+        build_opus_head(encode_rate, pre_skip),
         SERIAL,
         PacketWriteEndInfo::EndPage,
         0,
     )?;
     writer.write_packet(build_opus_tags(), SERIAL, PacketWriteEndInfo::EndPage, 0)?;
 
-    let mut encoded = vec![0u8; MAX_PACKET_BYTES];
-    let mut frame_buf = vec![0f32; frame_samples];
-    let mut absgp: u64 = 0;
-    let mut frame_idx: usize = 0;
-    let mut samples = reader.samples::<f32>();
-
-    loop {
-        let mut n_read = 0usize;
-        for slot in frame_buf.iter_mut() {
-            match samples.next() {
-                Some(Ok(s)) => {
-                    *slot = s;
-                    n_read += 1;
-                }
-                Some(Err(e)) => return Err(AudioError::Wav(e)),
-                None => break,
-            }
-        }
-        if n_read == 0 {
-            break;
-        }
-        for slot in &mut frame_buf[n_read..] {
-            *slot = 0.0;
-        }
-
-        let n = encoder.encode_float(&frame_buf, &mut encoded)?;
-        absgp += GRANULE_PER_FRAME;
-        frame_idx += 1;
-
-        let end = if frame_idx == total_frames {
-            PacketWriteEndInfo::EndStream
+    // Native rates stream straight from the WAV reader (constant memory).
+    // Off-list rates must be buffered once to resample, then streamed out.
+    let mut samples_iter: Box<dyn Iterator<Item = std::result::Result<f32, hound::Error>>> =
+        if encode_rate == in_rate {
+            Box::new(reader.samples::<f32>())
         } else {
-            PacketWriteEndInfo::NormalPacket
+            let samples: Vec<f32> = reader
+                .samples::<f32>()
+                .collect::<std::result::Result<Vec<f32>, hound::Error>>()?;
+            Box::new(
+                resample_linear(&samples, in_rate, encode_rate)
+                    .into_iter()
+                    .map(Ok),
+            )
         };
-        writer.write_packet(encoded[..n].to_vec(), SERIAL, end, absgp)?;
-    }
+
+    write_frames(&mut encoder, &mut writer, encode_rate, &mut samples_iter)?;
 
     let mut file = writer.into_inner();
     file.flush()?;
+    Ok(())
+}
+
+/// Pick the Opus-native rate (one of [`SUPPORTED_SAMPLE_RATES`]) closest to
+/// `rate`. Used to decide what an off-list WAV should be resampled to: 22050
+/// Hz → 24000 Hz, 44100 Hz → 48000 Hz, 32000 Hz → 24000 Hz, etc.
+fn nearest_supported_rate(rate: u32) -> u32 {
+    *SUPPORTED_SAMPLE_RATES
+        .iter()
+        .min_by_key(|&&r| (r as i64 - rate as i64).abs())
+        .expect("SUPPORTED_SAMPLE_RATES is non-empty")
+}
+
+/// Linear-interpolation resample of `input` (mono float, `in_rate` Hz) to
+/// `out_rate` Hz. Returns a fresh buffer. Used to bring off-list WAV rates
+/// (e.g. Piper's 22050 Hz) onto an Opus-native rate before encoding — the
+/// resampling grid changes but pitch and duration are preserved (output
+/// length scales with `out_rate/in_rate`). Endpoints past the last input
+/// sample are held constant so a trailing frame stays well-formed.
+fn resample_linear(input: &[f32], in_rate: u32, out_rate: u32) -> Vec<f32> {
+    if in_rate == out_rate || input.is_empty() {
+        return input.to_vec();
+    }
+    let ratio = out_rate as f64 / in_rate as f64;
+    let out_len = (input.len() as f64 * ratio).ceil() as usize;
+    let last = input[input.len() - 1];
+    let mut out = Vec::with_capacity(out_len);
+    for k in 0..out_len {
+        let p = k as f64 / ratio;
+        let i = p.floor() as usize;
+        let frac = p - i as f64;
+        let a = input[i] as f64;
+        let b = input.get(i + 1).copied().unwrap_or(last) as f64;
+        out.push((a * (1.0 - frac) + b * frac) as f32);
+    }
+    out
+}
+
+/// Encode an `f32` sample stream at `encode_rate` (one of the Opus-native
+/// rates) into 20 ms Opus frames wrapped in Ogg pages. The last frame is
+/// marked `EndStream`; because the stream length isn't known up front, the
+/// previously-completed frame is buffered and flushed as a `NormalPacket`
+/// when the next frame arrives (or as the terminal `EndStream` page at the
+/// end of input). `samples` yields one float per output sample.
+fn write_frames(
+    encoder: &mut Encoder,
+    writer: &mut PacketWriter<BufWriter<File>>,
+    encode_rate: u32,
+    samples: &mut dyn Iterator<Item = std::result::Result<f32, hound::Error>>,
+) -> Result<()> {
+    let frame_samples = frame_samples(encode_rate);
+    let mut encoded = vec![0u8; MAX_PACKET_BYTES];
+    let mut frame_buf = vec![0f32; frame_samples];
+    let mut absgp: u64 = 0;
+    let mut filled: usize = 0;
+    // The most recently completed frame, awaiting its `EndStream` decision.
+    let mut pending: Option<(Vec<u8>, u64)> = None;
+
+    loop {
+        let s = match samples.next() {
+            Some(Ok(s)) => s,
+            Some(Err(e)) => return Err(AudioError::Wav(e)),
+            None => break,
+        };
+        frame_buf[filled] = s;
+        filled += 1;
+        if filled == frame_samples {
+            let n = encoder.encode_float(&frame_buf, &mut encoded)?;
+            absgp += GRANULE_PER_FRAME;
+            let data = encoded[..n].to_vec();
+            if let Some((prev, prev_gp)) = pending.take() {
+                writer.write_packet(prev, SERIAL, PacketWriteEndInfo::NormalPacket, prev_gp)?;
+            }
+            pending = Some((data, absgp));
+            filled = 0;
+        }
+    }
+
+    // Flush a trailing partial frame (zero-padded to a full 20 ms).
+    if filled > 0 {
+        for slot in &mut frame_buf[filled..] {
+            *slot = 0.0;
+        }
+        let n = encoder.encode_float(&frame_buf, &mut encoded)?;
+        absgp += GRANULE_PER_FRAME;
+        let data = encoded[..n].to_vec();
+        if let Some((prev, prev_gp)) = pending.take() {
+            writer.write_packet(prev, SERIAL, PacketWriteEndInfo::NormalPacket, prev_gp)?;
+        }
+        pending = Some((data, absgp));
+    }
+
+    if let Some((data, gp)) = pending.take() {
+        writer.write_packet(data, SERIAL, PacketWriteEndInfo::EndStream, gp)?;
+    }
     Ok(())
 }
 
@@ -296,27 +379,82 @@ mod tests {
         );
     }
 
-    /// Rates outside the Opus-native set must be rejected up front.
+    /// An off-list rate (Piper's 22050 Hz) must NOT be rejected — it is
+    /// resampled to the nearest Opus-native rate (24000 Hz) and encoded, with
+    /// the resampled rate recorded in `OpusHead`. Regression guard for #206.
     #[test]
-    fn rejects_unsupported_sample_rate() {
+    fn resamples_off_list_rate_to_nearest_native() {
         let dir = tempfile::tempdir().expect("tempdir");
         let wav_path = dir.path().join("in.wav");
         let opus_path = dir.path().join("out.opus");
 
-        let spec = hound::WavSpec {
-            channels: 1,
-            sample_rate: 22_050,
-            bits_per_sample: 32,
-            sample_format: hound::SampleFormat::Float,
-        };
-        write_wav_with_spec(&wav_path, spec);
+        write_sine_wav(&wav_path, 22_050, 440.0, 0.25);
+        encode_wav_to_opus(&wav_path, &opus_path)
+            .unwrap_or_else(|e| panic!("22050 Hz wav should resample+encode, got: {e}"));
 
-        let err =
-            encode_wav_to_opus(&wav_path, &opus_path).expect_err("should reject 22.05 kHz wav");
-        match err {
-            AudioError::UnsupportedFormat(_) => {}
-            other => panic!("expected UnsupportedFormat, got {other:?}"),
-        }
+        let bytes = std::fs::read(&opus_path).expect("read opus");
+        assert!(bytes.len() > 1000, "opus too small: {}", bytes.len());
+        assert_eq!(
+            read_opus_head_rate(&opus_path),
+            24_000,
+            "22050 Hz must be resampled to 24000 Hz in OpusHead"
+        );
+    }
+
+    /// A 44100 Hz WAV must resample to 48000 Hz (the nearest native rate),
+    /// exercising the upsample branch of `nearest_supported_rate`.
+    #[test]
+    fn resamples_44100_to_48000() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wav_path = dir.path().join("in.wav");
+        let opus_path = dir.path().join("out.opus");
+
+        write_sine_wav(&wav_path, 44_100, 440.0, 0.25);
+        encode_wav_to_opus(&wav_path, &opus_path)
+            .unwrap_or_else(|e| panic!("44100 Hz wav should resample+encode, got: {e}"));
+
+        assert_eq!(
+            read_opus_head_rate(&opus_path),
+            48_000,
+            "44100 Hz must be resampled to 48000 Hz in OpusHead"
+        );
+    }
+
+    /// `nearest_supported_rate` must pick the closest native rate, exercising
+    /// both upsample (22050→24000, 44100→48000, 11025→12000) and downsample
+    /// (32000→24000) candidates, and pass native rates through unchanged.
+    #[test]
+    fn nearest_supported_rate_picks_closest_native() {
+        assert_eq!(nearest_supported_rate(8_000), 8_000);
+        assert_eq!(nearest_supported_rate(22_050), 24_000);
+        assert_eq!(nearest_supported_rate(32_000), 24_000);
+        assert_eq!(nearest_supported_rate(44_100), 48_000);
+        assert_eq!(nearest_supported_rate(11_025), 12_000);
+    }
+
+    /// `resample_linear` must scale output length by `out_rate/in_rate`, keep
+    /// the first sample, pass equal rates through untouched, and return an
+    /// empty buffer for empty input.
+    #[test]
+    fn resample_linear_scales_length_and_handles_empty() {
+        let input: Vec<f32> = (0..22_050).map(|i| i as f32 / 100.0).collect();
+
+        let out = resample_linear(&input, 22_050, 24_000);
+        // Length scales by out/in rate; `ceil` can land one sample over due to
+        // float rounding (22050 * 24000/22050 ≈ 24000.000000x).
+        assert!(
+            out.len() == 24_000 || out.len() == 24_001,
+            "length must scale by out/in rate, got {}",
+            out.len()
+        );
+        assert!((out[0] - input[0]).abs() < 1e-3, "first sample preserved");
+
+        // Equal rates pass through unchanged (same length, same content).
+        let same = resample_linear(&input, 22_050, 22_050);
+        assert_eq!(same.len(), input.len());
+
+        // Empty input stays empty.
+        assert!(resample_linear(&[], 22_050, 24_000).is_empty());
     }
 
     /// Non-mono input must be rejected up front — `encode_wav_to_opus` checks

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -1020,4 +1020,35 @@ mod tests {
         assert_eq!(stats.considered, 0);
         assert_eq!(stats.migrated, 0);
     }
+
+    /// A legacy `.wav` at an off-list rate (Piper's 22050 Hz) must migrate to
+    /// `.opus` rather than being left as an oversized `.wav` — regression
+    /// guard for #206 (the migration previously logged "unsupported wav
+    /// format" and skipped this entry).
+    #[test]
+    fn migrate_22050_wav_audio_to_opus() {
+        let (svc, _dir) = make_service();
+        let entry = svc.add_entry("legacy piper wav".to_string()).unwrap();
+        let id = entry.id;
+
+        let wav_filename = format!("{id}.wav");
+        let wav_path = svc.cache_dir().join("audio").join(&wav_filename);
+        write_sine_wav(&wav_path, 22_050, 440.0, 0.2);
+
+        update_entry_with(&svc, &entry, |e| {
+            e.audio_path = Some(wav_filename.clone());
+            e.status = EntryStatus::Ready;
+        });
+
+        let stats = svc.migrate_wav_audio_to_opus();
+        assert_eq!(stats.considered, 1);
+        assert_eq!(stats.migrated, 1);
+        assert_eq!(stats.failed, 0);
+
+        let after = svc.get_entry(&id).unwrap();
+        let new_filename = after.audio_path.expect("audio_path must remain set");
+        assert!(new_filename.ends_with(".opus"), "got {new_filename}");
+        assert!(svc.cache_dir().join("audio").join(&new_filename).exists());
+        assert!(!wav_path.exists(), "source .wav should be removed");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #206. Piper voices emit WAVs at rates libopus does not accept as an
encoder input (e.g. `ruslan` at 22050 Hz), so `encode_wav_to_opus` rejected
them and every Piper entry stayed as a large `.wav` instead of being
transcoded to `.opus`. The startup WAV→Opus migration hit the same error.

- Off-list WAV rates are now resampled to the **nearest** Opus-native rate
  before encoding (22050 → 24000, 44100 → 48000, 32000 → 24000, 11025 → 12000).
- Native rates (8/12/16/24/48 kHz, e.g. Silero's 48 kHz) pass through
  untouched — the common path stays streaming.
- `OpusHead` records the native (resampled) rate the encoder actually used.
- Frame writing was refactored into `write_frames` (buffers the last frame to
  mark `EndStream` without knowing output length up front), so behavior is
  identical for the native path.

## Test plan

- `audio` unit tests: replaced the "22050 rejected" case with positive
  resample checks (22050→24000, 44100→48000), added `nearest_supported_rate`
  and `resample_linear` unit tests, kept per-rate round-trips.
- `storage::service` test: legacy 22050 Hz `.wav` now migrates to `.opus`.
- `cargo test --lib` (986) green; clippy + rustfmt + eslint + tsc + knip green.

OpenSpec: change `2026-08-20-opus-resample-off-list-rates` archived; storage
spec updated (Audio File Storage, Legacy Migration, Config `sample_rate`).