### PR TITLE
build(linux): .deb/.AppImage packages with bundled TTS runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: release
 
 # Tag push `v*` (or a manual dispatch with an explicit tag) builds the
-# Windows NSIS installer and publishes a DRAFT GitHub release with the
-# installer + updater artifacts. The draft is published manually after the
-# VM checklist passes (OpenSpec change windows-installer-and-release, D1).
+# Windows NSIS installer and the Linux .deb/.AppImage packages and publishes
+# a DRAFT GitHub release with all artifacts attached to it. The draft is
+# published manually after the VM checklist passes (OpenSpec change
+# windows-installer-and-release, D1; Linux half = issue #218).
 
 on:
   push:
@@ -52,17 +53,7 @@ jobs:
 
       - name: Guard tag matches app version
         shell: bash
-        # A tag pushed without bumping tauri.conf.json would make the freshly
-        # installed app older than latest.json — an update prompt loop on
-        # every start. Fail fast, before the expensive build.
-        run: |
-          set -euo pipefail
-          tag="${{ inputs.tag || github.ref_name }}"
-          conf_version=$(jq -r .version src-tauri/tauri.conf.json)
-          if [ "$conf_version" != "${tag#v}" ]; then
-            echo "::error::tag $tag does not match tauri.conf.json version $conf_version — bump the version first"
-            exit 1
-          fi
+        run: bash scripts/guard-tag-version.sh "${{ inputs.tag || github.ref_name }}"
 
       # mpv + onnxruntime.dll, pinned + sha256-verified. Must happen before
       # `tauri build` because bundle.resources references them.
@@ -136,34 +127,10 @@ jobs:
 
       # Extract the CHANGELOG.md section for this version so the draft release
       # body is the human-curated notes, not GitHub's auto-generated diff
-      # summary (issue #94). The `## [Unreleased]` heading and deeper
-      # `###`/`####` headings never match the `## [<semver>]` pattern, so only
-      # the target version's block is captured (up to the next top-level
-      # `## [` heading).
+      # summary (see scripts/release-notes.sh for the matching rules).
       - name: Extract changelog section for release notes
         shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ inputs.tag || github.ref_name }}"
-          version="${tag#v}"
-          awk -v v="$version" '
-            /^## \[/ {
-              rest = substr($0, 5)
-              cb = index(rest, "]")
-              hdr = (cb > 0) ? substr(rest, 1, cb - 1) : rest
-              capture = (hdr == v)
-            }
-            capture { print }
-          ' CHANGELOG.md > release_notes.md
-          # Fallback when the tag has no CHANGELOG section yet (a tag pushed
-          # before the entry was added): keep a usable draft body instead of
-          # an empty notes file.
-          if [ ! -s release_notes.md ]; then
-            echo "See CHANGELOG.md — no section for version $version yet." > release_notes.md
-            echo "::warning::No CHANGELOG.md section for $version — using stub release notes"
-          fi
-          echo "----- release notes -----"
-          cat release_notes.md
+        run: bash scripts/release-notes.sh "${{ inputs.tag || github.ref_name }}"
 
       - name: Draft release
         uses: softprops/action-gh-release@v2
