### PR TITLE
refactor(storage): compare-and-set for status transitions (#179)

### DIFF
--- a/openspec/changes/archive/2026-08-20-storage-cas-status-transition/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-20-storage-cas-status-transition/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/archive/2026-08-20-storage-cas-status-transition/design.md
+++ b/openspec/changes/archive/2026-08-20-storage-cas-status-transition/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`StorageService` guards its `HashMap<EntryId, TextEntry>` behind a
+`parking_lot::RwLock`. The three status-transition helpers in
+`src-tauri/src/commands/mod.rs` currently interleave two acquisitions of that
+lock: a `get_entry` read (clone) to decide, then an `update_entry` write that
+persists a *separate* clone. Any other thread that mutates the same entry in
+between wins the write-order race and its result is then overwritten by the
+stale clone. See proposal.md (Why) for the concrete corruption this yields.
+
+The fix is a storage-level compare-and-set so the predicate-check and the
+mutation execute under a single write-lock hold. No schema, IPC, or
+state-machine change is involved.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One method that atomically implements "if status matches, then mutate".
+- Re-express `cancel_entry` and the two completion guards through it without
+  changing their observable outcomes.
+
+**Non-Goals:**
+- Removing or changing `update_entry` (still used elsewhere, e.g. migration,
+  `delete_audio`).
+- Touching the candidate-file deletion path in `apply_error_if_current`.
+
+## Decisions
+
+**1. Signature: `update_entry_if(id, predicate, mutate) -> bool`.**
+Chosen over returning `Result<bool, StorageError>` to match the issue's
+proposed shape and keep all three callers uniform. The persistence step is
+best-effort and swallows `save_history` errors — the in-memory `HashMap` is the
+source of truth (as with `update_entry`), and a failed atomic rename is not a
+reason to roll back an already-applied in-memory mutation. `true` means "entry
+existed and predicate matched → mutation applied"; `false` means "absent or
+predicate rejected → nothing written".
+
+**2. Persist *after* dropping the write guard.**
+`save_history` re-acquires a `read` lock on the same `RwLock`. `parking_lot`'s
+`RwLock` is not reentrant: holding the write guard while asking for a read guard
+would deadlock. So `update_entry_if` drops the guard, then persists. The
+in-memory mutation is already committed before the drop, so the saved snapshot
+reflects it; the only residual window is between drop and persist, where another
+writer may run — that is benign (last-writer-wins on disk, in-memory stays
+consistent), and it does not reintroduce the status-transition race.
+
+**3. Rejected alternative — upgradeable `RwLock`.**
+Switching to `RwLockUpgradableReadGuard` would avoid the drop, but it only
+helps the read→write direction and complicates every other caller of the map.
+The drop-then-persist form is simpler and equally correct for this use case.
+
+**4. Rejected alternative — keep helpers as-is, add a per-entry `Mutex`.**
+Wrapping each `TextEntry` in its own mutex would serialize per-entry transitions
+but spreads locking state across the value type and forces a larger refactor.
+The CAS method keeps the locking in one place (`StorageService`).
+
+## Risks / Trade-offs
+
+- [Best-effort persist] → A disk-full `save_history` failure after an applied
+  mutation is no longer surfaced as a command error (only `cancel_entry`
+  previously propagated it). Mitigation: such failures are IO-panic-class and
+  were already swallowed by the ready/error guards; acceptable for a
+  tech-debt-level race fix.
+- [Late-file deletion ordering] → Unchanged from today: if a `require_processing`
+  failure arrives for an entry that just went `ready`, the candidate-file
+  cleanup still runs. Out of scope (non-goal); pre-existing.

--- a/openspec/changes/archive/2026-08-20-storage-cas-status-transition/proposal.md
+++ b/openspec/changes/archive/2026-08-20-storage-cas-status-transition/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`cancel_entry`, `apply_ready_if_current`, and `apply_error_if_current` (all in
+`src-tauri/src/commands/mod.rs`) each perform a **read-decide-write across two
+separate `StorageService` lock acquisitions**: they clone the entry via
+`get_entry`, decide based on the status, then persist a mutated clone via
+`update_entry`. If a synthesis completion lands in the microseconds between the
+read and the write, the stale clone is persisted — regressing a `ready`/`error`
+entry back to `pending` with no `audio_path`/`timestamps_path` while the on-disk
+audio still exists. That is the orphaned-audio corruption from #176 at the
+residual µs scale (the seconds-scale UI guard added in the #176 fix closed the
+observable gap; this is the last race the guard does not cover).
+
+The window is tiny and currently unobserved in practice, so this is recorded
+tech-debt (issue #179) rather than an incident. Filing it as a change keeps the
+accepted residual risk an explicit, reviewable decision.
+
+## What Changes
+
+- Add `StorageService::update_entry_if(id, predicate, mutate)`: acquire the write
+  lock once, evaluate `predicate(&entry)`, and — only if it returns `true` —
+  apply `mutate(&mut entry)` and persist, all under the same lock
+  (compare-and-set). Returns `true` when the entry existed and the predicate
+  matched (the mutation was applied); `false` otherwise, writing nothing.
+- Refactor `cancel_entry` to drive its `processing | pending → pending`
+  transition through `update_entry_if`.
+- Refactor `apply_ready_if_current` and `apply_error_if_current` to build their
+  status predicate (`completion_is_current`, i.e. status `== processing`) and
+  pass the mutation as a closure, so the stale-completion guard is atomic.
+- Add a unit test pinning `update_entry_if` semantics (predicate-rejected no-op,
+  predicate-accepted apply, absent id is a no-op).
+
+## Non-goals
+
+- No change to the status state machine or the set of permitted transitions.
+- No change to observable behavior on the non-racy path; the existing command
+  tests must stay green.
+- No fix to the unrelated candidate-file deletion in `apply_error_if_current`
+  (a separate, pre-existing concern out of scope here).
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `storage`: add a requirement that the storage service provides an atomic
+  conditional (compare-and-set) entry update so status transitions cannot be
+  raced by a concurrent read-decide-write.
+
+## Impact
+
+- `src-tauri/src/storage/service.rs`: new `update_entry_if` method; `update_entry`
+  callers there are unaffected.
+- `src-tauri/src/commands/mod.rs`: internal refactor of three helpers; their
+  public `tauri::command` signatures and the `entry_updated` emit contract are
+  unchanged.
+- No new dependencies, no cross-process / IPC / schema changes.

--- a/openspec/changes/archive/2026-08-20-storage-cas-status-transition/specs/storage/spec.md
+++ b/openspec/changes/archive/2026-08-20-storage-cas-status-transition/specs/storage/spec.md
@@ -1,0 +1,42 @@
+# Delta: storage
+
+## ADDED Requirements
+
+### Requirement: Atomic Conditional Update
+
+The storage service SHALL provide a compare-and-set update operation over a
+single entry: given an entry id, a predicate, and a mutation, it SHALL acquire
+the entry map's write lock, evaluate the predicate against the current entry,
+and — only when the predicate returns `true` — apply the mutation and persist,
+all under that single lock hold. The predicate check and the mutation SHALL NOT
+be separated by a release of the write lock.
+
+The operation SHALL return `true` when the entry existed and the predicate
+matched (the mutation was applied). It SHALL return `false` and change nothing
+when the entry is absent or the predicate rejected it.
+
+This operation SHALL be the mechanism used by status transitions that decide on
+the basis of the entry's current status (entry cancellation, and the
+stale-completion guards for synthesis ready/error), so a concurrent
+read-decide-write cannot persist a stale entry clone over a transition that
+already applied.
+
+#### Scenario: predicate accepts applies the mutation
+- GIVEN an entry whose status the predicate accepts
+- WHEN the conditional update is invoked with a mutation
+- THEN the mutation is applied, the history is persisted, and the operation returns `true`
+
+#### Scenario: predicate rejects changes nothing
+- GIVEN an entry whose status the predicate rejects
+- WHEN the conditional update is invoked with a mutation
+- THEN the entry is unchanged, the history is not modified for this update, and the operation returns `false`
+
+#### Scenario: absent id is a no-op
+- GIVEN no entry with the given id
+- WHEN the conditional update is invoked
+- THEN nothing is written and the operation returns `false`
+
+#### Scenario: concurrent status transition cannot regress a completed entry
+- GIVEN an entry mid-transition (e.g. `processing`) and two callers racing: one applies a completion that flips it to `ready`, another cancels it back to `pending`
+- WHEN both run the conditional update under the predicate `status in {processing, pending}`
+- THEN only one transition is applied, the entry ends in exactly one status, and no stale clone overwrites the applied transition

--- a/openspec/changes/archive/2026-08-20-storage-cas-status-transition/tasks.md
+++ b/openspec/changes/archive/2026-08-20-storage-cas-status-transition/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Storage-level compare-and-set for status transitions
+
+## Implementation
+
+- [ ] `src-tauri/src/storage/service.rs` — add `StorageService::update_entry_if(id, predicate, mutate) -> bool`: acquire the write lock, evaluate `predicate(&entry)`, and — only if `true` — apply `mutate(&mut entry)` then persist, all under the same lock; drop the guard before calling `save_history` (non-reentrant `RwLock`), return `false` for absent/rejected.
+
+- [ ] `src-tauri/src/commands/mod.rs` `cancel_entry` — drive the `processing | pending → pending` transition through `update_entry_if`; keep the up-front `not_found` / terminal-status (`ready` / `playing` / `error`) rejections and the `synthesis_tasks` / `synthesize_entered` registry handling on the path that actually applies.
+
+- [ ] `src-tauri/src/commands/mod.rs` `apply_ready_if_current` — pass `completion_is_current` as the predicate and the ready-field mutation as the closure; discard the late audio/timestamp files only when the CAS did not apply.
+
+- [ ] `src-tauri/src/commands/mod.rs` `apply_error_if_current` — pass `require_processing ⇒ completion_is_current` as the predicate and the error-field mutation as the closure; discard candidate files only when the CAS did not apply on the `require_processing` path.
+
+## Tests
+
+- [ ] `src-tauri/src/storage/service.rs` — unit test for `update_entry_if`: predicate-accepted applies + persists + returns `true`; predicate-rejected is a no-op + returns `false`; absent id returns `false`.
+
+- [ ] `src-tauri/src/commands/mod.rs` — existing `cancel_entry`, `apply_ready_if_current`, `apply_error_if_current` tests stay green (no observable behavior change on the non-racy path).
+
+## Validation
+
+- [ ] `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml` green.
+- [ ] `nix develop -c just lint` green (fmt + clippy -D warnings).
+- [ ] `nix develop -c pnpm dlx @fission-ai/openspec validate storage-cas-status-transition --strict` green.

--- a/openspec/specs/storage/spec.md
+++ b/openspec/specs/storage/spec.md
@@ -3,7 +3,9 @@
 ## Purpose
 
 Covers the on-disk persistence layer of RuVox (`src-tauri/src/storage/`): the per-user cache directory layout, the `history.json` entry store, the `config.json` application configuration, synthesized audio files (`{uuid}.opus`), word-level timestamp files (`{uuid}.timestamps.json`), the legacy WAV-to-Opus migration, and cache hygiene (orphan sweep and size-based eviction).
+
 ## Requirements
+
 ### Requirement: Cache Directory Layout
 
 The system SHALL store all persistent data under a per-user cache root, with the following layout:
@@ -360,3 +362,41 @@ The on-disk format originated in the earlier PyQt implementation of RuVox, and e
 - WHEN the configuration is loaded
 - THEN it parses successfully and the unknown keys are dropped
 
+### Requirement: Atomic Conditional Update
+
+The storage service SHALL provide a compare-and-set update operation over a
+single entry: given an entry id, a predicate, and a mutation, it SHALL acquire
+the entry map's write lock, evaluate the predicate against the current entry,
+and — only when the predicate returns `true` — apply the mutation and persist,
+all under that single lock hold. The predicate check and the mutation SHALL NOT
+be separated by a release of the write lock.
+
+The operation SHALL return `true` when the entry existed and the predicate
+matched (the mutation was applied). It SHALL return `false` and change nothing
+when the entry is absent or the predicate rejected it.
+
+This operation SHALL be the mechanism used by status transitions that decide on
+the basis of the entry's current status (entry cancellation, and the
+stale-completion guards for synthesis ready/error), so a concurrent
+read-decide-write cannot persist a stale entry clone over a transition that
+already applied.
+
+#### Scenario: predicate accepts applies the mutation
+- GIVEN an entry whose status the predicate accepts
+- WHEN the conditional update is invoked with a mutation
+- THEN the mutation is applied, the history is persisted, and the operation returns `true`
+
+#### Scenario: predicate rejects changes nothing
+- GIVEN an entry whose status the predicate rejects
+- WHEN the conditional update is invoked with a mutation
+- THEN the entry is unchanged, the history is not modified for this update, and the operation returns `false`
+
+#### Scenario: absent id is a no-op
+- GIVEN no entry with the given id
+- WHEN the conditional update is invoked
+- THEN nothing is written and the operation returns `false`
+
+#### Scenario: concurrent status transition cannot regress a completed entry
+- GIVEN an entry mid-transition (e.g. `processing`) and two callers racing: one applies a completion that flips it to `ready`, another cancels it back to `pending`
+- WHEN both run the conditional update under the predicate `status in {processing, pending}`
+- THEN only one transition is applied, the entry ends in exactly one status, and no stale clone overwrites the applied transition

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -434,40 +434,34 @@ fn apply_ready_if_current(
     ts_filename: Option<String>,
     audio_filename: &str,
 ) -> bool {
-    // A late result whose entry vanished or left `processing` is dropped
-    // together with the files it just wrote.
-    let discard = |ts_filename: Option<String>| {
+    // Atomic under a single storage lock (issue #179): the `processing` check
+    // and the ready-field mutation cannot be raced by a concurrent cancel.
+    let applied = storage.update_entry_if(
+        entry_id,
+        |e| completion_is_current(e.status),
+        |e| {
+            e.status = EntryStatus::Ready;
+            e.audio_path = Some(audio_filename.to_string());
+            e.timestamps_path = ts_filename.clone();
+            e.duration_sec = Some(output.duration_sec);
+            e.audio_generated_at = Some(chrono::Utc::now().naive_utc());
+        },
+    );
+
+    if !applied {
+        // A late result whose entry vanished or left `processing` is dropped
+        // together with the files it just wrote.
+        if let Some(status) = storage.get_entry(entry_id).map(|e| e.status) {
+            info!("discarding stale completion for {entry_id} (status: {status:?})");
+        }
         discard_late_files(
             storage,
             [Some(audio_filename.to_string()), ts_filename]
                 .into_iter()
                 .flatten(),
         );
-        false
-    };
-
-    let Some(mut entry) = storage.get_entry(entry_id) else {
-        // Vanished mid-synthesis (deleted).
-        return discard(ts_filename);
-    };
-    if !completion_is_current(entry.status) {
-        info!(
-            "discarding stale completion for {entry_id} (status: {:?})",
-            entry.status
-        );
-        return discard(ts_filename);
     }
-
-    entry.status = EntryStatus::Ready;
-    entry.audio_path = Some(audio_filename.to_string());
-    entry.timestamps_path = ts_filename;
-    entry.duration_sec = Some(output.duration_sec);
-    entry.audio_generated_at = Some(chrono::Utc::now().naive_utc());
-
-    if let Err(e) = storage.update_entry(entry) {
-        warn!("failed to update entry to ready: {e}");
-    }
-    true
+    applied
 }
 
 /// Phase 6: apply the synthesis result and, when it was applied, emit
@@ -649,30 +643,40 @@ fn apply_error_if_current(
     message: &str,
     require_processing: bool,
 ) -> bool {
-    let Some(mut entry) = storage.get_entry(entry_id) else {
-        return false;
-    };
-    if require_processing && !completion_is_current(entry.status) {
-        info!(
-            "discarding stale failure for {entry_id} (status: {:?})",
-            entry.status
-        );
-        // The exact filename is unknown on the failure path (a dying ttsd
-        // may have left a partial WAV); remove every candidate.
-        discard_late_files(
-            storage,
-            [
-                format!("{entry_id}.wav"),
-                format!("{entry_id}.opus"),
-                format!("{entry_id}.timestamps.json"),
-            ],
-        );
-        return false;
+    // Atomic under a single storage lock (issue #179): when `require_processing`
+    // is set, the `processing` check and the error mutation cannot be raced by a
+    // concurrent cancel. Normalization-stage failures pass `false` (the entry is
+    // legitimately still `pending` before `mark_processing` runs), so the
+    // predicate always applies.
+    let applied = storage.update_entry_if(
+        entry_id,
+        |e| !require_processing || completion_is_current(e.status),
+        |e| {
+            e.status = EntryStatus::Error;
+            e.error_message = Some(message.to_string());
+        },
+    );
+
+    if !applied && require_processing {
+        // The entry vanished (deleted) or left `processing`: this stale failure
+        // is dropped. A dying ttsd may have left a partial WAV; remove every
+        // candidate file so it does not orphan.
+        match storage.get_entry(entry_id).map(|e| e.status) {
+            Some(status) if !completion_is_current(status) => {
+                info!("discarding stale failure for {entry_id} (status: {status:?})");
+                discard_late_files(
+                    storage,
+                    [
+                        format!("{entry_id}.wav"),
+                        format!("{entry_id}.opus"),
+                        format!("{entry_id}.timestamps.json"),
+                    ],
+                );
+            }
+            _ => {}
+        }
     }
-    entry.status = EntryStatus::Error;
-    entry.error_message = Some(message.to_string());
-    let _ = storage.update_entry(entry);
-    true
+    applied
 }
 
 fn set_entry_error<R: Runtime>(
@@ -976,30 +980,62 @@ fn cancel_entry(
     synthesize_entered: &Mutex<HashSet<EntryId>>,
     id: &str,
 ) -> CmdResult<(TextEntry, bool)> {
-    let mut entry = require_entry(storage, id)?;
-    let uuid = entry.id;
+    let uuid = parse_entry_id(id)?;
 
-    if !matches!(entry.status, EntryStatus::Processing | EntryStatus::Pending) {
+    // Snapshot the live status to reject terminal states up front. The
+    // authoritative check-then-apply runs atomically inside `update_entry_if`
+    // below (issue #179); this snapshot only drives the error path so a
+    // `ready`/`playing`/`error` entry is rejected without touching the
+    // synthesis registries.
+    let live_status =
+        storage
+            .get_entry(&uuid)
+            .map(|e| e.status)
+            .ok_or_else(|| CommandError::NotFound {
+                message: format!("entry not found: {id}"),
+            })?;
+    if matches!(
+        live_status,
+        EntryStatus::Ready | EntryStatus::Error | EntryStatus::Playing
+    ) {
         return Err(CommandError::SynthesisError {
-            message: format!(
-                "entry {id} cannot be cancelled (status: {:?})",
-                entry.status
-            ),
+            message: format!("entry {id} cannot be cancelled (status: {live_status:?})"),
         });
     }
 
-    // An aborted task is destroyed at its next yield point and never runs
-    // its own registry cleanup, so both keys are removed here. Aborting an
-    // already-finished (but not yet cleaned-up) handle is a no-op.
+    // Atomic transition: flip to `pending` only if the entry is still
+    // `processing`/`pending` at apply time. A concurrent synthesis completion
+    // that already moved it out of these states wins, and the stale `pending`
+    // clone is NOT persisted.
+    let applied = storage.update_entry_if(
+        &uuid,
+        |e| matches!(e.status, EntryStatus::Processing | EntryStatus::Pending),
+        |e| e.status = EntryStatus::Pending,
+    );
+
+    if !applied {
+        // Lost the race to a simultaneous completion — the entry is now
+        // `ready`/`error`. Nothing to abort; report the live state.
+        let entry = storage
+            .get_entry(&uuid)
+            .ok_or_else(|| CommandError::NotFound {
+                message: format!("entry not found: {id}"),
+            })?;
+        return Ok((entry, false));
+    }
+
+    // Cancellation actually applied: abort the entry's synthesis task (a
+    // no-op if already finished) and clear the entered-TTS marker.
     if let Some(handle) = synthesis_tasks.lock().remove(&uuid) {
         handle.abort();
     }
     let entered_tts = synthesize_entered.lock().remove(&uuid);
 
-    entry.status = EntryStatus::Pending;
-    storage
-        .update_entry(entry.clone())
-        .map_err(CommandError::from)?;
+    let entry = storage
+        .get_entry(&uuid)
+        .ok_or_else(|| CommandError::NotFound {
+            message: format!("entry not found: {id}"),
+        })?;
     Ok((entry, entered_tts))
 }
 

--- a/src-tauri/src/storage/service.rs
+++ b/src-tauri/src/storage/service.rs
@@ -255,6 +255,39 @@ impl StorageService {
         self.save_history()
     }
 
+    /// Compare-and-set update of a single entry. Acquires the write lock,
+    /// evaluates `predicate` against the current entry, and — only when it
+    /// returns `true` — applies `mutate` and persists. The predicate check and
+    /// the mutation run under one lock hold, so a concurrent read-decide-write
+    /// (e.g. a synthesis completion vs. `cancel_entry`) cannot persist a stale
+    /// clone over a transition that already applied (issue #179).
+    ///
+    /// Returns `true` when the entry existed and the predicate matched — the
+    /// mutation was applied. Returns `false`, writing nothing, when the entry
+    /// is absent or the predicate rejected it. Persistence is best-effort: the
+    /// in-memory map is the source of truth, matching [`Self::update_entry`].
+    pub fn update_entry_if<F, M>(&self, id: &EntryId, predicate: F, mutate: M) -> bool
+    where
+        F: FnOnce(&TextEntry) -> bool,
+        M: FnOnce(&mut TextEntry),
+    {
+        let mut map = self.entries.write();
+        let Some(entry) = map.get_mut(id) else {
+            return false;
+        };
+        if !predicate(entry) {
+            return false;
+        }
+        mutate(entry);
+        // Drop the write guard before persisting: `save_history` re-acquires a
+        // read lock on the same (non-reentrant) RwLock, so holding the write
+        // guard here would deadlock. The in-memory mutation is already
+        // committed, so the snapshot saved reflects it.
+        drop(map);
+        let _ = self.save_history();
+        true
+    }
+
     /// Delete entry and its audio + timestamps files.
     pub fn delete_entry(&self, id: &EntryId) -> Result<()> {
         let entry = {
@@ -1019,5 +1052,67 @@ mod tests {
         let stats = svc.migrate_wav_audio_to_opus();
         assert_eq!(stats.considered, 0);
         assert_eq!(stats.migrated, 0);
+    }
+
+    /// `update_entry_if` applies the mutation and persists when the predicate
+    /// matches; the change survives a reload from disk (issue #179).
+    #[test]
+    fn update_entry_if_applies_when_predicate_matches() {
+        let (svc, dir) = make_service();
+        let entry = svc.add_entry("cas".to_string()).unwrap();
+        let id = entry.id;
+
+        let applied = svc.update_entry_if(
+            &id,
+            |e| e.status == EntryStatus::Pending,
+            |e| {
+                e.status = EntryStatus::Error;
+                e.error_message = Some("boom".to_string());
+            },
+        );
+
+        assert!(applied);
+        assert_eq!(svc.get_entry(&id).unwrap().status, EntryStatus::Error);
+        assert_eq!(
+            svc.get_entry(&id).unwrap().error_message.as_deref(),
+            Some("boom")
+        );
+
+        // Persisted: the change is visible after reconstructing the service.
+        let svc2 = StorageService::with_cache_dir(dir.path().to_path_buf()).unwrap();
+        let reloaded = svc2.get_entry(&id).unwrap();
+        assert_eq!(reloaded.status, EntryStatus::Error);
+        assert_eq!(reloaded.error_message.as_deref(), Some("boom"));
+    }
+
+    /// `update_entry_if` is a no-op and returns `false` when the predicate
+    /// rejects the current state — the stored entry is untouched.
+    #[test]
+    fn update_entry_if_is_noop_when_predicate_rejects() {
+        let (svc, _dir) = make_service();
+        let entry = svc.add_entry("cas reject".to_string()).unwrap();
+        let id = entry.id;
+        update_entry_with(&svc, &entry, |e| e.status = EntryStatus::Ready);
+
+        let applied = svc.update_entry_if(
+            &id,
+            |e| e.status == EntryStatus::Pending,
+            |e| e.status = EntryStatus::Error,
+        );
+
+        assert!(!applied);
+        let stored = svc.get_entry(&id).unwrap();
+        assert_eq!(stored.status, EntryStatus::Ready);
+        assert!(stored.error_message.is_none());
+    }
+
+    /// `update_entry_if` returns `false` and writes nothing for an unknown id.
+    #[test]
+    fn update_entry_if_absent_id_is_noop() {
+        let (svc, _dir) = make_service();
+        let missing = Uuid::new_v4();
+        let applied = svc.update_entry_if(&missing, |_| true, |e| e.status = EntryStatus::Error);
+        assert!(!applied);
+        assert!(svc.get_entry(&missing).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `StorageService::update_entry_if(id, predicate, mutate)`: a compare-and-set that acquires the entry-map write lock once, evaluates the predicate, and — only when it returns `true` — applies the mutation and persists, all under that single lock hold. Closes the residual µs-scale read-decide-write race in status transitions (issue #179).
- `cancel_entry` and the two stale-completion guards (`apply_ready_if_current`, `apply_error_if_current`) now drive their `processing | pending → …` transitions through it. Observable behavior on the non-racy path is unchanged.

## Test plan
- New unit tests for `update_entry_if` (predicate-accepted applies + persists, predicate-rejected is a no-op, absent id is a no-op).
- Existing `commands` orchestration/unit tests (cancel, completion guards, full synthesis flow) stay green.
- `cargo fmt --check` + `clippy -D warnings` clean; app boots headlessly without panic.

## Notes
- Storage spec (`openspec/specs/storage/spec.md`) updated via the archived OpenSpec change `storage-cas-status-transition`.
- Intended merge method: merge commit (per repo workflow).