### PR TITLE
fix(piper): write synthesized audio as 32-bit float WAV

### DIFF
--- a/openspec/changes/archive/2026-08-20-piper-float-wav/design.md
+++ b/openspec/changes/archive/2026-08-20-piper-float-wav/design.md
@@ -1,0 +1,23 @@
+# Design: piper-float-wav
+
+## Decision
+
+Change Piper's WAV writer to emit 32-bit-float PCM (`write_wav_f32` in
+`src-tauri/src/tts/piper/engine.rs`), replacing the i16 quantization.
+
+## Rejected alternative: int→float conversion in the encoder
+
+`encode_wav_to_opus` could accept 16-bit Int WAVs and convert samples to f32
+before encoding. Rejected because:
+
+- **Quality**: Piper synthesizes f32 internally. Writing i16 quantizes the
+  signal, and converting back to float cannot recover that precision. Writing
+  float directly keeps the full synthesized signal.
+- **Simplicity**: the encoder keeps a single accepted input format (mono
+  32-bit-float); no second decode path to maintain and test.
+- **Cost is already paid**: the float WAV is transient — it is transcoded to
+  `.opus` and removed on success, so the larger on-disk size never persists.
+
+Trade-off accepted: legacy int-PCM `.wav` files written by older builds are
+still rejected by the encoder and by the startup migration sweep; they are
+cleaned up manually (single-user install base at this stage).

--- a/openspec/changes/archive/2026-08-20-piper-float-wav/proposal.md
+++ b/openspec/changes/archive/2026-08-20-piper-float-wav/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: piper-float-wav
+
+Fixes #206 (follow-up to `opus-resample-off-list-rates`).
+
+## Why
+
+`opus-resample-off-list-rates` fixed the off-list *sample rate* rejection, but
+a real Piper run still keeps the `.wav`: `PiperEngine` quantizes its
+internally-synthesized f32 samples to 16-bit Int PCM on write
+(`write_wav_i16`), and `crate::audio::encode_wav_to_opus` rejects any non-float
+WAV up front with `unsupported wav format: expected 32-bit float PCM, got Int
+16-bit` — before the rate check even runs. So every Piper entry is still kept
+as a large `.wav` instead of transcoding to `.opus`.
+
+## What Changes
+
+`PiperEngine` writes its synthesized audio as a mono **32-bit-float** WAV
+(`write_wav_f32`) instead of 16-bit Int PCM:
+
+- Piper synthesizes f32 samples internally, so writing float skips a lossy i16
+  quantization step (strictly better source quality for the Opus encode).
+- The float WAV is exactly what `encode_wav_to_opus` accepts, so the clip
+  transcodes to `.opus`; the off-list rate (e.g. 22050 Hz for `ruslan`) is
+  resampled to the nearest Opus-native rate by the already-merged
+  `opus-resample-off-list-rates` change.
+
+## Non-goals
+
+- Converting integer PCM to float inside the encoder — the encoder keeps
+  rejecting int PCM; Piper is fixed at the source instead. Legacy `.wav` files
+  left by older builds are not auto-migrated (they are int PCM); the user
+  cleans them up manually.
+- Changing Piper's output sample rate — voices still emit at their own rate;
+  the Rust side resamples as before.