@@ -175,3 +142,89 @@ jobs:
             src-tauri/target/release/bundle/nsis/*_x64-setup.exe
             src-tauri/target/release/bundle/nsis/*_x64-setup.exe.sig
             latest.json
+
+  # Linux half of #94, split out by issue #218: build .deb + .AppImage on a
+  # Linux runner and attach them to the SAME draft release the Windows job
+  # created (same tag_name; softprops/action-gh-release updates an existing
+  # draft and merges assets — whichever job finishes first creates it, both
+  # write identical release notes via scripts/release-notes.sh). The in-app
+  # updater manifest (latest.json) stays Windows-only for now.
+  linux-packages:
+    runs-on: ubuntu-latest
+    # Warm cargo cache ~12-15 min (two-stage build + bundling); cold apt+cargo
+    # caches can push past 30 min (apt throttling note in ci.yml applies).
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      # Same package set as the ci.yml rust job plus patchelf (AppImage
+      # bundling); cache-apt-pkgs for the same incident-#204 reason. `version`
+      # differs from ci.yml because the package list here is different.
+      - name: Install Tauri system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev libmpv-dev pkg-config build-essential patchelf file
+          version: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri\nsilero-native"
+          shared-key: linux-gnu-release
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Guard tag matches app version
+        run: bash scripts/guard-tag-version.sh "${{ inputs.tag || github.ref_name }}"
+
+      # Two-stage build, same shape as the Windows job: produce the vendored
+      # espeak-ng-data first (espeak-rs-sys emits it into its build tree),
+      # copy it into bundle resources (referenced by tauri.linux.conf.json),
+      # then let `tauri build` bundle .deb + .AppImage.
+      - name: Build frontend (tauri-codegen needs dist/ during cargo build)
+        run: pnpm build
+
+      - name: cargo build lib --crate-type=rlib (produces espeak-ng-data)
+        run: cargo rustc --release --lib --crate-type=rlib --features tauri/custom-protocol --manifest-path src-tauri/Cargo.toml
+
+      - name: Extract espeak-ng-data into bundle resources
+        run: |
+          set -euo pipefail
+          src=$(ls -d src-tauri/target/release/build/espeak-rs-sys-*/out/share/espeak-ng-data | head -1)
+          # Sanity: the Russian pipeline needs these three at minimum.
+          test -f "$src/ru_dict" && test -f "$src/phondata" && test -f "$src/intonations"
+          cp -r "$src/." src-tauri/resources/espeak-ng-data/
+          test -f src-tauri/resources/espeak-ng-data/ru_dict
+
+      # Pinned + sha256-verified libonnxruntime for the silero-native engine
+      # (ort load-dynamic dlopens it from ORT_DYLIB_PATH, set by the app to
+      # the bundled copy). Must replace the committed placeholder before
+      # `tauri build` — same rule as the Windows onnxruntime.dll fetch.
+      - name: Fetch libonnxruntime into bundle resources
+        run: bash scripts/fetch-linux-onnxruntime.sh
+
+      - name: Build .deb and .AppImage packages
+        run: pnpm tauri build
+
+      - name: Extract changelog section for release notes
+        run: bash scripts/release-notes.sh "${{ inputs.tag || github.ref_name }}"
+
+      - name: Attach Linux artifacts to the draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          draft: true
+          body_path: release_notes.md
+          files: |
+            src-tauri/target/release/bundle/deb/*.deb
+            src-tauri/target/release/bundle/appimage/*.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Install Tauri system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev libmpv-dev pkg-config build-essential patchelf file
+          packages: libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev libmpv-dev pkg-config build-essential patchelf file squashfs-tools
           version: 1
 
       - uses: dtolnay/rust-toolchain@stable
@@ -215,6 +215,14 @@ jobs:
 
       - name: Build .deb and .AppImage packages
         run: pnpm tauri build
+
+      # Repack the AppImage with GDK_BACKEND autodetection — without this the
+      # CI-built AppImage fails to start on pure-Wayland sessions (the local
+      # builder applies the same fix; keep the two in sync).
+      - name: Apply wayland fix to the AppImage
+        run: |
+          appimage=$(ls src-tauri/target/release/bundle/appimage/*.AppImage | head -1)
+          bash scripts/fix-appimage-wayland.sh "$appimage" "$appimage"
 
       - name: Extract changelog section for release notes
         run: bash scripts/release-notes.sh "${{ inputs.tag || github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follo
 
 ## [Unreleased]
 
+### Added
+- **Linux packages (`.deb`, `.AppImage`)** — release artifacts for Ubuntu 24.04-class systems, built by a GitHub Actions job. The `.deb` installs via `dpkg -i`; the AppImage runs directly on systems with FUSE and via `--appimage-extract-and-run` anywhere else.
+- **TTS works out of the box on Linux** — packages bundle `espeak-ng-data` and a pinned `libonnxruntime.so` (sha256-verified at build time), so Silero (native) and Piper synthesize on a clean system without system-wide ONNX Runtime; previously Silero hung silently at startup.
+
 ## [0.3.1] — 2026-08-20
 
 ### Added

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -243,6 +243,30 @@ pkgs.mkShell {
     # for the production bundle; in dev we set them manually.
     export XDG_DATA_DIRS="${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:${pkgs.hicolor-icon-theme}/share:$XDG_DATA_DIRS"
 
+    # tauri-cli's AppImage bundler locates libayatana-appindicator3 by running
+    # `pkg-config --libs-only-L ayatana-appindicator3-0.1` and stripping ONLY
+    # the leading "-L" off the output (tauri-cli rust.rs `get_library_path`,
+    # tauri <= 2.11.4). Under Nix that query returns one -L flag per
+    # transitive dependency, so the whole flag list is misparsed into a single
+    # bogus directory and AppImage bundling aborts with "Failed to copy
+    # custom files". Shim pkg-config to answer that exact query with the one
+    # appindicator libdir; every other invocation passes through untouched.
+    if [ ! -e /tmp/ruvox-pkgconfig-shim/pkg-config ]; then
+      mkdir -p /tmp/ruvox-pkgconfig-shim
+      cat > /tmp/ruvox-pkgconfig-shim/pkg-config <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "--libs-only-L" ] && [ "$2" = "ayatana-appindicator3-0.1" ]; then
+  echo "-L$(REAL_PKG_CONFIG --variable=libdir ayatana-appindicator3-0.1)"
+  exit 0
+fi
+exec REAL_PKG_CONFIG "$@"
+EOF
+    fi
+    _real_pc=$(command -v pkg-config)
+    sed -i "s|REAL_PKG_CONFIG|$_real_pc|g" /tmp/ruvox-pkgconfig-shim/pkg-config
+    chmod +x /tmp/ruvox-pkgconfig-shim/pkg-config
+    export PATH="/tmp/ruvox-pkgconfig-shim:$PATH"
+
     # Install pre-commit hooks (idempotent; silently skipped outside a git
     # checkout or when lefthook.yml is absent)
     lefthook install > /dev/null 2>&1 || true

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -251,9 +251,11 @@ pkgs.mkShell {
     # bogus directory and AppImage bundling aborts with "Failed to copy
     # custom files". Shim pkg-config to answer that exact query with the one
     # appindicator libdir; every other invocation passes through untouched.
-    if [ ! -e /tmp/ruvox-pkgconfig-shim/pkg-config ]; then
-      mkdir -p /tmp/ruvox-pkgconfig-shim
-      cat > /tmp/ruvox-pkgconfig-shim/pkg-config <<'EOF'
+    # Per-shell directory: no cross-user collisions in a world-writable /tmp
+    # and no sed -i race between concurrent shell entries.
+    _pc_shim="''${XDG_RUNTIME_DIR:-/tmp}/ruvox-pkgconfig-shim.$$"
+    mkdir -p "$_pc_shim"
+    cat > "$_pc_shim/pkg-config" <<'EOF'
 #!/usr/bin/env bash
 if [ "$1" = "--libs-only-L" ] && [ "$2" = "ayatana-appindicator3-0.1" ]; then
   echo "-L$(REAL_PKG_CONFIG --variable=libdir ayatana-appindicator3-0.1)"
@@ -261,11 +263,10 @@ if [ "$1" = "--libs-only-L" ] && [ "$2" = "ayatana-appindicator3-0.1" ]; then
 fi
 exec REAL_PKG_CONFIG "$@"
 EOF
-    fi
     _real_pc=$(command -v pkg-config)
-    sed -i "s|REAL_PKG_CONFIG|$_real_pc|g" /tmp/ruvox-pkgconfig-shim/pkg-config
-    chmod +x /tmp/ruvox-pkgconfig-shim/pkg-config
-    export PATH="/tmp/ruvox-pkgconfig-shim:$PATH"
+    sed -i "s|REAL_PKG_CONFIG|$_real_pc|g" "$_pc_shim/pkg-config"
+    chmod +x "$_pc_shim/pkg-config"
+    export PATH="$_pc_shim:$PATH"
 
     # Install pre-commit hooks (idempotent; silently skipped outside a git
     # checkout or when lefthook.yml is absent)

--- a/openspec/changes/archive/2026-08-24-linux-runtime-bundling/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-24-linux-runtime-bundling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/archive/2026-08-24-linux-runtime-bundling/design.md
+++ b/openspec/changes/archive/2026-08-24-linux-runtime-bundling/design.md
@@ -1,0 +1,59 @@
+# Design: linux-runtime-bundling
+
+## Context
+
+`ort` is built with `load-dynamic` + `disable-linking`, so the binary has no
+ONNX Runtime linkage at all: at engine init it dlopens the dylib named by
+`ORT_DYLIB_PATH`. The tauri resources map only had a Windows entry
+(`onnxruntime.dll`), and Linux packages shipped a zero-byte placeholder — so on
+a clean system Silero Native hung silently inside ONNX session creation with no
+error surfaced. Piper independently needs `espeak-ng-data/`; nix builds got it
+from a wrapper, packaged builds did not.
+
+## Goals / Non-Goals
+
+- Goal: packaged Linux installs work out of the box (both engines usable)
+  without system-wide ONNX Runtime or espeak data.
+- Goal: dev and nix behavior unchanged; wrapper-provided env keeps priority.
+- Non-goal: vendoring ONNX Runtime into the git repo (fetched at build time,
+  pinned + checksummed).
+- Non-goal: changing engine selection/fallback logic.
+
+## Decisions
+
+### Decision: resolve paths in-process at startup, not in wrapper scripts
+`.deb`/AppImage launches go through different entry points (desktop file,
+AppRun, direct binary); a startup lookup is the one place that covers all of
+them. `init_platform_env` runs before engines initialize and skips any variable
+already present in the environment.
+
+### Decision: product-dir priority over sibling wildcard
+The `lib/` sibling scan (`/usr/lib/*/espeak-ng-data`) can match other products'
+files alphabetically before ours. The scan now promotes the `RuVox` product dir
+to the front of the candidate list; covered by unit tests for both lookups.
+A foreign `libonnxruntime.so` would fail dlopen against the pinned ort-sys ABI
+instead of degrading gracefully, which makes shadowing not just wrong but
+user-visible.
+
+### Decision: reject zero-byte placeholders explicitly
+A placeholder that "exists" would pass an existence check and poison
+`ORT_DYLIB_PATH`. Candidates are size-checked; placeholders are skipped.
+
+### Decision: pinned fetch with checksum, shared by CI and local builder
+`scripts/fetch-linux-onnxruntime.sh` pins version 1.24.1 (matching the
+`ort-sys` API) plus sha256, supports `--check`, and is called identically from
+the release workflow and `scripts/build-linux-packages.sh` so the two cannot
+drift.
+
+## Risks / Trade-offs
+
+- A future `ort` upgrade must bump the pin in lockstep — enforced by review;
+  mismatch fails loudly at first synthesis, not silently at package build.
+- AppImage squashfs is zstd, which stock p7zip cannot extract; repack uses
+  `unsquashfs -o <offset>` (see `scripts/fix-appimage-wayland.sh`).
+
+## Migration Plan
+
+Backfill change: behavior already implemented, VM-verified end-to-end for both
+package formats (engine load from bundled paths, synthesis, playback on pure
+Wayland). Artifacts document it; archiving syncs the specs.

--- a/openspec/changes/archive/2026-08-24-linux-runtime-bundling/proposal.md
+++ b/openspec/changes/archive/2026-08-24-linux-runtime-bundling/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The Linux release packages (`.deb` and `.AppImage`) shipped without the runtime
+pieces the TTS engines need at startup: `espeak-ng-data/` (required by Piper
+phonemization) and a real `libonnxruntime.so` (required by the `ort` crate,
+which is built with `load-dynamic` and dlopens the dylib named by
+`ORT_DYLIB_PATH`). On a fresh install Silero Native therefore hung silently at
+ONNX session creation and Piper had no phonemization data, so no engine could
+synthesize. The Nix build never hit this because its wrapper sets these paths —
+but end users do not run Nix.
+
+## What Changes
+
+- Linux packages bundle `espeak-ng-data/` and a pinned `libonnxruntime.so`
+  (1.24.1, matching the `ort`/`ort-sys` ABI) as resources, for both `.deb`
+  (`/usr/lib/RuVox/`) and `.AppImage` (squashfs `usr/lib/RuVox/`).
+- On Linux, before engines initialize, startup locates the bundled directories
+  and sets `PIPER_ESPEAKNG_DATA_DIRECTORY` and `ORT_DYLIB_PATH` in the process
+  environment. The lookup prefers our own product dir over sibling wildcard
+  matches, rejects zero-byte placeholder files, and leaves any pre-existing
+  environment values untouched (the nix wrapper keeps priority).
+- If nothing is bundled or found (e.g. a dev build), startup proceeds exactly
+  as before; the variables are simply not set.
+- CI (release workflow) and the local Docker builder both fetch the pinned
+  ONNX Runtime with checksum verification and apply the wayland AppImage fix.
+
+This is a backfill change: the behavior described here is already implemented
+and verified end-to-end in a VM (engine load from bundled paths, synthesis and
+playback for both package formats on pure Wayland); the artifacts document it
+and sync the specs.
+
+## Capabilities
+
+### New Capabilities
+
+- `linux-runtime`: how the backend adapts to Linux at runtime — startup
+  environment for bundled TTS runtime resources (`espeak-ng-data`,
+  `libonnxruntime`), the lookup order and guards, and what happens when they
+  are absent.
+
+### Modified Capabilities
+
+- `windows-runtime`: the "Non-Windows startup" scenario under "Windows startup
+  environment" stated that the startup code does not set
+  `PIPER_ESPEAKNG_DATA_DIRECTORY` on Linux. With Linux bundling this is no
+  longer true in general; the requirement is reworded to allow the Linux
+  startup path to set it when bundled data ships with the package (nix builds
+  remain covered by the wrapper).
+
+## Impact
+
+- `src-tauri/src/lib.rs` (`init_platform_env`, `find_bundled_espeak_data`,
+  `find_bundled_onnxruntime` + unit tests)
+- `src-tauri/tauri.linux.conf.json` / `tauri.windows.conf.json` (resources map)
+- `scripts/fetch-linux-onnxruntime.sh`, `scripts/build-linux-packages.sh`,
+  `scripts/docker/Dockerfile`, `scripts/fix-appimage-wayland.sh`
+- `.github/workflows/release.yml` (linux-packages job)

--- a/openspec/changes/archive/2026-08-24-linux-runtime-bundling/specs/linux-runtime/spec.md
+++ b/openspec/changes/archive/2026-08-24-linux-runtime-bundling/specs/linux-runtime/spec.md
@@ -1,0 +1,69 @@
+# linux-runtime Delta
+
+## ADDED Requirements
+
+### Requirement: Linux startup environment for bundled TTS resources
+
+On Linux, before any worker threads or TTS engines are initialized, the
+startup sequence SHALL locate bundled runtime resources and, when found, set
+the corresponding process environment variables:
+
+- `espeak-ng-data/` (Piper phonemization) → `PIPER_ESPEAKNG_DATA_DIRECTORY`
+- `libonnxruntime.so` (Silero Native ONNX Runtime dylib) → `ORT_DYLIB_PATH`
+
+The lookup SHALL examine the executable's own directory, its parent directory,
+and the sibling product directories under the parent's `lib/` directory. The
+application's own product directory (`RuVox`) SHALL be tried before any
+wildcard match over siblings, so another product's files can never shadow the
+bundled resources. A candidate that exists but is a zero-byte placeholder
+SHALL be rejected.
+
+Pre-existing values of these variables in the process environment SHALL NOT
+be overridden (a nix wrapper or the user keeps priority). If no bundled
+resources are found — e.g. a dev build run via `cargo tauri dev` — startup
+MUST proceed unchanged with the variables left unset.
+
+#### Scenario: Deb install synthesizes from bundled resources
+
+- GIVEN the app was installed from a Linux `.deb` package on a clean system
+  without a system-wide `libonnxruntime`
+- WHEN the application starts and Silero Native synthesis is requested
+- THEN `PIPER_ESPEAKNG_DATA_DIRECTORY` points at `/usr/lib/RuVox/espeak-ng-data`,
+  `ORT_DYLIB_PATH` points at `/usr/lib/RuVox/libonnxruntime.so`, and synthesis
+  completes without falling back to another engine
+
+#### Scenario: Own product dir wins over sibling products
+
+- GIVEN `lib/RuVox/espeak-ng-data` and `lib/<Other>/espeak-ng-data` both exist
+  next to the executable
+- WHEN the startup lookup resolves the bundled data directory
+- THEN the `RuVox` copy is selected regardless of alphabetical order
+
+#### Scenario: Nix build keeps wrapper-provided values
+
+- GIVEN the app runs as a nix build with `PIPER_ESPEAKNG_DATA_DIRECTORY` and
+  `ORT_DYLIB_PATH` already set by the wrapper
+- WHEN the application starts
+- THEN both values are preserved exactly as provided
+
+#### Scenario: Dev build without bundles starts normally
+
+- GIVEN the app runs from a dev checkout without any bundled resource
+  directories
+- WHEN the application starts
+- THEN neither variable is set and engine selection behaves as before this
+  capability existed
+
+### Requirement: Linux packages bundle pinned runtime resources
+
+Linux release packages (`.deb`, `.AppImage`) SHALL include as resources:
+`espeak-ng-data/` and `libonnxruntime.so` fetched at a pinned upstream version
+whose API matches the `ort-sys` crate ABI, verified by checksum. The release
+workflow and the local Docker builder SHALL fetch it the same way.
+
+#### Scenario: Package contents
+
+- GIVEN a Linux package built by the release workflow or the local builder
+- WHEN its payload is inspected
+- THEN `usr/lib/RuVox/espeak-ng-data/` and `usr/lib/RuVox/libonnxruntime.so`
+  are present and non-empty

--- a/openspec/changes/archive/2026-08-24-linux-runtime-bundling/specs/windows-runtime/spec.md
+++ b/openspec/changes/archive/2026-08-24-linux-runtime-bundling/specs/windows-runtime/spec.md
@@ -1,12 +1,6 @@
-# windows-runtime Specification
+# windows-runtime Delta
 
-## Purpose
-
-Defines how the backend adapts to Windows at runtime: startup environment,
-per-OS subprocess cleanup semantics, and which engines and helper
-subprocesses exist on Windows.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Windows startup environment
 
@@ -38,30 +32,3 @@ with the package; nix builds keep relying on the wrapper-provided values.
   `espeak-ng-data` resources
 - WHEN the application starts
 - THEN the startup code does not set `PIPER_ESPEAKNG_DATA_DIRECTORY`
-
-### Requirement: Per-OS subprocess cleanup
-
-Orphan mpv reaping based on `/tmp` socket names and `/proc` inspection
-SHALL run on Unix platforms only. On Windows the application MUST NOT
-attempt `/proc`-based reaping (tauri-plugin-mpv uses named pipes there),
-and startup MUST NOT fail due to the absence of that cleanup.
-
-#### Scenario: Windows startup without reaping
-
-- GIVEN the app runs on Windows
-- WHEN the application starts
-- THEN no orphan-mpv reaping is attempted and startup proceeds normally
-
-### Requirement: Engines and helper subprocesses on Windows
-
-The Windows build SHALL ship Piper and Silero Native as the available TTS
-engines. The ttsd (Python/`uv`) subprocess SHALL NOT be required or
-bundled on Windows, and no Windows code path SHALL assume `uv` is
-installed.
-
-#### Scenario: Engine set on Windows
-
-- GIVEN the app runs on a fresh Windows installation without `uv`
-- WHEN the application starts and TTS is used
-- THEN Piper and Silero Native work, and no attempt to spawn `uv` blocks
-  or breaks startup

--- a/openspec/changes/archive/2026-08-24-linux-runtime-bundling/tasks.md
+++ b/openspec/changes/archive/2026-08-24-linux-runtime-bundling/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: linux-runtime-bundling
+
+## 1. Implementation
+
+- [x] 1.1 `src-tauri/src/lib.rs`: `init_platform_env` — locate bundled `espeak-ng-data` and `libonnxruntime`, set `PIPER_ESPEAKNG_DATA_DIRECTORY` / `ORT_DYLIB_PATH` when found, never overriding pre-existing values
+- [x] 1.2 Lookup helpers with own-product-dir priority over sibling wildcard and zero-byte placeholder rejection; unit tests for both (priority, placeholder, dev-build no-op)
+- [x] 1.3 `tauri.linux.conf.json`: bundle both resources under the Linux resources map
+- [x] 1.4 `scripts/fetch-linux-onnxruntime.sh`: pinned version + sha256 (+ `--check`)
+- [x] 1.5 `.github/workflows/release.yml`: fetch step in linux-packages job
+- [x] 1.6 `scripts/build-linux-packages.sh` + `scripts/docker/Dockerfile`: local Docker builder mirroring CI
+
+## 2. Gates
+
+- [x] 2.1 `cargo test --manifest-path src-tauri/Cargo.toml` green (1012 lib tests), fmt/clippy clean
+- [x] 2.2 Manual pass in Ubuntu 24.04 VM on pure Wayland: install `.deb` → Silero synthesis + playback from bundled dylib (`/proc/<pid>/maps`); same for `.AppImage` (`--appimage-extract-and-run`, dylib resolved from extracted `usr/lib/RuVox/`)
+
+## 3. Wrap-up
+
+- [x] 3.1 Pre-PR reviewer pass over branch diff; findings fixed (product-dir priority tests, release.yml wayland-fix step, appimagetool pin, per-shell pkg-config shim) or deferred (env-priority unit test — documented behavior)
+- [ ] 3.2 Validate specs, archive change (sync delta)
+- [ ] 3.3 PR, merge

--- a/openspec/specs/linux-runtime/spec.md
+++ b/openspec/specs/linux-runtime/spec.md
@@ -1,0 +1,72 @@
+# linux-runtime Specification
+
+## Purpose
+TBD - created by archiving change linux-runtime-bundling. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: Linux startup environment for bundled TTS resources
+
+On Linux, before any worker threads or TTS engines are initialized, the
+startup sequence SHALL locate bundled runtime resources and, when found, set
+the corresponding process environment variables:
+
+- `espeak-ng-data/` (Piper phonemization) → `PIPER_ESPEAKNG_DATA_DIRECTORY`
+- `libonnxruntime.so` (Silero Native ONNX Runtime dylib) → `ORT_DYLIB_PATH`
+
+The lookup SHALL examine the executable's own directory, its parent directory,
+and the sibling product directories under the parent's `lib/` directory. The
+application's own product directory (`RuVox`) SHALL be tried before any
+wildcard match over siblings, so another product's files can never shadow the
+bundled resources. A candidate that exists but is a zero-byte placeholder
+SHALL be rejected.
+
+Pre-existing values of these variables in the process environment SHALL NOT
+be overridden (a nix wrapper or the user keeps priority). If no bundled
+resources are found — e.g. a dev build run via `cargo tauri dev` — startup
+MUST proceed unchanged with the variables left unset.
+
+#### Scenario: Deb install synthesizes from bundled resources
+
+- GIVEN the app was installed from a Linux `.deb` package on a clean system
+  without a system-wide `libonnxruntime`
+- WHEN the application starts and Silero Native synthesis is requested
+- THEN `PIPER_ESPEAKNG_DATA_DIRECTORY` points at `/usr/lib/RuVox/espeak-ng-data`,
+  `ORT_DYLIB_PATH` points at `/usr/lib/RuVox/libonnxruntime.so`, and synthesis
+  completes without falling back to another engine
+
+#### Scenario: Own product dir wins over sibling products
+
+- GIVEN `lib/RuVox/espeak-ng-data` and `lib/<Other>/espeak-ng-data` both exist
+  next to the executable
+- WHEN the startup lookup resolves the bundled data directory
+- THEN the `RuVox` copy is selected regardless of alphabetical order
+
+#### Scenario: Nix build keeps wrapper-provided values
+
+- GIVEN the app runs as a nix build with `PIPER_ESPEAKNG_DATA_DIRECTORY` and
+  `ORT_DYLIB_PATH` already set by the wrapper
+- WHEN the application starts
+- THEN both values are preserved exactly as provided
+
+#### Scenario: Dev build without bundles starts normally
+
+- GIVEN the app runs from a dev checkout without any bundled resource
+  directories
+- WHEN the application starts
+- THEN neither variable is set and engine selection behaves as before this
+  capability existed
+
+### Requirement: Linux packages bundle pinned runtime resources
+
+Linux release packages (`.deb`, `.AppImage`) SHALL include as resources:
+`espeak-ng-data/` and `libonnxruntime.so` fetched at a pinned upstream version
+whose API matches the `ort-sys` crate ABI, verified by checksum. The release
+workflow and the local Docker builder SHALL fetch it the same way.
+
+#### Scenario: Package contents
+
+- GIVEN a Linux package built by the release workflow or the local builder
+- WHEN its payload is inspected
+- THEN `usr/lib/RuVox/espeak-ng-data/` and `usr/lib/RuVox/libonnxruntime.so`
+  are present and non-empty

--- a/scripts/build-linux-packages.sh
+++ b/scripts/build-linux-packages.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Build the Linux release packages (.deb / .AppImage) locally in Docker.
+#
+# Usage:
+#   scripts/build-linux-packages.sh [deb|appimage|both]     (default: both)
+#
+# Replicates the release workflow's linux-packages job
+# (.github/workflows/release.yml) inside a stock ubuntu:24.04 container:
+#
+#   1. pnpm install + frontend build (tauri-codegen needs dist/)
+#   2. cargo rustc --lib --crate-type=rlib  (espeak-rs-sys emits espeak-ng-data)
+#   3. copy espeak-ng-data into src-tauri/resources/
+#   4. scripts/fetch-linux-onnxruntime.sh   (pinned libonnxruntime for `ort`)
+#   5. pnpm tauri build --bundles ...
+#   6. AppImage only: apply scripts/fix-appimage-wayland.sh in place —
+#      linuxdeploy-plugin-gtk hardcodes GDK_BACKEND=x11 in the AppRun hook,
+#      which makes the AppImage fail to start on pure-Wayland sessions.
+#
+# Why Docker: release artifacts must not embed Nix-store paths (a build under
+# `nix develop` links against /nix/store dylibs that users don't have). The
+# container is a standard ubuntu:24.04 userspace, matching the CI runner.
+#
+# Caches live under tmp/ (safe to delete, keyed to the container layout):
+#   tmp/docker-cargo-registry, tmp/docker-cargo-git  — cargo downloads
+#   tmp/docker-target                                — cargo build dir
+#   tmp/docker-pnpm                                  — pnpm store
+#   tmp/docker-cache                                 — bundler downloads (linuxdeploy etc.)
+#   tmp/docker-out                                   — finished artifacts
+set -euo pipefail
+
+sel="${1:-both}"
+case "$sel" in
+    deb | appimage | both) ;;
+    *)
+        echo "usage: $0 [deb|appimage|both]" >&2
+        exit 1
+        ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cache="$repo_root/tmp"
+out="$cache/docker-out"
+mkdir -p "$out"
+
+command -v docker >/dev/null || { echo "error: docker is required" >&2; exit 1; }
+
+echo "==> [1/2] building image"
+docker build -q -t ruvox-build "$repo_root/scripts/docker"
+
+echo "==> [2/2] building packages: $sel"
+docker run --rm -i \
+    -e BUNDLES="$sel" \
+    -v "$repo_root":/src:ro \
+    -v "$cache/docker-cargo-registry":/root/.cargo/registry \
+    -v "$cache/docker-cargo-git":/root/.cargo/git \
+    -v "$cache/docker-target":/target \
+    -v "$cache/docker-pnpm":/pnpm-store \
+    -v "$cache/docker-cache":/root/.cache \
+    -v "$out":/out \
+    ruvox-build bash -s <<'EOF'
+set -euo pipefail
+case "$BUNDLES" in
+    both) BUNDLES="deb appimage" ;;
+esac
+
+echo "[copy] repo -> /work"
+cp -a /src /work
+cd /work
+# Host-owned node_modules/target would confuse pnpm/cargo here; the cargo
+# build dir is the mounted cache instead (CARGO_TARGET_DIR below).
+rm -rf node_modules src-tauri/target
+export CI=true CARGO_TARGET_DIR=/target
+pnpm config set store-dir /pnpm-store
+
+echo "[pnpm] install"
+pnpm install --frozen-lockfile
+
+echo "[espeak] rlib build produces vendored espeak-ng-data"
+cargo rustc --release --lib --crate-type=rlib --features tauri/custom-protocol --manifest-path src-tauri/Cargo.toml
+src=$(ls -d /target/release/build/espeak-rs-sys-*/out/share/espeak-ng-data | head -1)
+# Sanity: the Russian pipeline needs these three at minimum.
+test -f "$src/ru_dict" && test -f "$src/phondata" && test -f "$src/intonations"
+mkdir -p src-tauri/resources/espeak-ng-data
+cp -r "$src/." src-tauri/resources/espeak-ng-data/
+test -f src-tauri/resources/espeak-ng-data/ru_dict
+
+echo "[onnxruntime] fetch pinned libonnxruntime"
+bash scripts/fetch-linux-onnxruntime.sh
+
+echo "[tauri] build --bundles $BUNDLES"
+pnpm tauri build --bundles $BUNDLES
+
+case "$BUNDLES" in
+    *appimage*)
+        echo "[appimage] applying wayland fix (GDK_BACKEND autodetect)"
+        appimage=$(ls /target/release/bundle/appimage/*.AppImage | head -1)
+        bash scripts/fix-appimage-wayland.sh "$appimage" "$appimage"
+        ;;
+esac
+
+case "$BUNDLES" in
+    *deb*) cp -a /target/release/bundle/deb/*.deb /out/ ;;
+esac
+case "$BUNDLES" in
+    *appimage*) cp -a /target/release/bundle/appimage/*.AppImage /out/ ;;
+esac
+chown -R "$(stat -c%u /out):$(stat -c%g /out)" /out || true
+EOF
+
+echo "==> artifacts:"
+ls -la "$out"

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    curl \
+    git \
+    pkg-config \
+    ca-certificates \
+    file \
+    patchelf \
+    dpkg-dev \
+    fakeroot \
+    wget \
+    xz-utils \
+    p7zip-full \
+    squashfs-tools \
+    libssl-dev \
+    libwebkit2gtk-4.1-dev \
+    libjavascriptcoregtk-4.1-dev \
+    libsoup-3.0-dev \
+    libgtk-3-dev \
+    librsvg2-dev \
+    libayatana-appindicator3-dev \
+    libxdo-dev \
+    libmpv-dev \
+    libclang-dev \
+    clang \
+    xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 + pnpm (corepack respects packageManager pin)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable
+
+# Rust (stable)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+WORKDIR /repo

--- a/scripts/fetch-linux-onnxruntime.sh
+++ b/scripts/fetch-linux-onnxruntime.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Downloads and verifies the Linux onnxruntime shared library that gets
+# bundled into the .deb and .AppImage packages. The Linux twin of the
+# onnxruntime part of scripts/fetch-windows-resources.sh.
+#
+# `ort` is built with `load-dynamic` (see silero-native/Cargo.toml): it
+# dlopens libonnxruntime at runtime from ORT_DYLIB_PATH, which the app sets
+# to the bundled copy (src-tauri/src/lib.rs init_platform_env). The pinned
+# version must match the ort-sys bindings (2.0.0-rc.12 targets the ONNX
+# Runtime 1.24 API) — bump both together.
+#
+# Runs on the Linux CI runner before `tauri build` (release.yml
+# linux-packages job); also usable for local package builds. The committed
+# 0-byte placeholder at src-tauri/resources/libonnxruntime.so keeps compile-
+# time resource validation green between releases — never bundle a build
+# where it is still a placeholder.
+
+set -euo pipefail
+
+ORT_VERSION="1.24.1"
+ORT_ARCHIVE="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_ARCHIVE}"
+ORT_SHA256="9142552248b735920f9390027e4512a2cacf8946a1ffcbe9071a5c210531026f"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+target="$repo_root/src-tauri/resources/libonnxruntime.so"
+
+if [ "${1:-}" = "--check" ]; then
+    # Release-build guard: the file must exist and be a real ELF, not the
+    # placeholder (mirrors the "never bundle placeholders" rule).
+    [ -s "$target" ] || { echo "error: $target is missing or a placeholder — run $0 first" >&2; exit 1; }
+    head -c 4 "$target" | grep -q $'\x7fELF' || { echo "error: $target is not an ELF shared library" >&2; exit 1; }
+    exit 0
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+echo "==> downloading ${ORT_ARCHIVE}"
+wget -q "$ORT_URL" -O "$tmp_dir/$ORT_ARCHIVE"
+
+echo "$ORT_SHA256  $tmp_dir/$ORT_ARCHIVE" | sha256sum -c -
+
+echo "==> extracting libonnxruntime.so"
+# Extract the versioned file directly: in the archive libonnxruntime.so is a
+# symlink into it, and extracting the symlink alone leaves it dangling.
+tar xzf "$tmp_dir/$ORT_ARCHIVE" -C "$tmp_dir" \
+    "onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}"
+cp "$tmp_dir/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so.${ORT_VERSION}" "$target"
+
+./"$0" --check
+echo "==> ok: $target ($(stat -c%s "$target") bytes)"

--- a/scripts/fix-appimage-wayland.sh
+++ b/scripts/fix-appimage-wayland.sh
@@ -55,6 +55,11 @@ EXTRACT() {
 }
 
 # --- locate appimagetool (avoid FUSE: extract its AppImage) ---
+# Pinned continuous-build asset + sha256 (same discipline as
+# fetch-*-resources scripts). The asset is replaced on upstream updates —
+# bump both values together when that happens.
+AIT_URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+AIT_SHA256="b90f4a8b18967545fda78a445b27680a1642f1ef9488ced28b65398f2be7add2"
 AIT=""
 if command -v appimagetool >/dev/null 2>&1; then
   AIT="appimagetool"
@@ -62,7 +67,11 @@ else
   AITBIN="$TMP/appimagetool.AppImage"
   if [ ! -s "$AITBIN" ]; then
     command -v wget >/dev/null 2>&1 || { echo "error: need wget to fetch appimagetool" >&2; exit 1; }
-    wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O "$AITBIN"
+    wget -q "$AIT_URL" -O "$AITBIN"
+    echo "$AIT_SHA256  $AITBIN" | sha256sum -c - || {
+      echo "error: appimagetool sha256 mismatch — the pinned upstream asset was likely replaced; update AIT_URL/AIT_SHA256" >&2
+      exit 1
+    }
   fi
   AITDIR="$TMP/ait"; mkdir -p "$AITDIR"
   # The appimagetool squashfs is plain gzip — the same offset-based extract

--- a/scripts/fix-appimage-wayland.sh
+++ b/scripts/fix-appimage-wayland.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Make a Tauri AppImage robust on pure-Wayland sessions (no XWayland).
+#
+# tauri's linuxdeploy-plugin-gtk injects `export GDK_BACKEND=x11` into the
+# AppImage's AppRun hook (a workaround for tauri#8541). On a session without
+# XWayland this makes GTK fail to initialize ("Failed to initialize GTK") even
+# though the app renders fine under Wayland. We let GDK auto-detect the backend
+# (preferring wayland) so the AppImage works both with and without XWayland.
+#
+# Usage:
+#   scripts/fix-appimage-wayland.sh <input.AppImage> [output.AppImage]
+#
+# Repackages the AppImage with appimagetool. appimagetool is fetched on demand
+# (its AppImage is extracted without FUSE to run on hosts that lack /dev/fuse).
+set -euo pipefail
+
+SRC="${1:?usage: $0 <input.AppImage> [output.AppImage]}"
+DST="${2:-${SRC%.AppImage}.wayland.AppImage}"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+APPDIR="$TMP/appdir"
+
+# --- pick an extractor ---
+# An AppImage is an ELF runtime followed by a squashfs image at a page-aligned
+# offset. unsquashfs with an explicit -o offset is the primary extractor: the
+# squashfs may be zstd-compressed (tauri's linuxdeploy output is), which
+# neither p7zip 16 (`7z` on ubuntu-24.04) nor 7-Zip < 24.09 can read, while
+# squashfs-tools supports zstd natively. 7z/7zz remain as fallback for hosts
+# without squashfs-tools.
+# $1 — destination directory ($SRC is the AppImage to extract).
+EXTRACT() {
+  local dest="$1" off
+  if command -v unsquashfs >/dev/null 2>&1; then
+    # The ELF runtime can contain the bytes "hsqs" itself (false positive),
+    # so try every match until unsquashfs accepts one as a real superblock.
+    while read -r off; do
+      if unsquashfs -f -d "$dest" -o "$off" "$SRC" >/dev/null 2>&1; then
+        return 0
+      fi
+      rm -rf "$dest"
+    done < <(grep -abo hsqs "$SRC" | cut -d: -f1)
+    echo "error: no valid squashfs superblock found in $SRC" >&2
+    return 1
+  elif command -v 7zz >/dev/null 2>&1; then
+    7zz x -y -o"$dest" "$SRC" >/dev/null
+  elif command -v 7z >/dev/null 2>&1; then
+    7z x -y -o"$dest" "$SRC" >/dev/null
+  else
+    echo "error: need unsquashfs, 7zz or 7z to extract the AppImage" >&2
+    exit 1
+  fi
+}
+
+# --- locate appimagetool (avoid FUSE: extract its AppImage) ---
+AIT=""
+if command -v appimagetool >/dev/null 2>&1; then
+  AIT="appimagetool"
+else
+  AITBIN="$TMP/appimagetool.AppImage"
+  if [ ! -s "$AITBIN" ]; then
+    command -v wget >/dev/null 2>&1 || { echo "error: need wget to fetch appimagetool" >&2; exit 1; }
+    wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O "$AITBIN"
+  fi
+  AITDIR="$TMP/ait"; mkdir -p "$AITDIR"
+  # The appimagetool squashfs is plain gzip — the same offset-based extract
+  # works (EXTRACT reads $SRC; point it at the AIT download for this call).
+  src_save="$SRC"; SRC="$AITBIN"
+  EXTRACT "$AITDIR"
+  SRC="$src_save"
+  chmod -R +x "$AITDIR/AppRun" "$AITDIR/usr/bin" "$AITDIR/usr/lib" 2>/dev/null || true
+  if [ -x "$AITDIR/squashfs-root/AppRun" ]; then
+    AIT="$AITDIR/squashfs-root/AppRun"
+  elif [ -x "$AITDIR/AppRun" ]; then
+    AIT="$AITDIR/AppRun"
+  else
+    echo "error: could not locate appimagetool AppRun" >&2
+    exit 1
+  fi
+fi
+
+command -v file >/dev/null 2>&1 || { echo "error: appimagetool needs 'file'" >&2; exit 1; }
+
+# --- extract target AppImage ---
+EXTRACT "$APPDIR"
+
+# --- patch GDK_BACKEND ---
+HOOK="$APPDIR/apprun-hooks/linuxdeploy-plugin-gtk.sh"
+if [ -f "$HOOK" ]; then
+  sed -i 's|^export GDK_BACKEND=x11.*|export GDK_BACKEND="${GDK_BACKEND:-wayland}"|' "$HOOK"
+fi
+
+# --- restore exec bits (7z drops them) ---
+chmod +x "$APPDIR/AppRun" "$APPDIR/AppRun.wrapped" 2>/dev/null || true
+find "$APPDIR/usr/bin" -type f -exec chmod +x {} \; 2>/dev/null || true
+find "$APPDIR/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1" -type f -exec chmod +x {} \; 2>/dev/null || true
+
+# --- repackage ---
+"$AIT" "$APPDIR" "$DST" >/dev/null
+echo "wrote $DST"

--- a/scripts/guard-tag-version.sh
+++ b/scripts/guard-tag-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Guard: a tag pushed without bumping tauri.conf.json would make the freshly
+# installed app OLDER than latest.json — an update prompt loop on every
+# start. Fail fast, before the expensive build. Used by both release jobs
+# (.github/workflows/release.yml).
+set -euo pipefail
+
+tag="${1:?usage: guard-tag-version.sh <tag>}"
+conf_version=$(jq -r .version src-tauri/tauri.conf.json)
+if [ "$conf_version" != "${tag#v}" ]; then
+  echo "::error::tag $tag does not match tauri.conf.json version $conf_version — bump the version first"
+  exit 1
+fi

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Extract the CHANGELOG.md section for this version so the draft release
+# body is the human-curated notes, not GitHub's auto-generated diff summary
+# (issue #94). The `## [Unreleased]` heading and deeper `###`/`####`
+# headings never match the `## [<semver>]` pattern, so only the target
+# version's block is captured (up to the next top-level `## [` heading).
+# Shared by both release jobs (.github/workflows/release.yml) so whichever
+# job finishes first writes identical notes into the same draft release.
+set -euo pipefail
+
+tag="${1:?usage: release-notes.sh <tag>}"
+version="${tag#v}"
+awk -v v="$version" '
+  /^## \[/ {
+    rest = substr($0, 5)
+    cb = index(rest, "]")
+    hdr = (cb > 0) ? substr(rest, 1, cb - 1) : rest
+    capture = (hdr == v)
+  }
+  capture { print }
+' CHANGELOG.md > release_notes.md
+
+# Fallback when the tag has no CHANGELOG section yet (a tag pushed before
+# the entry was added): keep a usable draft body instead of empty notes.
+if [ ! -s release_notes.md ]; then
+  echo "See CHANGELOG.md — no section for version $version yet." > release_notes.md
+  echo "::warning::No CHANGELOG.md section for $version — using stub release notes"
+fi

