### PR TITLE
feat(queue): add per-entry audio export

### DIFF
--- a/openspec/changes/add-audio-export/.openspec.yaml
+++ b/openspec/changes/add-audio-export/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/add-audio-export/design.md
+++ b/openspec/changes/add-audio-export/design.md
@@ -1,0 +1,87 @@
+# Design: add-audio-export
+
+## Context
+
+Audio is stored under `<data_dir>/audio/` as Ogg-Opus (transcoded from the
+raw WAV at synthesis, `replace_wav_with_opus`) with a `.wav` fallback when
+the transcode fails; `TextEntry.audio_path` holds the file name. The repo
+already has an rfd-backend dialog precedent — `pick_import_file` (#224) —
+which deliberately avoids the dialog plugin and its capability surface. The
+queue context menu (QueueList.tsx) is the per-entry action surface; its
+Play item already gates on `ready`/`playing`.
+
+## Goals / Non-goals
+
+- Goal: two clicks from a queue item to the audio file on disk, with the
+  native save dialog and a clear confirmation.
+- Non-goals: Opus→WAV transcoding on export (needs an Ogg-Opus decoder the
+  repo does not have), batch export, timestamps export, new plugins.
+
+## Decisions
+
+### D1: rfd backend, no dialog/fs plugins
+
+The save dialog runs backend-side on `tokio::task::spawn_blocking` via
+`rfd::FileDialog::save_file` — the exact pattern of `pick_import_file`
+(#224). This avoids `tauri-plugin-dialog` + `tauri-plugin-fs`, their JS
+counterparts, and capability scoping for arbitrary user-chosen paths; the
+copy happens inside the Rust process, which needs no fs scope at all.
+
+### D2: two commands, dialog separated from the copy
+
+`pick_export_audio_path(entry_id)` (dialog) and
+`export_audio(entry_id, path)` (copy) mirror the import split
+(`pick_import_file` / `read_text_file`). The split keeps the copy logic
+unit-testable without a real dialog: the export core is a dialog-free
+`export_audio_to(storage, entry_id, &path)` helper, with the `#[tauri::command]`
+wrappers around it. The pick command needs `entry_id` (not just a filter)
+because the backend derives both the default file name and the filter from
+the stored audio format.
+
+### D3: export as-is, no transcode
+
+The stored file is copied byte-for-byte — `.opus` (Ogg-Opus, the normal
+case) or `.wav` (transcode fallback). This covers the issue's "(Opus/WAV)"
+without an Ogg-Opus decoder (only an encoder exists in `src/audio`). The
+save-dialog filter and default name (`ruvox-<entry_id>.<ext>`) follow the
+stored extension. `export_audio` never mutates the cache and emits no
+`entry_updated`.
+
+### D4: error mapping
+
+Reuses the `CommandError` taxonomy: `entry.not_found` (existing),
+`export.no_audio` (no `audio_path` on the entry, or the file is gone — e.g.
+cache eviction), `export.copy_failed` (I/O error, message param carries the
+OS error). Codes localize under `errors.export.*` in both catalogs;
+frontend failure handling is the standard red notification pattern
+(`errors.title` + `formatError`).
+
+### D5: UI wiring
+
+The menu item «Сохранить аудио как…» sits between «Воспроизвести» and
+«Перегенерировать аудио», gated like Play (`ready`/`playing`). Handler:
+pick → `null` = silent no-op → export → success notification «Аудио
+сохранено: {0}» (path as the param) / red error on rejection. No modal
+confirmation needed — the action creates a file and overwrites nothing the
+app owns; the OS save dialog itself asks about overwrites.
+
+## Risks / Trade-offs
+
+- **Two IPC round-trips per export** instead of one combined command:
+  consistent with the import split and keeps rfd dialog usage out of the
+  testable core; the cost is negligible for a user-initiated action.
+- **rfd save dialog on the blocking pool**: same as the import picker —
+  modal-blocking, off the tokio reactor, no timeout needed (user-driven).
+- **Export of an evicted file fails late** (dialog first, copy second):
+  accepted; the error names the cause and the cache is the source of truth.
+- **`ruvox-<uuid>.opus` default name is not human-friendly**: acceptable
+  MVP; the user renames in the dialog. A text-derived slug risks path
+ -illegal characters and encoding issues for no functional gain.
+
+## Migration Plan
+
+None — additive commands and a menu item.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-audio-export/proposal.md
+++ b/openspec/changes/add-audio-export/proposal.md
@@ -1,0 +1,48 @@
+# Proposal: add-audio-export
+
+## Why
+
+There is no audio export: the only way to reach a synthesized file is
+"Open cache folder" in Settings, which exposes the raw cache layout
+(`audio/<uuid>.opus|.wav` names) and requires manual copying. The user
+needs a per-entry "Save audio as…" action that writes the entry's audio to
+a user-chosen path. (Issue #225; acceptance: the user can export an entry's
+audio to disk.)
+
+## What Changes
+
+1. **Two backend commands** (the #224 rfd-backend pattern — no dialog/fs
+   plugins, no capability changes):
+   - `pick_export_audio_path(entry_id)` — native save dialog (rfd,
+     `spawn_blocking`), pre-filled name `ruvox-<entry_id>.<ext>` and a file
+     filter matching the entry's stored audio format (`.opus` normal case,
+     `.wav` fallback); returns the chosen path or `null` on cancel.
+   - `export_audio(entry_id, path)` — copies the entry's stored audio file
+     from the storage audio dir to the target path. Errors:
+     `entry.not_found`, `export.no_audio` (no audio file on disk),
+     `export.copy_failed`.
+2. **Queue context menu item** «Сохранить аудио как…» (after «Воспроизвести»),
+   enabled for `ready`/`playing` entries — the same gate as Play. On
+   success a confirmation notification shows the target path; a cancelled
+   dialog is a silent no-op; failures surface the localized red error.
+3. **README** «Как управлять»/export mention is out of scope — the feature is
+   self-evident from the menu; the CHANGELOG entry is proposed separately at
+   review time.
+
+Export is a byte-for-byte copy of the stored file — the entry already holds
+Ogg-Opus (transcoded at synthesis) or WAV (transcode fallback), so the
+issue's "Opus/WAV" is covered by exporting what is on disk. No transcode,
+no decoder dependency.
+
+## Impact
+
+- **Affected specs:** `ipc-commands` (new "Audio Export Commands"
+  requirement), `ui` ("Queue list behavior" — new menu item + flow).
+- **Affected code:**
+  - `src-tauri/src/commands/mod.rs` (or a sibling module): the two commands
+    + registration; a dialog-free `export_audio_to` core for unit tests.
+  - `src/lib/tauri.ts` — `pickExportAudioPath`, `exportAudio` wrappers.
+  - `src/components/QueueList.tsx` — menu item + handler; `src/i18n/{ru,en}.ts`
+    — menu/notification/error strings.
+- **Out of scope:** Opus→WAV transcoding on export, batch export, export of
+  timestamps.

--- a/openspec/changes/add-audio-export/specs/ipc-commands/spec.md
+++ b/openspec/changes/add-audio-export/specs/ipc-commands/spec.md
@@ -23,8 +23,10 @@ byte-for-byte to `path` on the blocking thread, and return `Unit`. The copy
 MUST NOT modify the cached original. A missing entry SHALL fail with
 `entry.not_found`; a missing source file SHALL fail with `export.no_audio`;
 an I/O failure of the copy SHALL fail with `export.copy_failed` carrying the
-underlying error as a message param. The commands MUST NOT create history
-or queue side effects — no `entry_updated` emission, no status change.
+underlying error as a message param. A panicked blocking task SHALL fail
+with `export.dialog_panicked` (pick) or `export.task_panicked` (copy). The
+commands MUST NOT create history or queue side effects — no `entry_updated`
+emission, no status change.
 
 The frontend wrappers SHALL be `commands.pickExportAudioPath(entryId)` and
 `commands.exportAudio(entryId, path)`.

--- a/openspec/changes/add-audio-export/specs/ipc-commands/spec.md
+++ b/openspec/changes/add-audio-export/specs/ipc-commands/spec.md
@@ -1,0 +1,65 @@
+# IPC Commands — Audio Export (delta)
+
+## ADDED Requirements
+
+### Requirement: Audio Export Commands
+
+The system SHALL expose two Tauri commands for per-entry audio export
+(issue #225), following the #224 rfd-backend pattern (no dialog/fs plugin,
+no capability changes):
+
+`pick_export_audio_path(entry_id)` SHALL read the entry under the storage
+lock, derive the save-dialog default name `ruvox-<entry_id>.<ext>` and a
+file filter from the entry's stored audio format — `Ogg Opus`/`opus` for an
+`.opus` file, `WAV`/`wav` for a `.wav` file — open the native save dialog on
+the blocking thread (the dialog is modal-blocking and must not run on the
+tokio reactor), and return the chosen path as `Option<String>`: `None` when
+the user cancels. A missing entry SHALL fail with `entry.not_found`; an
+entry without a stored `audio_path` SHALL fail with `export.no_audio`.
+
+`export_audio(entry_id, path)` SHALL resolve the entry's stored audio file
+under the storage lock (`audio/<audio_path>` inside the data dir), copy it
+byte-for-byte to `path` on the blocking thread, and return `Unit`. The copy
+MUST NOT modify the cached original. A missing entry SHALL fail with
+`entry.not_found`; a missing source file SHALL fail with `export.no_audio`;
+an I/O failure of the copy SHALL fail with `export.copy_failed` carrying the
+underlying error as a message param. The commands MUST NOT create history
+or queue side effects — no `entry_updated` emission, no status change.
+
+The frontend wrappers SHALL be `commands.pickExportAudioPath(entryId)` and
+`commands.exportAudio(entryId, path)`.
+
+#### Scenario: Save dialog is filtered by the stored format
+
+- GIVEN an entry whose stored audio file is `audio/<id>.opus`
+- WHEN `pick_export_audio_path` is invoked for the entry
+- THEN the save dialog opens pre-filled with `ruvox-<id>.opus` and an
+  `Ogg Opus`/`opus` filter, and the chosen path is returned
+
+#### Scenario: Cancelled dialog resolves to null
+
+- GIVEN the save dialog is open for an entry
+- WHEN the user cancels the dialog
+- THEN the command resolves to `null` and no file is written
+
+#### Scenario: Export copies the stored file
+
+- GIVEN an entry with a stored audio file and a chosen target path
+- WHEN `export_audio` is invoked
+- THEN the cached file is copied byte-for-byte to the target path, the cache
+  file remains in place, and no `entry_updated` is emitted
+
+#### Scenario: Export without audio fails
+
+- GIVEN an entry whose `audio_path` is `None` or whose cached audio file has
+  been evicted
+- WHEN `export_audio` is invoked
+- THEN the command rejects with `export.no_audio` and no file is written
+
+#### Scenario: Export to an unwritable target fails
+
+- GIVEN a chosen target path whose copy fails at the OS level (e.g. a
+  read-only directory)
+- WHEN `export_audio` is invoked
+- THEN the command rejects with `export.copy_failed` and the localized error
+  is shown by the frontend

--- a/openspec/changes/add-audio-export/specs/ui/spec.md
+++ b/openspec/changes/add-audio-export/specs/ui/spec.md
@@ -1,0 +1,56 @@
+# UI — Queue Context Menu Audio Export (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Queue list behavior
+
+The system SHALL load entries on mount via `commands.getEntries()` sorted by `created_at` descending, and SHALL keep the list in sync by listening to `events.entryUpdated` (prepend new entries, replace existing ones in place) and `events.entryRemoved` (remove and clear the selection if the selected entry was deleted).
+
+Each queue item SHALL show a 60-character preview of `original_text`, a status badge (Ожидание/Обработка/Готово/Играет/Ошибка), the duration when available, and a Play action enabled only for `ready`/`playing` entries. Clicking an item SHALL store it as the selected entry in the Zustand `selectedEntry` store.
+
+Right-clicking an item SHALL open a context menu with "Воспроизвести", "Сохранить аудио как…", "Перегенерировать аудио" and "Удалить". The "Сохранить аудио как…" item SHALL be enabled under the same gate as Play (`ready`/`playing` entries). Activating it SHALL call `commands.pickExportAudioPath(entryId)`; a `null` result (cancelled dialog) SHALL be a silent no-op; a chosen path SHALL be handed to `commands.exportAudio(entryId, path)`, and on success a confirmation notification SHALL show the target path. Failures SHALL surface the localized red error notification. Deletion MUST be confirmed via `modals.openConfirmModal` before calling `commands.deleteEntry`.
+
+The navbar search input SHALL filter entries case-insensitively by `original_text` substring; when the playing entry is scrolled out of view, a floating "К читаемому" button SHALL appear that selects and scrolls to the playing entry.
+
+#### Scenario: New entry appears at the top
+
+- GIVEN the queue shows existing entries
+- WHEN an `entry_updated` event arrives with an entry id not in the list
+- THEN the entry is prepended and the list remains sorted by `created_at` descending
+
+#### Scenario: Delete requires confirmation
+
+- GIVEN a queue item's context menu is open
+- WHEN the user clicks "Удалить"
+- THEN a confirmation modal appears, and only after confirming does the system call `commands.deleteEntry` and remove the item
+
+#### Scenario: Search filters the list
+
+- GIVEN the queue contains entries
+- WHEN the user types into "Поиск по записям"
+- THEN only entries whose `original_text` contains the query (case-insensitive) remain visible, or "Ничего не найдено" is shown when none match
+
+#### Scenario: Export a ready entry's audio
+
+- GIVEN an entry with status `ready` and a stored audio file
+- WHEN the user activates "Сохранить аудио как…" and chooses a target path
+- THEN `commands.exportAudio` is called with the entry id and the chosen
+  path, and a confirmation notification with the path is shown
+
+#### Scenario: Cancelled save dialog does nothing
+
+- GIVEN the save dialog opened from "Сохранить аудио как…"
+- WHEN the user cancels it
+- THEN no export command is invoked and no notification is shown
+
+#### Scenario: Export failure surfaces an error
+
+- GIVEN an entry whose cached audio file has been evicted
+- WHEN the user activates "Сохранить аудио как…" and chooses a target path
+- THEN a red error notification is shown and no success notification appears
+
+#### Scenario: Export is disabled for pending entries
+
+- GIVEN an entry with status `pending` or `processing` or `error`
+- WHEN the item's context menu is open
+- THEN "Сохранить аудио как…" is disabled

--- a/openspec/changes/add-audio-export/tasks.md
+++ b/openspec/changes/add-audio-export/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: add-audio-export
+
+## 1. Backend
+
+- [x] 1.1 `src-tauri/src/commands/mod.rs` (or a sibling module): add
+      `pick_export_audio_path(entry_id)` — storage read of the entry under
+      the lock, `rfd::FileDialog::save_file` with the stored-format filter
+      and `ruvox-<entry_id>.<ext>` default name on `spawn_blocking`;
+      `entry.not_found` / `export.no_audio` errors; `None` on cancel.
+- [x] 1.2 Add the dialog-free `export_audio_to(storage, entry_id, path)`
+      core (resolve `audio/<audio_path>` under the lock, blocking copy) and
+      the `export_audio(entry_id, path)` command wrapper; errors
+      `entry.not_found` / `export.no_audio` / `export.copy_failed`; register
+      both commands in the invoke handler.
+
+## 2. Backend tests
+
+- [x] 2.1 Unit tests for `export_audio_to` via the storage test util:
+      success copies bytes and leaves the cache file intact; missing
+      `audio_path` / missing file → `export.no_audio`; missing entry →
+      `entry.not_found`; copy into a nonexistent directory →
+      `export.copy_failed`.
+
+## 3. Frontend
+
+- [x] 3.1 `src/lib/tauri.ts`: `pickExportAudioPath(entryId)` and
+      `exportAudio(entryId, path)` wrappers.
+- [x] 3.2 `src/i18n/{ru,en}.ts`: `queue.menu.export_audio`
+      («Сохранить аудио как…»), `notify.export.ok` («Аудио сохранено: {0}»),
+      `errors.export.no_audio`, `errors.export.copy_failed`.
+- [x] 3.3 `src/components/QueueList.tsx`: menu item between Play and
+      Regenerate, gated like Play; handler pick → cancel no-op → export →
+      success notification with path / red error via `formatError`.
+
+## 4. Frontend tests
+
+- [x] 4.1 `QueueList.test.tsx`: menu action invokes pick + export with the
+      entry id and chosen path, shows the success notification; cancelled
+      pick invokes nothing else; rejected export shows the red error;
+      disabled for non-ready/non-playing entries.
+
+## 5. Validation
+
+- [x] 5.1 `nix develop -c just lint` and `nix develop -c just test` green.
+- [ ] 5.2 Manual pass (checklist to the user): export a ready entry on real
+       storage — dialog pre-filled, file lands on disk and plays; cancel is
+       a no-op; error paths surface localized messages; no `entry_updated`
+       side effects.
+- [ ] 5.3 Propose the additive `CHANGELOG.md` `[Unreleased]` entry as a diff
+      for user approval (human-owned file).

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,0 +1,81 @@
+//! Export command cluster (audio-export spec, #225): save-dialog picker and
+//! a byte-for-byte copy of an entry's stored audio file. Split out of
+//! `mod.rs` along the domain seam like `import.rs`; errors map onto the
+//! `export.*` wire codes here. Follows the #224 rfd-backend pattern — no
+//! dialog/fs plugin, no capability surface.
+
+use std::path::Path;
+
+use super::*;
+
+/// Dialog-free export core (unit-testable without rfd): resolve the entry's
+/// cached audio file under the storage lock, then copy it to the target on
+/// the caller's thread. The command wrapper puts this on the blocking pool.
+/// A vanished source file maps to `export.no_audio` (cache eviction), any
+/// other I/O failure to `export.copy_failed`.
+pub(crate) fn export_audio_to(storage: &StorageService, id: &str, target: &Path) -> CmdResult<()> {
+    let entry = require_entry(storage, id)?;
+    let audio_name = entry
+        .audio_path
+        .ok_or_else(|| CommandError::not_found("export.no_audio", vec![id.to_string()]))?;
+    let source = storage.data_dir().join("audio").join(&audio_name);
+    if !source.is_file() {
+        return Err(CommandError::not_found("export.no_audio", vec![audio_name]));
+    }
+    std::fs::copy(&source, target)
+        .map(|_| ())
+        .map_err(|e| CommandError::internal("export.copy_failed", vec![e.to_string()]))
+}
+
+/// Open the native save dialog for an entry's audio (#225): the default
+/// name and the file filter follow the stored audio format (`Ogg Opus` for
+/// `.opus`, `WAV` for `.wav`). Returns the chosen path or `None` on cancel.
+/// The dialog is modal-blocking, so it runs on the blocking pool (the
+/// #224 `pick_import_file` pattern).
+#[tauri::command]
+pub async fn pick_export_audio_path(
+    state: State<'_, AppState>,
+    id: String,
+) -> CmdResult<Option<String>> {
+    let entry = require_entry(&state.storage, &id)?;
+    let audio_name = entry
+        .audio_path
+        .ok_or_else(|| CommandError::not_found("export.no_audio", vec![id.clone()]))?;
+    let ext = Path::new(&audio_name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("opus")
+        .to_string();
+    let default_name = format!("ruvox-{}.{}", entry.id, ext);
+    let (filter_name, filter_ext) = if ext == "wav" {
+        ("WAV", "wav")
+    } else {
+        ("Ogg Opus", "opus")
+    };
+
+    tokio::task::spawn_blocking(move || {
+        rfd::FileDialog::new()
+            .set_file_name(&default_name)
+            .add_filter(filter_name, &[filter_ext])
+            .save_file()
+            .map(|p| p.to_string_lossy().into_owned())
+    })
+    .await
+    .map_err(|e| {
+        CommandError::internal("export.dialog_panicked", vec![]).with_message(e.to_string())
+    })
+}
+
+/// Copy an entry's stored audio file to a user-chosen path (#225).
+/// Byte-for-byte: the cache original is untouched and no `entry_updated`
+/// is emitted — exporting is not a queue event. The copy is I/O-bound, so
+/// it runs on the blocking pool.
+#[tauri::command]
+pub async fn export_audio(state: State<'_, AppState>, id: String, path: String) -> CmdResult<()> {
+    let storage = Arc::clone(&state.storage);
+    tokio::task::spawn_blocking(move || export_audio_to(&storage, &id, Path::new(&path)))
+        .await
+        .map_err(|e| {
+            CommandError::internal("export.task_panicked", vec![]).with_message(e.to_string())
+        })?
+}

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -8,30 +8,52 @@ use std::path::Path;
 
 use super::*;
 
+/// Pure default-name/filter derivation for the save dialog (unit-testable
+/// without rfd): the name follows the stored audio file's extension, and so
+/// does the filter — `Ogg Opus`/`opus` normally, `WAV`/`wav` for the
+/// synthesis-transcode fallback (a no-extension name falls back to `opus`).
+fn save_dialog_defaults(
+    entry_id: &EntryId,
+    audio_name: &str,
+) -> (String, &'static str, &'static str) {
+    let ext = Path::new(audio_name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("opus")
+        .to_string();
+    let (filter_name, filter_ext) = if ext == "wav" {
+        ("WAV", "wav")
+    } else {
+        ("Ogg Opus", "opus")
+    };
+    (
+        format!("ruvox-{}.{}", entry_id, ext),
+        filter_name,
+        filter_ext,
+    )
+}
+
 /// Dialog-free export core (unit-testable without rfd): resolve the entry's
 /// cached audio file under the storage lock, then copy it to the target on
 /// the caller's thread. The command wrapper puts this on the blocking pool.
-/// A vanished source file maps to `export.no_audio` (cache eviction), any
+/// A vanished cached file maps to `export.no_audio` (cache eviction), any
 /// other I/O failure to `export.copy_failed`.
 pub(crate) fn export_audio_to(storage: &StorageService, id: &str, target: &Path) -> CmdResult<()> {
-    let entry = require_entry(storage, id)?;
-    let audio_name = entry
-        .audio_path
+    let uuid = parse_entry_id(id)?;
+    // require_entry keeps `entry.not_found` distinct from `export.no_audio`.
+    require_entry(storage, id)?;
+    let source = storage
+        .get_audio_path(&uuid)
         .ok_or_else(|| CommandError::not_found("export.no_audio", vec![id.to_string()]))?;
-    let source = storage.data_dir().join("audio").join(&audio_name);
-    if !source.is_file() {
-        return Err(CommandError::not_found("export.no_audio", vec![audio_name]));
-    }
     std::fs::copy(&source, target)
         .map(|_| ())
         .map_err(|e| CommandError::internal("export.copy_failed", vec![e.to_string()]))
 }
 
 /// Open the native save dialog for an entry's audio (#225): the default
-/// name and the file filter follow the stored audio format (`Ogg Opus` for
-/// `.opus`, `WAV` for `.wav`). Returns the chosen path or `None` on cancel.
-/// The dialog is modal-blocking, so it runs on the blocking pool (the
-/// #224 `pick_import_file` pattern).
+/// name and the file filter follow the stored audio format. Returns the
+/// chosen path or `None` on cancel. The dialog is modal-blocking, so it
+/// runs on the blocking pool (the #224 `pick_import_file` pattern).
 #[tauri::command]
 pub async fn pick_export_audio_path(
     state: State<'_, AppState>,
@@ -41,17 +63,7 @@ pub async fn pick_export_audio_path(
     let audio_name = entry
         .audio_path
         .ok_or_else(|| CommandError::not_found("export.no_audio", vec![id.clone()]))?;
-    let ext = Path::new(&audio_name)
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("opus")
-        .to_string();
-    let default_name = format!("ruvox-{}.{}", entry.id, ext);
-    let (filter_name, filter_ext) = if ext == "wav" {
-        ("WAV", "wav")
-    } else {
-        ("Ogg Opus", "opus")
-    };
+    let (default_name, filter_name, filter_ext) = save_dialog_defaults(&entry.id, &audio_name);
 
     tokio::task::spawn_blocking(move || {
         rfd::FileDialog::new()
@@ -78,4 +90,35 @@ pub async fn export_audio(state: State<'_, AppState>, id: String, path: String) 
         .map_err(|e| {
             CommandError::internal("export.task_panicked", vec![]).with_message(e.to_string())
         })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_dialog_defaults_follow_the_opus_format() {
+        let id: EntryId = "550e8400-e29b-41d4-a716-446655440000".parse().unwrap();
+        let (name, filter_name, filter_ext) =
+            save_dialog_defaults(&id, "550e8400-e29b-41d4-a716-446655440000.opus");
+        assert_eq!(name, format!("ruvox-{id}.opus"));
+        assert_eq!((filter_name, filter_ext), ("Ogg Opus", "opus"));
+    }
+
+    #[test]
+    fn save_dialog_defaults_follow_the_wav_fallback() {
+        let id: EntryId = "550e8400-e29b-41d4-a716-446655440000".parse().unwrap();
+        let (name, filter_name, filter_ext) =
+            save_dialog_defaults(&id, "550e8400-e29b-41d4-a716-446655440000.wav");
+        assert_eq!(name, format!("ruvox-{id}.wav"));
+        assert_eq!((filter_name, filter_ext), ("WAV", "wav"));
+    }
+
+    #[test]
+    fn save_dialog_defaults_fall_back_to_opus_without_extension() {
+        let id: EntryId = "550e8400-e29b-41d4-a716-446655440000".parse().unwrap();
+        let (name, filter_name, filter_ext) = save_dialog_defaults(&id, "no-extension-name");
+        assert_eq!(name, format!("ruvox-{id}.opus"));
+        assert_eq!((filter_name, filter_ext), ("Ogg Opus", "opus"));
+    }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1596,6 +1596,10 @@ pub async fn fetch_image_bytes(url: String) -> CmdResult<Vec<u8>> {
 mod import;
 pub use import::{fetch_url_text, pick_import_file, read_text_file};
 
+// Audio export commands live in commands/export.rs (same domain-seam split).
+mod export;
+pub use export::{export_audio, pick_export_audio_path};
+
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 /// Shared HTTP client for [`fetch_image_bytes`] and [`fetch_url_text`].
@@ -2160,6 +2164,7 @@ mod tests {
     use super::*;
     use crate::storage::test_util::make_service;
     use std::collections::HashMap;
+    use std::path::Path;
     use test_case::test_case;
 
     // ── apply_config_patch ──────────────────────────────────────────────────
@@ -2888,6 +2893,100 @@ mod tests {
         );
         // One pre-download attempt, no retry after the failed download.
         assert_eq!(engine.recorded_voices(), vec!["ghost"]);
+    }
+
+    /// Seed a ready entry with a stored audio file: set `audio_path` and
+    /// write `audio/<name>` under the storage data dir.
+    fn seed_audio_entry(storage: &StorageService, audio_name: &str, contents: &[u8]) -> EntryId {
+        let mut entry = storage.add_entry("текст".to_string()).unwrap();
+        entry.audio_path = Some(audio_name.to_string());
+        entry.status = EntryStatus::Ready;
+        storage.update_entry(entry.clone()).unwrap();
+        let path = storage.data_dir().join("audio").join(audio_name);
+        std::fs::write(path, contents).unwrap();
+        entry.id
+    }
+
+    #[test]
+    fn export_audio_to_copies_bytes_and_keeps_cache_intact() {
+        let (storage, _dir) = make_service();
+        let contents = b"ogg opus payload";
+        let id = seed_audio_entry(&storage, "audio.opus", contents);
+        let target_dir = TempDir::new().unwrap();
+        let target = target_dir.path().join("export.opus");
+
+        super::export::export_audio_to(&storage, &id.to_string(), &target).unwrap();
+
+        assert_eq!(std::fs::read(&target).unwrap(), contents);
+        // The cached original must stay in place.
+        assert!(storage.data_dir().join("audio").join("audio.opus").exists());
+    }
+
+    #[test]
+    fn export_audio_to_fails_with_no_audio_when_entry_has_no_file() {
+        let (storage, _dir) = make_service();
+        let entry = storage.add_entry("текст".to_string()).unwrap();
+
+        let err = super::export::export_audio_to(
+            &storage,
+            &entry.id.to_string(),
+            Path::new("/tmp/ruvox-export-should-not-exist.opus"),
+        )
+        .unwrap_err();
+
+        assert_not_found(err, "export.no_audio");
+    }
+
+    #[test]
+    fn export_audio_to_fails_with_no_audio_when_cache_file_was_evicted() {
+        let (storage, _dir) = make_service();
+        let id = seed_audio_entry(&storage, "audio.opus", b"payload");
+        // Evict the cached file: the entry still references it.
+        std::fs::remove_file(storage.data_dir().join("audio").join("audio.opus")).unwrap();
+        let target_dir = TempDir::new().unwrap();
+
+        let err = super::export::export_audio_to(
+            &storage,
+            &id.to_string(),
+            &target_dir.path().join("export.opus"),
+        )
+        .unwrap_err();
+
+        assert_not_found(err, "export.no_audio");
+    }
+
+    #[test]
+    fn export_audio_to_fails_with_not_found_for_missing_entry() {
+        let (storage, _dir) = make_service();
+        let target_dir = TempDir::new().unwrap();
+
+        let err = super::export::export_audio_to(
+            &storage,
+            &uuid::Uuid::new_v4().to_string(),
+            &target_dir.path().join("export.opus"),
+        )
+        .unwrap_err();
+
+        assert_not_found(err, "entry.not_found");
+    }
+
+    #[test]
+    fn export_audio_to_maps_target_io_failure_to_copy_failed() {
+        let (storage, _dir) = make_service();
+        let contents = b"ogg opus payload";
+        let id = seed_audio_entry(&storage, "audio.opus", contents);
+        // Target parent directory does not exist — the copy fails at the OS
+        // level (the save dialog guarantees an existing parent in real use;
+        // this pins the error mapping).
+        let target_dir = TempDir::new().unwrap();
+        let target = target_dir.path().join("missing-dir").join("export.opus");
+
+        let err = super::export::export_audio_to(&storage, &id.to_string(), &target).unwrap_err();
+
+        match err {
+            CommandError::Internal { code, .. } => assert_eq!(code, "export.copy_failed"),
+            other => panic!("expected Internal, got {other:?}"),
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -430,6 +430,8 @@ pub(crate) fn invoke_handler<R: Runtime>()
         pick_import_file,
         read_text_file,
         fetch_url_text,
+        pick_export_audio_path,
+        export_audio,
     ]
 }
 

--- a/src/components/QueueList.test.tsx
+++ b/src/components/QueueList.test.tsx
@@ -5,11 +5,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MantineProvider } from '@mantine/core';
 import type { TextEntry } from '../lib/tauri';
 
-const { cancelSynthesis, getEntries, showNotification } = vi.hoisted(() => ({
-  cancelSynthesis: vi.fn().mockResolvedValue(undefined),
-  getEntries: vi.fn(),
-  showNotification: vi.fn(),
-}));
+const { cancelSynthesis, getEntries, showNotification, pickExportAudioPath, exportAudio } =
+  vi.hoisted(() => ({
+    cancelSynthesis: vi.fn().mockResolvedValue(undefined),
+    getEntries: vi.fn(),
+    showNotification: vi.fn(),
+    pickExportAudioPath: vi.fn().mockResolvedValue(null),
+    exportAudio: vi.fn().mockResolvedValue(undefined),
+  }));
 
 vi.mock('@mantine/notifications', () => ({
   notifications: { show: showNotification },
@@ -22,6 +25,8 @@ vi.mock('../lib/tauri', () => ({
     playEntry: vi.fn().mockResolvedValue(undefined),
     regenerateEntry: vi.fn().mockResolvedValue(undefined),
     deleteEntry: vi.fn().mockResolvedValue(undefined),
+    pickExportAudioPath,
+    exportAudio,
   },
   events: {
     entryUpdated: vi.fn().mockResolvedValue(() => {}),
@@ -89,6 +94,10 @@ describe('QueueList context menu', () => {
     root = createRoot(host);
     cancelSynthesis.mockClear();
     showNotification.mockClear();
+    pickExportAudioPath.mockClear();
+    pickExportAudioPath.mockResolvedValue(null);
+    exportAudio.mockClear();
+    exportAudio.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -187,4 +196,100 @@ describe('QueueList context menu', () => {
       }),
     );
   });
+
+  function exportItem(): HTMLElement {
+    const el = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((e) => e.textContent === 'Сохранить аудио как…');
+    expect(el).toBeDefined();
+    return el!;
+  }
+
+  it('clicking "Сохранить аудио как…" exports the chosen path and confirms', async () => {
+    pickExportAudioPath.mockResolvedValue('/home/user/ruvox-entry-1.opus');
+    await renderWith(makeEntry('ready'));
+    await openMenu();
+
+    await act(async () => {
+      exportItem().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(pickExportAudioPath).toHaveBeenCalledWith('entry-1');
+    expect(exportAudio).toHaveBeenCalledWith('entry-1', '/home/user/ruvox-entry-1.opus');
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'green',
+        message: 'Аудио сохранено: /home/user/ruvox-entry-1.opus',
+      }),
+    );
+  });
+
+  it('a cancelled save dialog invokes no export and shows nothing', async () => {
+    pickExportAudioPath.mockResolvedValue(null);
+    await renderWith(makeEntry('ready'));
+    await openMenu();
+
+    await act(async () => {
+      exportItem().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(exportAudio).not.toHaveBeenCalled();
+    expect(showNotification).not.toHaveBeenCalled();
+  });
+
+  it('shows an error notification when exportAudio rejects', async () => {
+    // The cached file was evicted: the coded export.no_audio error must be
+    // localized, not stringified.
+    pickExportAudioPath.mockResolvedValue('/home/user/ruvox-entry-1.opus');
+    exportAudio.mockRejectedValueOnce({
+      type: 'not_found',
+      code: 'export.no_audio',
+      params: ['entry-1'],
+    });
+    await renderWith(makeEntry('ready'));
+    await openMenu();
+
+    await act(async () => {
+      exportItem().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'red',
+        message: 'У записи entry-1 нет сохранённого аудиофайла',
+      }),
+    );
+  });
+
+  it.each(['ready', 'playing'] as const)(
+    '"Сохранить аудио как…" is enabled for a %s entry',
+    async (status) => {
+      await renderWith(makeEntry(status));
+      await openMenu();
+
+      const item = exportItem();
+      expect(
+        item.hasAttribute('disabled') || item.dataset.disabled !== undefined,
+      ).toBe(false);
+    },
+  );
+
+  it.each(['pending', 'processing', 'error'] as const)(
+    '"Сохранить аудио как…" is disabled for a %s entry',
+    async (status) => {
+      await renderWith(makeEntry(status));
+      await openMenu();
+
+      const item = exportItem();
+      expect(
+        item.hasAttribute('disabled') || item.dataset.disabled !== undefined,
+      ).toBe(true);
+    },
+  );
 });

--- a/src/components/QueueList.test.tsx
+++ b/src/components/QueueList.test.tsx
@@ -267,6 +267,30 @@ describe('QueueList context menu', () => {
     );
   });
 
+  it('shows an error notification when the save-dialog pick itself rejects', async () => {
+    pickExportAudioPath.mockRejectedValueOnce({
+      type: 'internal',
+      code: 'export.dialog_panicked',
+    });
+    await renderWith(makeEntry('ready'));
+    await openMenu();
+
+    await act(async () => {
+      exportItem().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(exportAudio).not.toHaveBeenCalled();
+    expect(showNotification).toHaveBeenCalledTimes(1);
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'red',
+        message: 'Внутренняя ошибка при открытии диалога сохранения',
+      }),
+    );
+  });
+
   it.each(['ready', 'playing'] as const)(
     '"Сохранить аудио как…" is enabled for a %s entry',
     async (status) => {

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -291,12 +291,13 @@ export function QueueList() {
   }, [tt]);
 
   // "Save audio as…": pick a target with the native save dialog, then copy
-  // the cached audio there. A cancelled dialog is a silent no-op.
+  // the cached audio there. A cancelled dialog is a silent no-op; any
+  // rejection (dialog or copy) surfaces the localized red error.
   const handleExportAudio = useCallback(
     async (id: string) => {
-      const path = await commands.pickExportAudioPath(id);
-      if (path === null) return;
       try {
+        const path = await commands.pickExportAudioPath(id);
+        if (path === null) return;
         await commands.exportAudio(id, path);
         notifications.show({
           message: tt('notify.export.ok', [path]),
@@ -312,6 +313,12 @@ export function QueueList() {
     },
     [tt],
   );
+
+  // Play and "Save audio as…" share one gate: audio exists only on
+  // ready/playing entries.
+  const menuCanPlay =
+    menuEntry !== null &&
+    (menuEntry.status === 'ready' || menuEntry.status === 'playing');
 
   const handleDelete = useCallback(
     (id: string) => {
@@ -405,20 +412,16 @@ export function QueueList() {
           />
         </Menu.Target>
         <Menu.Dropdown>
+          {/* Play and "Save audio as…" share one gate (audio-export spec:
+              "the same gate as Play"). */}
           <Menu.Item
-            disabled={
-              menuEntry === null ||
-              (menuEntry.status !== 'ready' && menuEntry.status !== 'playing')
-            }
+            disabled={!menuCanPlay}
             onClick={() => menuEntry && handlePlay(menuEntry.id)}
           >
             {tt('queue.play')}
           </Menu.Item>
           <Menu.Item
-            disabled={
-              menuEntry === null ||
-              (menuEntry.status !== 'ready' && menuEntry.status !== 'playing')
-            }
+            disabled={!menuCanPlay}
             onClick={() => menuEntry && void handleExportAudio(menuEntry.id)}
           >
             {tt('queue.menu.export_audio')}

--- a/src/components/QueueList.tsx
+++ b/src/components/QueueList.tsx
@@ -290,6 +290,29 @@ export function QueueList() {
     }
   }, [tt]);
 
+  // "Save audio as…": pick a target with the native save dialog, then copy
+  // the cached audio there. A cancelled dialog is a silent no-op.
+  const handleExportAudio = useCallback(
+    async (id: string) => {
+      const path = await commands.pickExportAudioPath(id);
+      if (path === null) return;
+      try {
+        await commands.exportAudio(id, path);
+        notifications.show({
+          message: tt('notify.export.ok', [path]),
+          color: 'green',
+        });
+      } catch (e) {
+        notifications.show({
+          title: tt('errors.title'),
+          message: formatError(e),
+          color: 'red',
+        });
+      }
+    },
+    [tt],
+  );
+
   const handleDelete = useCallback(
     (id: string) => {
       modals.openConfirmModal({
@@ -390,6 +413,15 @@ export function QueueList() {
             onClick={() => menuEntry && handlePlay(menuEntry.id)}
           >
             {tt('queue.play')}
+          </Menu.Item>
+          <Menu.Item
+            disabled={
+              menuEntry === null ||
+              (menuEntry.status !== 'ready' && menuEntry.status !== 'playing')
+            }
+            onClick={() => menuEntry && void handleExportAudio(menuEntry.id)}
+          >
+            {tt('queue.menu.export_audio')}
           </Menu.Item>
           <Menu.Item
             disabled={menuEntry === null || menuEntry.status === 'processing'}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -54,6 +54,8 @@ export const en: Record<MessageKey, string> = {
   'queue.no_results': 'Nothing found',
   'queue.menu.regenerate': 'Regenerate audio',
   'queue.menu.cancel_synthesis': 'Cancel synthesis',
+  'queue.menu.export_audio': 'Save audio as…',
+  'notify.export.ok': 'Audio saved: {0}',
   'queue.delete.title': 'Delete this entry?',
   'queue.delete.body':
     'The entry and its audio file will be deleted permanently.',
@@ -323,6 +325,10 @@ export const en: Record<MessageKey, string> = {
   'errors.import.unknown_encoding': 'Unknown encoding: {0}',
   'errors.import.io_failed': 'Failed to read the file {0}',
   'errors.import.task_panicked': 'Internal error during import',
+  'errors.export.no_audio': 'Entry {0} has no stored audio file',
+  'errors.export.copy_failed': 'Failed to copy the audio file: {0}',
+  'errors.export.dialog_panicked': 'Internal error while opening the save dialog',
+  'errors.export.task_panicked': 'Internal error during audio export',
 
   // ── Engine availability reasons (get_available_engines) ─────────────────
   'errors.silero.ttsd_missing':

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -55,6 +55,8 @@ export const ru = {
   'queue.no_results': 'Ничего не найдено',
   'queue.menu.regenerate': 'Перегенерировать аудио',
   'queue.menu.cancel_synthesis': 'Отменить синтез',
+  'queue.menu.export_audio': 'Сохранить аудио как…',
+  'notify.export.ok': 'Аудио сохранено: {0}',
   'queue.delete.title': 'Удалить запись?',
   'queue.delete.body':
     'Запись и аудиофайл будут удалены без возможности восстановления.',
@@ -326,6 +328,10 @@ export const ru = {
   'errors.import.unknown_encoding': 'Неизвестная кодировка: {0}',
   'errors.import.io_failed': 'Не удалось прочитать файл {0}',
   'errors.import.task_panicked': 'Внутренняя ошибка при импорте',
+  'errors.export.no_audio': 'У записи {0} нет сохранённого аудиофайла',
+  'errors.export.copy_failed': 'Не удалось скопировать аудиофайл: {0}',
+  'errors.export.dialog_panicked': 'Внутренняя ошибка при открытии диалога сохранения',
+  'errors.export.task_panicked': 'Внутренняя ошибка при экспорте аудио',
 
   // ── Engine availability reasons (get_available_engines) ─────────────────
   'errors.silero.ttsd_missing':

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -258,6 +258,17 @@ export const commands = {
   previewNormalize: (text: string): Promise<PreviewNormalizeResult> =>
     tauriInvoke('preview_normalize', { text }),
 
+  /** Native save dialog for an entry's audio export (#225): the default name
+   * and filter follow the entry's stored audio format (rfd backend, like the
+   * import picker). null = the user cancelled the dialog. */
+  pickExportAudioPath: (id: EntryId): Promise<string | null> =>
+    tauriInvoke('pick_export_audio_path', { id }),
+
+  /** Copy the entry's cached audio file to the chosen path (#225). The cache
+   * original is untouched and no entry_updated is emitted. */
+  exportAudio: (id: EntryId, path: string): Promise<void> =>
+    tauriInvoke('export_audio', { id, path }),
+
   /** Raw bytes of a remote image for the viewer's "Copy image" action.
    * Fetched by a Rust command (scheme/content-type/size validated there) —
    * the webview holds no arbitrary-host http capability (#231). */


### PR DESCRIPTION
## Summary

There is no audio export — the only path to a synthesized file was "Open cache folder" in Settings with its raw cache layout. Add a per-entry **"Сохранить аудио как…"** action to the queue context menu (issue #225):

- a native save dialog pre-filled with `ruvox-<entry-id>.<ext>` and filtered by the entry's stored audio format (Ogg Opus normally, WAV when the synthesis transcode fell back);
- a byte-for-byte copy of the cached file to the chosen path — the cache original is untouched and no `entry_updated` is emitted;
- enabled for `ready`/`playing` entries under the same gate as Play; a cancelled dialog is a silent no-op; success shows a confirmation notification with the path; failures surface localized red errors (`export.no_audio`, `export.copy_failed`).

Both commands run on the #224 rfd-backend pattern — no dialog/fs plugin and no capability surface. The dialog-free export core is unit-tested in Rust; the menu action is covered by QueueList unit tests. The menu item is disabled for pending/processing/error entries.

Carries the `add-audio-export` OpenSpec change (ipc-commands + ui deltas).

## Test plan

- [x] `just lint`, `just test` green (440 TS tests incl. 9 new QueueList export tests; 8 new Rust tests: export core error mapping + dialog defaults)
- [x] ruvox-reviewer pass over the branch diff; findings folded in (pick rejection handling, `get_audio_path` reuse, save-dialog defaults helper, shared menu gate, spec delta completeness)

Closes #225