### PR TITLE
chore(infra,docs): add issue/PR templates and fix storefront leftovers (#229)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Something isn't working in RuVox
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to file a bug. Please search
+        [existing issues](https://github.com/xilec/RuVox/issues?q=is%3Aissue) first.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open …
+        2. Click …
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: RuVox version
+      description: The release tag (e.g. v0.4.0) or the commit the app was built from.
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Attach the relevant file from the logs folder (Settings → open logs).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Idea or enhancement proposal
+labels: ["enhancement", "type:idea"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Ideas start as issues; accepted ones go through an OpenSpec change
+        before implementation (see docs/contributing.md).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What can't you do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What and why. Link the issue: "Closes #N" -->
+
+## Testing
+
+- [ ] `just test` green (Rust + TS + Python)
+- [ ] `just lint` green
+- [ ] Manual pass done for UI/behavior changes (or N/A)
+
+## OpenSpec
+
+- [ ] Behavior change carries an OpenSpec change (delta specs synced, change archived), or N/A
+
+<!--
+PR titles feed CHANGELOG.md — keep the `<type>(<module>): <desc>` convention
+and write them in English.
+-->

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,7 +162,7 @@ uninstaller's "Delete the application data" checkbox can remove it):
 Installs from before 2026-08 keep their files in `~/.cache/ruvox/`; the first
 launch of a current build migrates them automatically (issue #222).
 
-See [Storage schema](storage-schema.md) for details.
+See [Storage schema](../openspec/specs/storage/spec.md) for details.
 
 ## Workflow
 

--- a/scripts/launch-prod.sh
+++ b/scripts/launch-prod.sh
@@ -7,7 +7,7 @@
 # subprocess) via the fallback path in src-tauri/src/lib.rs.
 set -euo pipefail
 
-REPO_DIR="/home/evgen/work/github/RuVox"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Matches rebuild_prod.sh's CARGO_TARGET_DIR override (short path — see that
 # script for why), falling back to the in-tree default for binaries built

--- a/src-tauri/src/tts/availability.rs
+++ b/src-tauri/src/tts/availability.rs
@@ -3,7 +3,7 @@
 //!
 //! Piper is in-process and always available — its model files may be
 //! missing, but engine itself loads, and a missing voice surfaces from
-//! synthesis as `voice_not_installed` (Phase 4 will offer to download it).
+//! synthesis as `voice_not_installed` (the app then offers to download it).
 //! Silero requires the `ttsd/` Python package, the `uv` toolchain to drive
 //! its venv, and (transitively) the torch + Silero model. The probe is
 //! cheap on purpose: it only checks the directory + `uv --version` so app

--- a/src-tauri/src/tts/piper/engine.rs
+++ b/src-tauri/src/tts/piper/engine.rs
@@ -113,8 +113,7 @@ impl PiperEngine {
             return Err(TtsError::Ttsd {
                 code: "voice_not_installed".to_string(),
                 message: format!(
-                    "Piper voice \"{voice_id}\" не установлен ({}). \
-                     Загрузка по требованию будет добавлена в Phase 4.",
+                    "Piper voice \"{voice_id}\" не установлен ({}).",
                     config_path.display()
                 ),
             });
@@ -170,8 +169,7 @@ impl TtsEngine for PiperEngine {
             let config_path = PiperEngine::config_path_for(&voices_dir, &voice_id);
             if !config_path.exists() {
                 let msg = format!(
-                    "Piper voice \"{voice_id}\" не установлен ({}). \
-                     Загрузка по требованию будет добавлена в Phase 4.",
+                    "Piper voice \"{voice_id}\" не установлен ({}).",
                     config_path.display()
                 );
                 warn!(target: "tts::piper", "warmup skipped: {msg}");


### PR DESCRIPTION
Closes #229.

## Summary
- Add GitHub issue templates (bug report, feature request) and a PR template; docs/contributing.md sends users to "open an issue" but no templates existed.
- Point the dead `[Storage schema](storage-schema.md)` link in docs/development.md at `openspec/specs/storage/spec.md`.
- `scripts/launch-prod.sh`: derive `REPO_DIR` from the script location instead of a hardcoded absolute path.
- Drop the stale "on-demand download coming in Phase 4" promise from the Piper `voice_not_installed` messages and the availability doc comment — on-demand download is implemented.

## Testing
- `just lint` green; `cargo test … piper` — 19 passed; REPO_DIR derivation verified.
- Repo topics are applied separately via `gh repo edit` (repo settings, not files).