--- a/src-tauri/resources/README.md
+++ b/src-tauri/resources/README.md
@@ -11,6 +11,10 @@ At release time they are replaced with real content:
   `scripts/fetch-windows-resources.sh`
 - `onnxruntime.dll` — from the pinned microsoft/onnxruntime release
   (same script)
+- `libonnxruntime.so` — Linux twin of the above, from the pinned
+  microsoft/onnxruntime release (`scripts/fetch-linux-onnxruntime.sh`,
+  release.yml linux-packages job); bundled into the .deb/.AppImage for the
+  silero-native engine
 - `espeak-ng-data/` — copied out of the espeak-rs-sys build tree by the
   release workflow (`.github/workflows/release.yml`)
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -657,7 +657,7 @@ mod onnxruntime_lookup_tests {
         let bin = tmp.path().join("app").join("bin");
         let dylib = tmp.path().join("app").join("libonnxruntime.so");
         fs::create_dir_all(&bin).unwrap();
-        write_dylib(&dylib.parent().unwrap());
+        write_dylib(dylib.parent().unwrap());
 
         assert_eq!(find_bundled_onnxruntime(&bin), Some(dylib));
     }
@@ -673,7 +673,7 @@ mod onnxruntime_lookup_tests {
             .join("RuVox")
             .join("libonnxruntime.so");
         fs::create_dir_all(&bin).unwrap();
-        write_dylib(&dylib.parent().unwrap());
+        write_dylib(dylib.parent().unwrap());
 
         assert_eq!(find_bundled_onnxruntime(&bin), Some(dylib));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -450,10 +450,213 @@ pub fn init_platform_env() {
     }
 }
 
