### PR TITLE
fix(viewer): block link navigation inside the mermaid zoom modal

### DIFF
--- a/src/components/TextViewer.test.tsx
+++ b/src/components/TextViewer.test.tsx
@@ -74,6 +74,16 @@ function makeEntry(): TextEntry {
   };
 }
 
+function makeMermaidEntry(): TextEntry {
+  return {
+    ...makeEntry(),
+    format: 'markdown',
+    html_source: null,
+    original_text:
+      '```mermaid\nflowchart LR\n  A[Node]\n  click A "https://example.com"\n```',
+  };
+}
+
 describe('TextViewer read-only behavior', () => {
   let host: HTMLDivElement;
   let root: Root;
@@ -164,5 +174,57 @@ describe('TextViewer read-only behavior', () => {
       );
     });
     expect(copyLinkAddress).toHaveBeenCalledWith('/ru/users/maybe_elf/');
+  });
+
+  // Regression (#159): the zoom modal is portaled outside the viewer
+  // container, so the delegated link-blocking handler does not cover it —
+  // links inside the zoomed SVG (mermaid `click` directives emit real <a>
+  // elements under securityLevel 'loose') navigated the webview.
+  it('blocks link navigation inside the mermaid zoom modal', async () => {
+    root = createRoot(host);
+    renderWith(makeMermaidEntry());
+
+    // renderMermaidIn is mocked; inject the SVG it would have produced.
+    const mermaidDiv = host.querySelector('.mermaid');
+    expect(mermaidDiv).not.toBeNull();
+    mermaidDiv!.innerHTML =
+      '<svg><a href="https://example.com"><text>Node</text></a></svg>';
+
+    // Open the zoom modal by clicking the diagram itself (a non-link area).
+    const svg = mermaidDiv!.querySelector('svg')!;
+    act(() => {
+      svg.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true }),
+      );
+    });
+    // Mantine Modal mounts its portal through a transition, so the dialog
+    // appears asynchronously rather than synchronously after the click.
+    let dialog: Element | null = null;
+    await act(async () => {
+      await vi.waitFor(() => {
+        dialog = document.body.querySelector('[role="dialog"]');
+        expect(dialog).not.toBeNull();
+      });
+    });
+
+    const link = dialog!.querySelector('a');
+    expect(link).not.toBeNull();
+
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+    act(() => {
+      link!.dispatchEvent(click);
+    });
+    expect(click.defaultPrevented).toBe(true);
+
+    // Middle click fires auxclick, not click — it must be blocked too.
+    const auxclick = new MouseEvent('auxclick', {
+      bubbles: true,
+      cancelable: true,
+      button: 1,
+    });
+    act(() => {
+      link!.dispatchEvent(auxclick);
+    });
+    expect(auxclick.defaultPrevented).toBe(true);
   });
 });

--- a/src/components/TextViewer.tsx
+++ b/src/components/TextViewer.tsx
@@ -8,7 +8,13 @@ import {
   Text,
   useComputedColorScheme,
 } from '@mantine/core';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { notifications } from '@mantine/notifications';
 import type { EntryFormat, TextEntry, WordTimestamp } from '../lib/tauri';
 import { commands, events } from '../lib/tauri';
@@ -30,6 +36,16 @@ import classes from './TextViewer.module.css';
 
 // Entries without a persisted format render in the viewer default mode.
 const DEFAULT_FORMAT: EntryFormat = "markdown";
+
+// Keep links inside the mermaid zoom modal inert, mirroring the delegated
+// handler that covers the viewer container. auxclick is included because
+// middle click fires auxclick, not click, and would bypass a click-only block.
+function blockZoomLinkClick(e: ReactMouseEvent) {
+  if ((e.target as HTMLElement).closest("a")) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+}
 
 interface Props {
   entry: TextEntry | null;
@@ -380,7 +396,13 @@ export function TextViewer({ entry }: Props) {
         styles={{ body: { overflowX: "auto" } }}
       >
         {zoomedSvg && (
+          // The modal is portaled outside containerRef, so the delegated
+          // read-only click handler does not reach it: block link navigation
+          // inside the zoomed SVG here (mermaid `click` directives emit real
+          // <a> elements under securityLevel 'loose').
           <Box
+            onClick={blockZoomLinkClick}
+            onAuxClick={blockZoomLinkClick}
             dangerouslySetInnerHTML={{ __html: zoomedSvg }}
             style={{ display: "flex", justifyContent: "center" }}
           />


### PR DESCRIPTION
Closes #159.

## Problem

The mermaid click-to-zoom modal (`TextViewer` renders `zoomedSvg` in a Mantine `Modal`) is portaled outside the viewer container (`containerRef`), so the delegated read-only click handler added for #156 never covered it. With `securityLevel: 'loose'`, mermaid `click` directives emit real `<a>` elements, and clicking one inside the zoomed SVG navigated the app webview.

## Fix

Block link navigation inside the modal, mirroring the viewer handler:

- Module-level `blockZoomLinkClick` wired via `onClick`/`onAuxClick` on the Box inside the Modal (`auxclick` included — middle click fires auxclick, not click, and would bypass a click-only block).
- Links stay visible with their `title` tooltips (already stamped by `makeInert` on the container before the SVG snapshot), consistent with the read-only viewer behavior.

## Tests

- New regression test in `TextViewer.test.tsx`: opens the zoom modal on a mermaid diagram with a link, asserts both `click` and middle-click `auxclick` on the link are `preventDefault`-ed. Uses `vi.waitFor` for the async portal mount.
- Green: `pnpm test:unit` (158/158), `pnpm typecheck`, `pnpm lint`.
- `ruvox-reviewer` pass on the branch diff: no blocking issues; its one low-severity finding (fixed-delay wait in the test) is folded in.

No OpenSpec change: bugfix restoring already-specified read-only viewer behavior.