--- a/openspec/changes/archive/2026-08-20-piper-float-wav/specs/storage/spec.md
+++ b/openspec/changes/archive/2026-08-20-piper-float-wav/specs/storage/spec.md
@@ -1,0 +1,44 @@
+# Delta: storage
+
+## MODIFIED Requirements
+
+### Requirement: Audio File Storage
+
+The system SHALL store synthesized audio per entry as `audio/{uuid}.opus`, where `{uuid}` is the entry's `EntryId`. The file SHALL be an Ogg-Opus stream:
+
+| Property | Value |
+|----------|-------|
+| Container | Ogg |
+| Codec | Opus (RFC 6716, RFC 7845) |
+| Channels | 1 (mono) |
+| Sample rate | One of 8 / 12 / 16 / 24 / 48 kHz — the rates libopus accepts natively (RFC 6716 §2). The TTS engine SHOULD write one of these; if it writes any other rate (e.g. a Piper voice at 22050 Hz, or 44100 Hz), the Rust side SHALL resample it to the nearest native rate before encoding. `OpusHead` SHALL record the native (resampled) rate the encoder actually used, not the original off-list rate |
+| Bitrate | 32 000 bps (VOIP application) |
+| Frame size | 20 ms |
+| Pre-skip | Queried from `libopus`'s lookahead, scaled to 48 kHz output ticks |
+
+The encoding pipeline is: the TTS engine (ttsd subprocess, Piper, or Silero Native) writes a mono 32-bit-float WAV; the Rust side transcodes it to Opus and removes the source WAV. Integer-PCM WAVs are rejected — engines SHALL write float. If the WAV's sample rate is not one of the Opus-native rates, the Rust side SHALL resample it to the nearest native rate first. On encode failure the source `.wav` SHALL be left in place as a playback fallback. `save_audio` SHALL return the relative filename for `TextEntry.audio_path`.
+
+#### Scenario: Saving audio returns the relative filename
+- GIVEN an entry with id `550e8400-e29b-41d4-a716-446655440000`
+- WHEN audio bytes are saved for the entry
+- THEN the file `audio/550e8400-e29b-41d4-a716-446655440000.opus` exists and the returned filename is `550e8400-e29b-41d4-a716-446655440000.opus`
+
+#### Scenario: Transcode failure keeps the WAV fallback
+- GIVEN a synthesized `.wav` that fails Opus encoding
+- WHEN the transcode step runs
+- THEN the source `.wav` remains on disk so playback can still use it
+
+#### Scenario: Piper clip is written as float WAV and transcodes to Opus
+- GIVEN a synthesis produced by the Piper engine
+- WHEN the clip is written to disk
+- THEN the WAV is mono 32-bit-float PCM, so the transcode step accepts it, stores `.opus`, and removes the source `.wav`
+
+#### Scenario: Off-list sample rate is resampled to the nearest native rate
+- GIVEN a synthesized mono 32-bit-float WAV at an off-list rate (e.g. 22050 Hz from a Piper voice)
+- WHEN the Rust side transcodes it to Opus
+- THEN the entry is stored as `.opus` (the source `.wav` is removed), `OpusHead` records 24000 Hz, and no "unsupported wav format" error is logged
+
+#### Scenario: Native sample rate passes through without resampling
+- GIVEN a synthesized mono 32-bit-float WAV at a native rate (e.g. 48000 Hz)
+- WHEN the Rust side transcodes it to Opus
+- THEN the entry is stored as `.opus` and `OpusHead` records 48000 Hz, with no resampling step

--- a/openspec/changes/archive/2026-08-20-piper-float-wav/tasks.md
+++ b/openspec/changes/archive/2026-08-20-piper-float-wav/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: piper-float-wav
+
+- [x] In `src-tauri/src/tts/piper/engine.rs`, replace `write_wav_i16` with
+  `write_wav_f32` (mono, 32-bit float, `SampleFormat::Float`; clamp samples to
+  -1.0..1.0, no i16 quantization) and update the `synthesize` call site.
+- [x] Add a `write_wav_f32_produces_float_mono_wav` unit test: written WAV is
+  mono / float / 32-bit / correct rate, and samples round-trip without
+  quantization.
+- [x] `cargo test --lib` green; `cargo clippy --lib` and `cargo fmt --check`
+  clean.
+- [x] Manual verification: run the dev build, synthesize with Piper, confirm a
+  `.opus` appears in the audio cache and no "keeping wav" warning is logged.
+- [x] Archive the change (sync delta specs into `openspec/specs/`).

--- a/openspec/specs/storage/spec.md
+++ b/openspec/specs/storage/spec.md
@@ -169,12 +169,12 @@ The system SHALL store synthesized audio per entry as `audio/{uuid}.opus`, where
 | Container | Ogg |
 | Codec | Opus (RFC 6716, RFC 7845) |
 | Channels | 1 (mono) |