-/// No-op on platforms whose environment is provided by the packaging
-/// (nix wrapper sets `PIPER_ESPEAKNG_DATA_DIRECTORY` on Linux).
+/// Linux and other non-Windows platforms: packaged artifacts (.deb,
+/// .AppImage) install the vendored espeak-ng-data under Tauri's Linux
+/// resource layout (`<exe_dir>/../lib/<product>/espeak-ng-data`); point
+/// Piper at it. The nix wrapper sets `PIPER_ESPEAKNG_DATA_DIRECTORY`
+/// itself (system espeak) — an existing variable always wins, so dev runs
+/// and Nix builds are unaffected.
 #[cfg(not(windows))]
-pub fn init_platform_env() {}
+pub fn init_platform_env() {
+    if std::env::var_os("PIPER_ESPEAKNG_DATA_DIRECTORY").is_none() {
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(exe_dir) = exe.parent() {
+                if let Some(data) = find_bundled_espeak_data(exe_dir) {
+                    // SAFETY: called from main before any threads exist.
+                    unsafe { std::env::set_var("PIPER_ESPEAKNG_DATA_DIRECTORY", data) };
+                }
+            }
+        }
+    }
+    // `ort` with `load-dynamic` dlopens libonnxruntime; without an explicit
+    // path it relies on the OS loader search, which does NOT include the
+    // install dir on Linux (unlike Windows, where the exe dir is searched).
+    // Point it at the bundled copy — an existing variable always wins, so
+    // the nix wrapper (system onnxruntime) is unaffected. The size guard
+    // skips the committed placeholder so a placeholder build degrades to
+    // Piper instead of failing the dlopen.
+    if std::env::var_os("ORT_DYLIB_PATH").is_none() {
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(exe_dir) = exe.parent() {
+                if let Some(dylib) = find_bundled_onnxruntime(exe_dir) {
+                    // SAFETY: called from main before any threads exist.
+                    unsafe { std::env::set_var("ORT_DYLIB_PATH", dylib) };
+                }
+            }
+        }
+    }
+}
+
+/// Search the install layouts a bundled Linux build can have for
+/// `espeak-ng-data`: flat/portable (`<exe_dir>/espeak-ng-data`) and the
+/// shared `/usr/bin` + `/usr/lib/<product>` layout of both `.deb` and
+/// `.AppImage`. Returns `None` when nothing is bundled — piper-rs then uses
+/// its built-in search (degraded Russian stress, still functional), matching
+/// pre-packaging behavior.
+#[cfg(not(windows))]
+fn find_bundled_espeak_data(exe_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let parent = exe_dir.parent()?;
+    let mut candidates = vec![
+        exe_dir.join("espeak-ng-data"),
+        parent.join("espeak-ng-data"),
+    ];
+    let lib = parent.join("lib");
+    if let Ok(entries) = std::fs::read_dir(&lib) {
+        // Multiple products could be installed; sort for determinism.
+        let mut bundled: Vec<_> = entries
+            .flatten()
+            .map(|e| e.path().join("espeak-ng-data"))
+            .collect();
+        bundled.sort();
+        candidates.append(&mut bundled);
+    }
+    candidates.into_iter().find(|c| c.is_dir())
+}
+
+/// Same install-layout search as [`find_bundled_espeak_data`], but for the
+/// bundled `libonnxruntime.so` file. Returns `None` (→ keep the default
+/// loader search / Piper fallback) when only the committed placeholder is
+/// present, so a placeholder build never points `ort` at a broken dylib.
+#[cfg(not(windows))]
+fn find_bundled_onnxruntime(exe_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let parent = exe_dir.parent()?;
+    let mut candidates = vec![
+        exe_dir.join("libonnxruntime.so"),
+        parent.join("libonnxruntime.so"),
+    ];
+    let lib = parent.join("lib");
+    if let Ok(entries) = std::fs::read_dir(&lib) {
+        let mut bundled: Vec<_> = entries
+            .flatten()
+            .map(|e| e.path().join("libonnxruntime.so"))
+            .collect();
+        bundled.sort();
+        candidates.append(&mut bundled);
+    }
+    candidates
+        .into_iter()
+        .find(|c| c.is_file() && std::fs::metadata(c).map(|m| m.len() > 0).unwrap_or(false))
+}
+
+#[cfg(all(test, not(windows)))]
+mod espeak_lookup_tests {
+    use super::find_bundled_espeak_data;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn touch_data(dir: &std::path::Path) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("ru_dict"), b"").unwrap();
+    }
+
+    #[test]
+    fn finds_flat_portable_layout() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("app").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        let data = tmp.path().join("app").join("espeak-ng-data");
+        touch_data(&data);
+
+        assert_eq!(find_bundled_espeak_data(&bin), Some(data));
+    }
+
+    #[test]
+    fn finds_deb_and_appimage_layout() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        let data = tmp
+            .path()
+            .join("usr")
+            .join("lib")
+            .join("RuVox")
+            .join("espeak-ng-data");
+        fs::create_dir_all(&bin).unwrap();
+        touch_data(&data);
+
+        assert_eq!(find_bundled_espeak_data(&bin), Some(data));
+    }
+
+    #[test]
+    fn none_when_not_bundled() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+
+        assert_eq!(find_bundled_espeak_data(&bin), None);
+    }
+
+    #[test]
+    fn ignores_incomplete_bundles() {
+        // A lib/ product dir without the data dir must not shadow a later
+        // candidate; with no other candidates the result is None.
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        fs::create_dir_all(tmp.path().join("usr").join("lib").join("Other")).unwrap();
+        fs::create_dir_all(&bin).unwrap();
+
+        assert_eq!(find_bundled_espeak_data(&bin), None);
+    }
+}
+
+#[cfg(all(test, not(windows)))]
+mod onnxruntime_lookup_tests {
+    use super::find_bundled_onnxruntime;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_dylib(dir: &std::path::Path) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("libonnxruntime.so"), b"ELF payload").unwrap();
+    }
+
+    #[test]
+    fn finds_flat_portable_layout() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("app").join("bin");
+        let dylib = tmp.path().join("app").join("libonnxruntime.so");
+        fs::create_dir_all(&bin).unwrap();
+        write_dylib(&dylib.parent().unwrap());
+
+        assert_eq!(find_bundled_onnxruntime(&bin), Some(dylib));
+    }
+
+    #[test]
+    fn finds_deb_and_appimage_layout() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        let dylib = tmp
+            .path()
+            .join("usr")
+            .join("lib")
+            .join("RuVox")
+            .join("libonnxruntime.so");
+        fs::create_dir_all(&bin).unwrap();
+        write_dylib(&dylib.parent().unwrap());
+
+        assert_eq!(find_bundled_onnxruntime(&bin), Some(dylib));
+    }
+
+    #[test]
+    fn none_when_not_bundled() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+
+        assert_eq!(find_bundled_onnxruntime(&bin), None);
+    }
+
+    #[test]
+    fn ignores_placeholder_file() {
+        // The committed 0-byte placeholder must not be picked up: ort would
+        // fail the dlopen instead of falling back to Piper.
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("libonnxruntime.so"), b"").unwrap();
+
+        assert_eq!(find_bundled_onnxruntime(&bin), None);
+    }
+}
 
 /// Diagnostic logging: LogDir always, Stdout in debug builds (#202).
 /// `RUST_LOG` overrides the level (level names only, default `info`).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -501,13 +501,21 @@ fn find_bundled_espeak_data(exe_dir: &std::path::Path) -> Option<std::path::Path
         parent.join("espeak-ng-data"),
     ];
     let lib = parent.join("lib");
