### PR TITLE
feat(settings): add button to open the logs folder

### DIFF
--- a/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/proposal.md
+++ b/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: settings-reveal-logs-folder
+
+Follow-up to #202 (file-logging, targeted at v0.3.0). The
+`file-logging` change explicitly deferred a "Reveal log folder" UI entry
+as a nice-to-have; this change delivers it.
+
+## Problem
+
+`file-logging` now writes diagnostic logs to the per-app log dir, but
+there is no way for a user to reach that folder from the app. When a user
+hits a problem they cannot grab the log file to attach to a bug report,
+and there is no discoverable hint of where logs live. Power users who
+know the path still have to open a terminal or file manager manually.
+
+## Change
+
+Expose the log directory to the frontend and add a one-click reveal from
+Settings:
+
+- **Backend:** add a `get_log_dir()` command that returns the absolute
+  per-user log directory resolved via Tauri's `app_log_dir()` (the same
+  directory `tauri-plugin-log` writes its rotated files into). The command
+  creates the directory if it does not yet exist, so the frontend can
+  reveal a real path even before the first log line is flushed.
+- **Frontend:** add a `getLogDir()` wrapper in `src/lib/tauri.ts`.
+- **UI:** add a "Логи" section in Settings that shows the resolved path
+  and an "Открыть папку" button. The button calls `revealItemInDir` from
+  `@tauri-apps/plugin-opener` to open the directory in the OS file
+  manager, with an error notification if the reveal fails.
+
+This mirrors the existing cache-dir reveal already present in Settings.
+
+## Out of scope
+
+- A built-in log viewer inside the app.
+- Copying / uploading logs (e.g. to a paste service) from Settings.
+- A tray-menu entry for the same action (Settings-only for now).

--- a/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/specs/ipc-commands/spec.md
+++ b/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/specs/ipc-commands/spec.md
@@ -1,0 +1,22 @@
+# Delta: ipc-commands
+
+New capability. No existing spec is modified.
+
+## ADDED Requirements
+
+### Requirement: Log directory command
+
+The system SHALL provide `get_log_dir()`, which returns the absolute
+per-user log directory path (the same directory `tauri-plugin-log` writes
+its rotated files into). The command SHALL create the directory if it does
+not yet exist, so the frontend can reveal a real path even before any log
+line is flushed. The frontend reveals this path in the OS file manager via
+a "Открыть папку" button in Settings.
+
+#### Scenario: log dir is created and returned
+
+- GIVEN the app running on any supported OS
+- WHEN `get_log_dir` is invoked
+- THEN it returns the absolute per-app log directory path and that directory
+  exists on disk
+

--- a/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/specs/logging/spec.md
+++ b/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/specs/logging/spec.md
@@ -1,0 +1,17 @@
+# Delta: logging
+
+New capability. No existing spec is modified.
+
+## ADDED Requirements
+
+### Requirement: Log directory is reachable from Settings
+
+The app SHALL expose the log directory path to the frontend (`get_log_dir`),
+and Settings SHALL offer an "Открыть папку" button that reveals that directory
+in the OS file manager so the user can grab logs for a support request.
+
+#### Scenario: Settings reveals the log folder
+
+- GIVEN the app running on any supported OS
+- WHEN the user presses "Открыть папку" in the Logs section of Settings
+- THEN the OS file manager opens the log directory

--- a/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/tasks.md
+++ b/openspec/changes/archive/2026-08-20-settings-reveal-logs-folder/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: settings-reveal-logs-folder
+
+- [x] Add a `get_log_dir()` command in `src-tauri/src/commands/mod.rs` that
+  resolves the per-app log dir via `app.path().app_log_dir()`, creates it if
+  missing, and returns the absolute path; register it in `generate_handler!`
+  in `src-tauri/src/lib.rs`.
+- [x] Add a `getLogDir()` wrapper to `src/lib/tauri.ts`.
+- [x] Add a "Логи" section in `src/dialogs/Settings.tsx` with the resolved
+  path and an "Открыть папку" button that calls `revealItemInDir`, with an
+  error notification on failure.
+- [x] Document `get_log_dir()` in the ipc-commands spec and the Settings
+  reveal action in the logging spec (delta specs below).
+- [x] Manual check: dev build opens Settings, the Logs section shows the path,
+  and "Открыть папку" reveals the log directory in the OS file manager.
+- [x] Archive the change (sync delta specs into `openspec/specs/`).

