### PR TITLE
fix(settings): include tt in the piperVoiceOptions useMemo deps

### DIFF
--- a/src/dialogs/Settings.tsx
+++ b/src/dialogs/Settings.tsx
@@ -335,7 +335,7 @@ export function SettingsModal({ opened, onClose, onSaved }: SettingsModalProps) 
 
   const piperVoiceOptions = useMemo(
     () => PIPER_VOICES.map((v) => ({ value: v.id, label: tt(v.key) })),
-    [],
+    [tt],
   );
 
   const speakerOptions = useMemo(


### PR DESCRIPTION
The empty dependency array silenced the exhaustive-deps lint (a CI warning) and also froze the Piper voice labels on the locale that was active at first render: switching the UI language no longer re-localized them until the dialog remounted. Every neighboring options memo already depends on `tt`.