+    // Our own product dir first — a wildcard over sibling products must be
+    // last so another app's files can never shadow ours.
     if let Ok(entries) = std::fs::read_dir(&lib) {
-        // Multiple products could be installed; sort for determinism.
         let mut bundled: Vec<_> = entries
             .flatten()
             .map(|e| e.path().join("espeak-ng-data"))
             .collect();
         bundled.sort();
+        if let Some(pos) = bundled
+            .iter()
+            .position(|p| p.ends_with("RuVox/espeak-ng-data"))
+        {
+            let ours = bundled.remove(pos);
+            candidates.push(ours);
+        }
         candidates.append(&mut bundled);
     }
     candidates.into_iter().find(|c| c.is_dir())
@@ -525,12 +533,22 @@ fn find_bundled_onnxruntime(exe_dir: &std::path::Path) -> Option<std::path::Path
         parent.join("libonnxruntime.so"),
     ];
     let lib = parent.join("lib");
+    // Our own product dir first — a wildcard over sibling products must be
+    // last so another app's ABI-incompatible libonnxruntime can never shadow
+    // ours (the pinned ort-sys bindings target ONNX Runtime 1.24).
     if let Ok(entries) = std::fs::read_dir(&lib) {
         let mut bundled: Vec<_> = entries
             .flatten()
             .map(|e| e.path().join("libonnxruntime.so"))
             .collect();
         bundled.sort();
+        if let Some(pos) = bundled
+            .iter()
+            .position(|p| p.ends_with("RuVox/libonnxruntime.so"))
+        {
+            let ours = bundled.remove(pos);
+            candidates.push(ours);
+        }
         candidates.append(&mut bundled);
     }
     candidates