-| Sample rate | One of 8 / 12 / 16 / 24 / 48 kHz — the rates libopus accepts natively (RFC 6716 §2). The TTS subprocess SHOULD write one of these; if it writes any other rate (e.g. a Piper voice at 22050 Hz, or 44100 Hz), the Rust side SHALL resample it to the nearest native rate before encoding. `OpusHead` SHALL record the native (resampled) rate the encoder actually used, not the original off-list rate |
+| Sample rate | One of 8 / 12 / 16 / 24 / 48 kHz — the rates libopus accepts natively (RFC 6716 §2). The TTS engine SHOULD write one of these; if it writes any other rate (e.g. a Piper voice at 22050 Hz, or 44100 Hz), the Rust side SHALL resample it to the nearest native rate before encoding. `OpusHead` SHALL record the native (resampled) rate the encoder actually used, not the original off-list rate |
 | Bitrate | 32 000 bps (VOIP application) |
 | Frame size | 20 ms |
 | Pre-skip | Queried from `libopus`'s lookahead, scaled to 48 kHz output ticks |
 
-The encoding pipeline is: the TTS subprocess writes a mono 32-bit-float WAV; the Rust side transcodes it to Opus and removes the source WAV. If the WAV's sample rate is not one of the Opus-native rates, the Rust side SHALL resample it to the nearest native rate first. On encode failure the source `.wav` SHALL be left in place as a playback fallback. `save_audio` SHALL return the relative filename for `TextEntry.audio_path`.
+The encoding pipeline is: the TTS engine (ttsd subprocess, Piper, or Silero Native) writes a mono 32-bit-float WAV; the Rust side transcodes it to Opus and removes the source WAV. Integer-PCM WAVs are rejected — engines SHALL write float. If the WAV's sample rate is not one of the Opus-native rates, the Rust side SHALL resample it to the nearest native rate first. On encode failure the source `.wav` SHALL be left in place as a playback fallback. `save_audio` SHALL return the relative filename for `TextEntry.audio_path`.
 
 #### Scenario: Saving audio returns the relative filename
 - GIVEN an entry with id `550e8400-e29b-41d4-a716-446655440000`
@@ -185,6 +185,11 @@ The encoding pipeline is: the TTS subprocess writes a mono 32-bit-float WAV; the
 - GIVEN a synthesized `.wav` that fails Opus encoding
 - WHEN the transcode step runs
 - THEN the source `.wav` remains on disk so playback can still use it
+
+#### Scenario: Piper clip is written as float WAV and transcodes to Opus
+- GIVEN a synthesis produced by the Piper engine
+- WHEN the clip is written to disk
+- THEN the WAV is mono 32-bit-float PCM, so the transcode step accepts it, stores `.opus`, and removes the source `.wav`
 
 #### Scenario: Off-list sample rate is resampled to the nearest native rate
 - GIVEN a synthesized mono 32-bit-float WAV at an off-list rate (e.g. 22050 Hz from a Piper voice)

--- a/src-tauri/src/tts/piper/engine.rs
+++ b/src-tauri/src/tts/piper/engine.rs
@@ -265,7 +265,7 @@ impl TtsEngine for PiperEngine {
         let samples_for_write = samples;
         let out_wav_for_write = out_wav.clone();
         tokio::task::spawn_blocking(move || {
-            write_wav_i16(&out_wav_for_write, sample_rate, &samples_for_write)
+            write_wav_f32(&out_wav_for_write, sample_rate, &samples_for_write)
         })
         .await
         .map_err(|e| {
@@ -323,19 +323,28 @@ fn load_voice_blocking(config_path: &Path) -> Result<(Piper, f32, f32, u32), Tts
     ))
 }
 
