### PR TITLE
feat(ui,tray),build(release): surface app version and CHANGELOG release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,7 @@ jobs:
           # an empty notes file.
           if [ ! -s release_notes.md ]; then
             echo "See CHANGELOG.md — no section for version $version yet." > release_notes.md
+            echo "::warning::No CHANGELOG.md section for $version — using stub release notes"
           fi
           echo "----- release notes -----"
           cat release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,12 +134,42 @@ jobs:
             > latest.json
           cat latest.json
 
+      # Extract the CHANGELOG.md section for this version so the draft release
+      # body is the human-curated notes, not GitHub's auto-generated diff
+      # summary (issue #94). The `## [Unreleased]` heading and deeper
+      # `###`/`####` headings never match the `## [<semver>]` pattern, so only
+      # the target version's block is captured (up to the next top-level
+      # `## [` heading).
+      - name: Extract changelog section for release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag || github.ref_name }}"
+          version="${tag#v}"
+          awk -v v="$version" '
+            /^## \[/ {
+              rest = substr($0, 5)
+              cb = index(rest, "]")
+              hdr = (cb > 0) ? substr(rest, 1, cb - 1) : rest
+              capture = (hdr == v)
+            }
+            capture { print }
+          ' CHANGELOG.md > release_notes.md
+          # Fallback when the tag has no CHANGELOG section yet (a tag pushed
+          # before the entry was added): keep a usable draft body instead of
+          # an empty notes file.
+          if [ ! -s release_notes.md ]; then
+            echo "See CHANGELOG.md — no section for version $version yet." > release_notes.md
+          fi
+          echo "----- release notes -----"
+          cat release_notes.md
+
       - name: Draft release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           draft: true