@@ -596,6 +614,30 @@ mod espeak_lookup_tests {
 
         assert_eq!(find_bundled_espeak_data(&bin), None);
     }
+
+    #[test]
+    fn prefers_own_product_dir_over_siblings() {
+        // Another product's espeak-ng-data must never shadow ours.
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        let other = tmp
+            .path()
+            .join("usr")
+            .join("lib")
+            .join("ZProduct")
+            .join("espeak-ng-data");
+        let ours = tmp
+            .path()
+            .join("usr")
+            .join("lib")
+            .join("RuVox")
+            .join("espeak-ng-data");
+        fs::create_dir_all(&bin).unwrap();
+        touch_data(&other);
+        touch_data(&ours);
+
+        assert_eq!(find_bundled_espeak_data(&bin), Some(ours));
+    }
 }
 
 #[cfg(all(test, not(windows)))]
@@ -655,6 +697,24 @@ mod onnxruntime_lookup_tests {
         fs::write(bin.join("libonnxruntime.so"), b"").unwrap();
 
         assert_eq!(find_bundled_onnxruntime(&bin), None);
+    }
+
+    #[test]
+    fn prefers_own_product_dir_over_siblings() {
+        // Another product's libonnxruntime must never shadow ours: the
+        // pinned ort-sys bindings target a specific ONNX Runtime ABI.
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("usr").join("bin");
+        let other = tmp.path().join("usr").join("lib").join("ZProduct");
+        let ours = tmp.path().join("usr").join("lib").join("RuVox");
+        fs::create_dir_all(&bin).unwrap();
+        write_dylib(&other);
+        write_dylib(&ours);
+
+        assert_eq!(
+            find_bundled_onnxruntime(&bin),
+            Some(ours.join("libonnxruntime.so"))
+        );
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,9 +25,6 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "nsis"
-    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -35,21 +32,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "windows": {
-      "webviewInstallMode": {
-        "type": "embedBootstrapper"
-      },
-      "nsis": {
-        "installerHooks": "./windows/hooks.nsh"
-      }
-    },
-    "createUpdaterArtifacts": true,
-    "resources": {
-      "resources/mpv": "mpv",
-      "resources/espeak-ng-data": "espeak-ng-data",
-      "resources/onnxruntime.dll": "onnxruntime.dll",
-      "resources/crt/*.dll": "./"
-    }
+    "createUpdaterArtifacts": true
   },
   "plugins": {
     "updater": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": [
+      "deb",
+      "appimage"
+    ],
+    "resources": {
+      "resources/espeak-ng-data": "espeak-ng-data",
+      "resources/libonnxruntime.so": "libonnxruntime.so"
+    },
+    "createUpdaterArtifacts": false
+  }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": [
+      "nsis"
+    ],
+    "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper"
+      },
+      "nsis": {
+        "installerHooks": "./windows/hooks.nsh"
+      }
+    },
+    "resources": {
+      "resources/mpv": "mpv",
+      "resources/espeak-ng-data": "espeak-ng-data",
+      "resources/onnxruntime.dll": "onnxruntime.dll",
+      "resources/crt/*.dll": "./"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Linux release packages now work out of the box:

- **Bundled runtime resources** — `.deb` and `.AppImage` ship `espeak-ng-data/` and a pinned, sha256-verified `libonnxruntime.so` (1.24.1, matching the `ort-sys` ABI). At startup `init_platform_env` resolves them (own product dir first, placeholder rejection, wrapper-provided env keeps priority) and sets `PIPER_ESPEAKNG_DATA_DIRECTORY` / `ORT_DYLIB_PATH`. Previously Silero Native hung silently at ONNX session creation on clean systems.
- **Local Docker builder** — `scripts/build-linux-packages.sh [deb|appimage|both]` replicates the release workflow's linux-packages job in a stock `ubuntu:24.04` container; artifacts land in `tmp/docker-out/`.
- **Pure-Wayland AppImage** — repack step (local + CI) drops the hardcoded `GDK_BACKEND=x11`; squashfs extraction via `unsquashfs -o <offset>` (zstd-safe), appimagetool pinned by sha256.
- **CI** — the linux-packages job applies the same wayland fix and fetch script as local builds.
- **Specs** — new `linux-runtime` capability + `windows-runtime` delta, archived as `2026-08-24-linux-runtime-bundling`; CHANGELOG Unreleased updated.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` green (1012 lib tests incl. lookup priority/placeholder tests); fmt/clippy (`--all-targets`) clean
- [x] VM manual pass (Ubuntu 24.04, pure Wayland): `.deb` and AppImage both launch, engine loads from bundled dylib (confirmed via `/proc/<pid>/maps`), Russian synthesis + playback verified end-to-end
- [x] ruvox-reviewer pass over branch diff; all findings fixed or deferred with rationale (env-priority unit test)