-/// Write `samples` (f32 in -1.0..1.0) as a mono i16 PCM WAV at `sample_rate`.
-fn write_wav_i16(path: &str, sample_rate: u32, samples: &[f32]) -> Result<(), TtsError> {
+/// Write `samples` (f32 in -1.0..1.0) as a mono 32-bit-float WAV at
+/// `sample_rate`.
+///
+/// The float format is what `crate::audio::encode_wav_to_opus` accepts, so a
+/// Piper clip transcodes straight to Opus (with any off-list sample rate
+/// resampled to the nearest Opus-native one). Writing i16 here would instead
+/// make the encoder reject the file (`unsupported wav format: expected 32-bit
+/// float PCM`) and keep the much larger `.wav` — the #206 regression. Since
+/// Piper synthesizes f32 internally, writing float also skips a lossy i16
+/// quantization step.
+fn write_wav_f32(path: &str, sample_rate: u32, samples: &[f32]) -> Result<(), TtsError> {
     let spec = hound::WavSpec {
         channels: 1,
         sample_rate,
-        bits_per_sample: 16,
-        sample_format: hound::SampleFormat::Int,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
     };
     let mut writer = hound::WavWriter::create(path, spec).map_err(map_hound_err)?;
     for s in samples {
-        let clipped = s.clamp(-1.0, 1.0);
-        let i = (clipped * 32767.0) as i16;
-        writer.write_sample(i).map_err(map_hound_err)?;
+        writer
+            .write_sample(s.clamp(-1.0, 1.0))
+            .map_err(map_hound_err)?;
     }
     writer.finalize().map_err(map_hound_err)
 }
@@ -344,5 +353,45 @@ fn map_hound_err(e: hound::Error) -> TtsError {
     match e {
         hound::Error::IoError(io) => TtsError::Ipc(io),
         other => TtsError::Ipc(std::io::Error::other(other.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `write_wav_f32` must emit a mono 32-bit-float WAV — the exact format
+    /// `crate::audio::encode_wav_to_opus` accepts — so a Piper clip transcodes
+    /// to Opus instead of being rejected (`expected 32-bit float PCM`) and
+    /// kept as a large `.wav` (#206). The samples must round-trip without any
+    /// i16 quantization.
+    #[test]
+    fn write_wav_f32_produces_float_mono_wav() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wav_path = dir.path().join("out.wav");
+        let samples: Vec<f32> = vec![-1.0, -0.5, 0.0, 0.25, 0.9, 1.5, -2.0];
+
+        write_wav_f32(wav_path.to_str().unwrap(), 22_050, &samples).expect("write wav");
+
+        let mut reader = hound::WavReader::open(&wav_path).expect("open wav");
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1, "must be mono");
+        assert_eq!(
+            spec.sample_format,
+            hound::SampleFormat::Float,
+            "must be float PCM (not int), or the Opus encoder rejects it"
+        );
+        assert_eq!(spec.bits_per_sample, 32, "must be 32-bit float");
+        assert_eq!(spec.sample_rate, 22_050);
+
+        let read: Vec<f32> = reader
+            .samples::<f32>()
+            .collect::<Result<Vec<f32>, hound::Error>>()
+            .expect("read samples");
+        let expected: Vec<f32> = vec![-1.0, -0.5, 0.0, 0.25, 0.9, 1.0, -1.0];
+        assert_eq!(
+            read, expected,
+            "in-range samples must round-trip without quantization; out-of-range must clamp to ±1.0"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fix for #206. The previous fix (`opus-resample-off-list-rates`, #213) handled the off-list sample rate rejection, but a real Piper run still kept the `.wav`: Piper quantized its internally-synthesized f32 samples to 16-bit Int PCM on write, and the Opus encoder rejects non-float WAV before the rate check even runs (`unsupported wav format: expected 32-bit float PCM, got Int 16-bit`).

Piper now writes a mono 32-bit-float WAV, which the encoder accepts; the off-list rate (e.g. 22050 Hz for `ruslan`) is resampled to the nearest Opus-native rate by the already-merged encoder-side fix. Writing float also skips a lossy i16 quantization step.

## Verification

- New unit test: written WAV is mono / float / 32-bit / correct rate, samples round-trip without quantization, out-of-range samples clamp to ±1.0.
- Full suite: 992 lib tests green, clippy + rustfmt clean.
- Manual: dev build, Piper synthesis → `.opus` in the audio cache, no `keeping wav` warning.

Legacy int-PCM `.wav` files from older builds are still rejected by the migration sweep (documented non-goal; cleaned up manually).

Fixes #206