--- a/openspec/specs/ipc-commands/spec.md
+++ b/openspec/specs/ipc-commands/spec.md
@@ -756,3 +756,19 @@ the engine.
 - WHEN a synthesis hits `voice_not_installed`
 - THEN the auto-download and retry run exactly as if Piper were the
   persisted engine
+
+### Requirement: Log directory command
+
+The system SHALL provide `get_log_dir()`, which returns the absolute
+per-user log directory path (the same directory `tauri-plugin-log` writes
+its rotated files into). The command SHALL create the directory if it does
+not yet exist, so the frontend can reveal a real path even before any log
+line is flushed. The frontend reveals this path in the OS file manager via
+a "Открыть папку" button in Settings.
+
+#### Scenario: log dir is created and returned
+
+- GIVEN the app running on any supported OS
+- WHEN `get_log_dir` is invoked
+- THEN it returns the absolute per-app log directory path and that directory
+  exists on disk

--- a/openspec/specs/logging/spec.md
+++ b/openspec/specs/logging/spec.md
@@ -68,3 +68,15 @@ silent in the UI.
 - WHEN the startup update check runs
 - THEN no UI notification is shown AND the log file contains an
   `update check (startup) failed` entry with the error message
+
+### Requirement: Log directory is reachable from Settings
+
+The app SHALL expose the log directory path to the frontend (`get_log_dir`),
+and Settings SHALL offer an "Открыть папку" button that reveals that directory
+in the OS file manager so the user can grab logs for a support request.
+
+#### Scenario: Settings reveals the log folder
+
+- GIVEN the app running on any supported OS
+- WHEN the user presses "Открыть папку" in the Logs section of Settings
+- THEN the OS file manager opens the log directory

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tauri::{AppHandle, Emitter, Runtime, State};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 use tauri_plugin_mpv::MpvExt;
 use tokio::task::AbortHandle;
 use tracing::{info, warn};
@@ -1416,6 +1416,35 @@ pub struct CacheSizeInfo {
 #[tauri::command]
 pub async fn get_cache_dir(state: State<'_, AppState>) -> CmdResult<String> {
     Ok(state.storage.cache_dir().to_string_lossy().into_owned())
+}
+
+/// Absolute path of the per-user log directory (the same one `tauri-plugin-log`
+/// writes its rotated files into). The frontend reveals it in the OS file
+/// manager so the user can grab logs for a support request.
+#[tauri::command]
+pub async fn get_log_dir<R: Runtime>(app: AppHandle<R>) -> CmdResult<String> {
+    let dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| CommandError::Internal {
+            message: format!("не удалось разрешить папку логов: {e}"),
+        })?;
+    // The logger creates the dir lazily on first write; create it now so the
+    // frontend can reveal a real path even before any log line is flushed.
+    // Run on a blocking thread so this async command does not park the
+    // executor's worker.
+    tauri::async_runtime::spawn_blocking({
+        let dir = dir.clone();
+        move || std::fs::create_dir_all(dir)
+    })
+    .await
+    .map_err(|e| CommandError::Internal {
+        message: format!("не удалось создать папку логов: {e}"),
+    })?
+    .map_err(|e| CommandError::Internal {
+        message: format!("не удалось создать папку логов: {e}"),
+    })?;
+    Ok(dir.to_string_lossy().into_owned())
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -424,6 +424,7 @@ pub(crate) fn invoke_handler<R: Runtime>()
         clear_cache,
         get_cache_stats,
         get_cache_dir,
+        get_log_dir,
     ]
 }
 