-          generate_release_notes: true
+          body_path: release_notes.md
           files: |
             src-tauri/target/release/bundle/nsis/*_x64-setup.exe
             src-tauri/target/release/bundle/nsis/*_x64-setup.exe.sig

--- a/openspec/changes/archive/2026-08-20-settings-app-version/design.md
+++ b/openspec/changes/archive/2026-08-20-settings-app-version/design.md
@@ -1,0 +1,57 @@
+# Design: settings-app-version
+
+## 1. Settings version display (frontend)
+
+`Settings.tsx` already loads `commands.getConfig()` and `commands.getCacheDir()`
+in the `useEffect` that runs on open (the `opened` dependency). Extend that same
+effect to also call `getVersion()` from `@tauri-apps/api/app` and store the
+result in a new `appVersion` state. Render it as a right-aligned
+`Версия: <version>` line in the dialog footer (bottom-right), above the
+"Сбросить"/"Сохранить" button row, so it is always visible on every platform.
+
+```tsx
+import { getVersion } from '@tauri-apps/api/app';
+
+// in the open effect, mirroring getCacheDir:
+getVersion().then(setAppVersion).catch(() => setAppVersion(''));
+```
+
+```tsx
+<Text size="xs" c="dimmed" ta="right" mt="md">Версия: {appVersion || '—'}</Text>
+```
+
+The `—` fallback matches the existing `getCacheDir` failure handling (state set
+to `''`, rendered as `—`), so a version read error never blocks the dialog.
+
+### Why not a new Rust command
+
+Tauri v2 already exposes `getVersion()` from `@tauri-apps/api/app`, which
+resolves the `version` field of `tauri.conf.json` baked in at build time. Adding
+a `get_app_version` command would be a second source of truth for the same
+value with no benefit.
+
+### Why not gate it behind the updater section
+
+The updater section is `UPDATER_ENABLED`-gated and only meaningful on Windows
+(`navigator.userAgent` includes `Windows`). Version visibility must work on
+Linux/nix too, because that is where most bug reports originate in this repo.
+
+## 2. Tray tooltip version (backend)
+
+`src-tauri/src/tray/mod.rs::init` builds the tray with `.tooltip("RuVox")`.
+Replace the literal with `format!("RuVox v{}", app.package_info().version)` —
+`package_info().version` is the same `tauri.conf.json` version, available in
+`tray::Builder` init. One line, no new command, the tooltip now reads
+`RuVox v0.3.1`.
+
+## Alternatives considered
+
+- **Dedicated About dialog:** rejected — `#94` allows "About dialog or tray
+  tooltip", and reusing Settings keeps the version next to the updater check
+  without introducing a new route/modal.
+- **Read version from a Rust command / env:** rejected — `getVersion()` and
+  `package_info().version` already cover frontend and backend with zero extra
+  surface.
+- **Show version only on Windows (next to updater):** rejected — bug reports
+  against Linux/nix builds would still have no version; display must be
+  platform-independent.

--- a/openspec/changes/archive/2026-08-20-settings-app-version/proposal.md
+++ b/openspec/changes/archive/2026-08-20-settings-app-version/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: settings-app-version
+
+Part of #94 (tag-driven release workflow + version in UI). This change covers
+the UI/tray half of #94: making the app version visible so bug reports can
+quote a specific build. The CHANGELOG-driven release notes (the other half of
+#94) are handled in `release.yml` and are out of scope here.
+
+## Why
+
+Bug reports against a specific version depend on the user knowing which version
+they run. Today there is no About dialog and the tray tooltip is a static
+`RuVox`, so the version is only discoverable by reading `tauri.conf.json` or
+the installer filename. Issue #94 asked for the version to be shown in the UI
+("About dialog or tray tooltip") for exactly this reason.
+
+## What Changes
+
+1. **Settings shows the app version.** The Settings dialog gains an
+   "О приложении" section (always visible, not gated behind the Windows-only
+   updater) that displays the version as `Версия: <version>`. The value comes
+   from Tauri's `getVersion()` (resolves `tauri.conf.json` `version` at build
+   time), fetched each time the dialog opens and falling back to `—` on IPC
+   failure so a version read error never blocks the dialog.
+2. **Tray tooltip shows the version.** The tray icon tooltip is formatted as
+   `RuVox v<version>` (e.g. `RuVox v0.3.1`), read from `app.package_info().version`
+   at tray init.
+
+## Scope
+
+- Frontend: `src/dialogs/Settings.tsx` — fetch version on open + render the
+  "О приложении" section.
+- Backend: `src-tauri/src/tray/mod.rs` — `format!("RuVox v{}", …)` in
+  `TrayIconBuilder::tooltip`.
+- OpenSpec deltas: `ui` (Settings version display), `tray` (tooltip version).
+
+## Non-goals
+
+- No new dedicated About dialog — `#94` allows "About dialog or tray tooltip";
+  reusing Settings avoids a new route and keeps the version next to the
+  updater check.
+- No CHANGELOG-driven release notes — handled separately in `release.yml`.
+- No version-based update gating beyond display.
+
+## Risks
+
+- `getVersion()` reads `tauri.conf.json` at build time; in dev it matches the
+  dev version, which is the intended behavior. Low risk.
+- The IPC call can fail (offline backend, dev tools); the `—` fallback keeps
+  the dialog usable, matching the existing `getCacheDir` failure handling.

--- a/openspec/changes/archive/2026-08-20-settings-app-version/specs/tray/spec.md
+++ b/openspec/changes/archive/2026-08-20-settings-app-version/specs/tray/spec.md
@@ -1,0 +1,18 @@
+# Delta: tray
+
+## ADDED Requirements
+
+### Requirement: Tray tooltip shows the app version
+
+The tray icon tooltip SHALL include the application version, formatted as
+`RuVox v<version>` (e.g. `RuVox v0.3.1`), so bug reports can quote the version
+directly from the tray. The version SHALL be read from the app package info
+(`app.package_info().version`, the `version` field of `tauri.conf.json`) at tray
+init.
+
+#### Scenario: Tooltip names the version
+
+- GIVEN the application is running
+- WHEN the user hovers the tray icon
+- THEN the tooltip reads `RuVox v<version>` matching the built `tauri.conf.json`
+  version, not the bare `RuVox`

--- a/openspec/changes/archive/2026-08-20-settings-app-version/specs/ui/spec.md
+++ b/openspec/changes/archive/2026-08-20-settings-app-version/specs/ui/spec.md
@@ -1,0 +1,28 @@
+# Delta: ui
+
+## ADDED Requirements
+
+### Requirement: Settings shows the app version
+
+The Settings dialog SHALL display the application version in the bottom-right of
+the dialog (the footer, right-aligned) so it is always visible (not gated behind
+the Windows-only updater). The version SHALL be read from the app manifest via
+Tauri's `getVersion()` (which resolves the `version` field of `tauri.conf.json`
+at build time) and shown as `Версия: <version>`.
+
+The version SHALL be fetched whenever the dialog opens (alongside `getConfig` and
+`getCacheDir`) and SHALL fall back to `—` if the IPC call fails, so a backend or
+version read error never blocks the dialog.
+
+#### Scenario: Version is shown when Settings opens
+
+- GIVEN the application has started
+- WHEN the user opens Settings
+- THEN the bottom-right footer shows `Версия: <version>` matching the built
+  `tauri.conf.json` version (e.g. `0.3.1`)
+
+#### Scenario: Version read failure degrades gracefully
+
+- GIVEN `getVersion()` fails (e.g. IPC unavailable)
+- WHEN the user opens Settings
+- THEN the version line shows `—` and the rest of the dialog still works

--- a/openspec/changes/archive/2026-08-20-settings-app-version/tasks.md
+++ b/openspec/changes/archive/2026-08-20-settings-app-version/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: settings-app-version
+
+## Frontend: Settings version display
+
+- [x] Import `getVersion` from `@tauri-apps/api/app` in `src/dialogs/Settings.tsx`
+- [x] Add `appVersion` state; fetch it in the open effect (mirroring
+      `getCacheDir`), falling back to `''` on failure
+- [x] Render an "О приложении" section after the theme selector with
+      `Версия: {appVersion || '—'}`
+- [x] `pnpm typecheck` green
+
+## Backend: tray tooltip version
+
+- [x] `src-tauri/src/tray/mod.rs`: `.tooltip(format!("RuVox v{}", app.package_info().version))`
+- [x] `cargo check` (or `cargo build`) green
+
+## OpenSpec
+
+- [x] Delta specs: `ui` (Settings version display), `tray` (tooltip version)
+- [x] `openspec change validate settings-app-version` green
+- [x] Verify change vs implementation, then archive (syncs deltas into
+      `openspec/specs/`)
+
+## Gates
+
+- [x] `pnpm test:unit` green (157 tests)
+- [x] `just lint` green (eslint)
+- [ ] Manual dev pass: open Settings → "О приложении" shows `Версия: 0.3.1`;
+      hover tray → tooltip `RuVox v0.3.1`

--- a/openspec/specs/tray/spec.md
+++ b/openspec/specs/tray/spec.md
@@ -109,3 +109,18 @@ instance.
 - GIVEN an entry is playing
 - WHEN the user quits via "Выход"
 - THEN mpv is destroyed and no panic occurs from in-flight player commands
+
+### Requirement: Tray tooltip shows the app version
+
+The tray icon tooltip SHALL include the application version, formatted as
+`RuVox v<version>` (e.g. `RuVox v0.3.1`), so bug reports can quote the version
+directly from the tray. The version SHALL be read from the app package info
+(`app.package_info().version`, the `version` field of `tauri.conf.json`) at tray
+init.
+
+#### Scenario: Tooltip names the version
+
+- GIVEN the application is running
+- WHEN the user hovers the tray icon
+- THEN the tooltip reads `RuVox v<version>` matching the built `tauri.conf.json`
+  version, not the bare `RuVox`

--- a/openspec/specs/ui/spec.md
+++ b/openspec/specs/ui/spec.md
@@ -278,3 +278,28 @@ revision).
 - THEN the prompt closes, the session continues on the Piper fallback, the
   persisted config is unchanged, and the prompt appears again on the next
   launch
+
+### Requirement: Settings shows the app version
+
+The Settings dialog SHALL display the application version in the bottom-right of
+the dialog (the footer, right-aligned) so it is always visible (not gated behind
+the Windows-only updater). The version SHALL be read from the app manifest via
+Tauri's `getVersion()` (which resolves the `version` field of `tauri.conf.json`
+at build time) and shown as `Версия: <version>`.
+
+The version SHALL be fetched whenever the dialog opens (alongside `getConfig` and
+`getCacheDir`) and SHALL fall back to `—` if the IPC call fails, so a backend or
+version read error never blocks the dialog.
+
+#### Scenario: Version is shown when Settings opens
+
+- GIVEN the application has started
+- WHEN the user opens Settings
+- THEN the bottom-right footer shows `Версия: <version>` matching the built
+  `tauri.conf.json` version (e.g. `0.3.1`)
+
+#### Scenario: Version read failure degrades gracefully
+
+- GIVEN `getVersion()` fails (e.g. IPC unavailable)
+- WHEN the user opens Settings
+- THEN the version line shows `—` and the rest of the dialog still works

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -21,7 +21,8 @@ pub fn init<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let menu = Menu::with_items(app, &[&show, &sep1, &add, &sep2, &quit])?;
 
     let _tray = TrayIconBuilder::with_id("main")
-        .tooltip("RuVox")
+        // Include the version so bug reports can quote it from the tray.
+        .tooltip(format!("RuVox v{}", app.package_info().version))
         .icon(load_tray_icon(app)?)
         .menu(&menu)
         .show_menu_on_left_click(false)

--- a/src/dialogs/Settings.tsx
+++ b/src/dialogs/Settings.tsx
@@ -20,6 +20,7 @@ import type { MantineColorScheme } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import { getVersion } from '@tauri-apps/api/app';
 import { commands, events } from '../lib/tauri';
 import type { CleanupMode, EngineKind, UIConfigPatch } from '../lib/tauri';
 import { formatError } from '../lib/errors';
@@ -223,6 +224,7 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
   const { setColorScheme } = useMantineColorScheme();
   const [cleanupOpen, setCleanupOpen] = useState(false);
   const [cacheDir, setCacheDir] = useState<string>('');
+  const [appVersion, setAppVersion] = useState<string>('');
   const [coercedAlert, setCoercedAlert] = useState(false);
   const [availability, setAvailability] = useState<AvailabilityMap>(PESSIMISTIC_AVAILABILITY);
   // Live bundle-download state: null when idle, otherwise the current file
@@ -284,6 +286,9 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
         });
       });
     commands.getCacheDir().then(setCacheDir).catch(() => setCacheDir(''));
+    // Always resolve the version (independent of the Windows-only updater) so
+    // bug reports can quote it on every platform.
+    getVersion().then(setAppVersion).catch(() => setAppVersion(''));
     // form is excluded intentionally: setValues is stable, re-running on form change would loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [opened]);
@@ -651,6 +656,10 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
               </Group>
             </>
           )}
+
+          <Text size="xs" c="dimmed" ta="right" mt="md">
+            Версия: {appVersion || '—'}
+          </Text>
 
           <Group justify="flex-end" mt="md">
             <Button variant="subtle" onClick={() => form.reset()}>


### PR DESCRIPTION
## Summary

- **App version is now visible** so bug reports can quote a specific build:
  - Settings: right-aligned `Версия: X.Y.Z` in the footer (always visible, not gated behind the Windows-only updater), read via Tauri's `getVersion()`.
  - Tray tooltip: `RuVox vX.Y.Z`, read from `package_info().version`.
- **Release notes come from CHANGELOG.md** (part of #94): `release.yml` now extracts the matching `## [<version>]` section with `awk` instead of GitHub's auto-generated diff summary, with a fallback stub when the tag has no entry yet.

## Spec

Documented via OpenSpec change `settings-app-version` (archived; synced into `openspec/specs/ui` and `openspec/specs/tray`).

## Test plan

- [ ] Open Settings → footer shows `Версия: 0.3.1`.
- [ ] Hover tray → tooltip `RuVox v0.3.1`.
- [x] `cargo-clippy`, `eslint`, `knip`, `typescript` green (pre-push hook).