--- a/src/dialogs/Settings.tsx
+++ b/src/dialogs/Settings.tsx
@@ -223,6 +223,7 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
   const { setColorScheme } = useMantineColorScheme();
   const [cleanupOpen, setCleanupOpen] = useState(false);
   const [cacheDir, setCacheDir] = useState<string>('');
+  const [logDir, setLogDir] = useState<string>('');
   const [coercedAlert, setCoercedAlert] = useState(false);
   const [availability, setAvailability] = useState<AvailabilityMap>(PESSIMISTIC_AVAILABILITY);
   // Live bundle-download state: null when idle, otherwise the current file
@@ -284,6 +285,7 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
         });
       });
     commands.getCacheDir().then(setCacheDir).catch(() => setCacheDir(''));
+    commands.getLogDir().then(setLogDir).catch(() => setLogDir(''));
     // form is excluded intentionally: setValues is stable, re-running on form change would loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [opened]);
@@ -386,9 +388,23 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
   const handleOpenCacheDir = async () => {
     if (!cacheDir) return;
     try {
-      // revealItemInDir always needs an item path, not a bare directory.
-      // history.json is always present, so use it as the marker.
+      // revealItemInDir accepts a file or a directory. For the cache we pass
+      // history.json as a stable marker; the log handler below passes the
+      // directory path directly (the freshly created log dir may be empty).
       await revealItemInDir(`${cacheDir}/history.json`);
+    } catch (err) {
+      notifications.show({
+        title: 'Не удалось открыть папку',
+        message: formatError(err),
+        color: 'red',
+      });
+    }
+  };
+
+  const handleOpenLogDir = async () => {
+    if (!logDir) return;
+    try {
+      await revealItemInDir(logDir);
     } catch (err) {
       notifications.show({
         title: 'Не удалось открыть папку',
@@ -620,6 +636,29 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
             </Button>
             <Button variant="default" onClick={() => setCleanupOpen(true)}>
               Очистить кэш…
+            </Button>
+          </Group>
+
+          <Divider />
+
+          <Text size="sm" fw={500} c="dimmed">
+            Логи
+          </Text>
+
+          {logDir && (
+            <Stack gap={4}>
+              <Text size="xs" c="dimmed">
+                Папка с логами
+              </Text>
+              <Text size="sm" style={{ wordBreak: 'break-all', fontFamily: 'var(--mantine-font-family-monospace)' }}>
+                {logDir}
+              </Text>
+            </Stack>
+          )}
+
+          <Group justify="flex-start">
+            <Button variant="default" onClick={handleOpenLogDir} disabled={!logDir}>
+              Открыть папку
             </Button>
           </Group>
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -205,6 +205,9 @@ export const commands = {
   getCacheDir: (): Promise<string> =>
     tauriInvoke('get_cache_dir'),
 
+  getLogDir: (): Promise<string> =>
+    tauriInvoke('get_log_dir'),
+
   previewNormalize: (text: string): Promise<PreviewNormalizeResult> =>
     tauriInvoke('preview_normalize', { text }),
 };


### PR DESCRIPTION
## What
Add a button in Settings to open the per-user log directory in the OS file manager — the same directory \`tauri-plugin-log\` writes its rotated files into. Implements the out-of-scope item deferred by the file-logging change (#202).

## How
- New \`get_log_dir\` command (resolves the per-app log dir via Tauri's \`app_log_dir()\` and creates it if missing); registered in \`generate_handler!\`.
- \`getLogDir()\` frontend wrapper in \`src/lib/tauri.ts\`.
- New "Логи" section in Settings showing the resolved path with an "Открыть папку" button (\`revealItemInDir\`), mirroring the existing cache-dir reveal, with an error notification on failure.

## Specs
OpenSpec change \`2026-08-20-settings-reveal-logs-folder\` archived; delta specs synced into \`openspec/specs/\` (ipc-commands: \`get_log_dir\`; logging: Settings reveal action).

## Checks
\`just lint\` and the pre-push hooks (clippy/eslint/knip/typecheck) are green.