### PR TITLE
chore(test): deduplicate jsdom stubs into a shared vitest setup

### DIFF
--- a/src/components/Player.test.tsx
+++ b/src/components/Player.test.tsx
@@ -43,24 +43,6 @@ vi.mock('../lib/tauri', () => ({
   },
 }));
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-  true;
-
-// jsdom has no matchMedia; Mantine providers need it.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-
 import { Player } from './Player';
 
 describe('Player speed restore', () => {

--- a/src/components/QueueList.test.tsx
+++ b/src/components/QueueList.test.tsx
@@ -37,33 +37,6 @@ vi.mock('../lib/tauri', () => ({
   },
 }));
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-  true;
-
-// jsdom has no matchMedia; Mantine's useComputedColorScheme needs it.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-
-// jsdom has no ResizeObserver; Mantine's ScrollArea needs it.
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??=
-  ResizeObserverStub;
-
 import { QueueList } from './QueueList';
 
 function makeEntry(status: TextEntry['status']): TextEntry {

--- a/src/components/TextViewer.test.tsx
+++ b/src/components/TextViewer.test.tsx
@@ -25,33 +25,6 @@ vi.mock('../lib/mermaid', () => ({
 }));
 vi.mock('../lib/viewerCopy', () => ({ copyLinkAddress }));
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-  true;
-
-// jsdom has no matchMedia; Mantine's useComputedColorScheme needs it.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-
-// jsdom has no ResizeObserver; Mantine's ScrollArea needs it.
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??=
-  ResizeObserverStub;
-
 import { TextViewer } from './TextViewer';
 
 function makeEntry(): TextEntry {

--- a/src/components/ViewerContextMenu.test.tsx
+++ b/src/components/ViewerContextMenu.test.tsx
@@ -12,31 +12,6 @@ vi.mock('../lib/viewerCopy', () => ({
   copyImageBitmap: vi.fn(),
 }));
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-  true;
-
-// jsdom has no matchMedia / ResizeObserver; Mantine needs both.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??=
-  ResizeObserverStub;
-
 import { ViewerContextMenu } from './ViewerContextMenu';
 
 function Harness() {

--- a/src/dialogs/EncodingDialog.test.tsx
+++ b/src/dialogs/EncodingDialog.test.tsx
@@ -30,29 +30,6 @@ import { commands } from '../lib/tauri';
 
 const readTextFile = vi.mocked(commands.readTextFile);
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
-// jsdom has no matchMedia / ResizeObserver; Mantine needs both.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??= ResizeObserverStub;
-
 const DETECTED = { text: 'кракозябры вместо кириллицы', encoding: 'windows-1251' };
 
 interface HarnessProps {

--- a/src/dialogs/GenerationParamsDialog.test.tsx
+++ b/src/dialogs/GenerationParamsDialog.test.tsx
@@ -8,29 +8,6 @@ import { useLocaleStore } from '../stores/locale';
 
 import { GenerationParamsDialog } from './GenerationParamsDialog';
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
-// jsdom has no matchMedia / ResizeObserver; Mantine needs both.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??= ResizeObserverStub;
-
 const SNAPSHOT: GenerationParams = {
   engine: 'silero_native',
   voice: 'ruslan',

--- a/src/dialogs/PreviewDialog.test.tsx
+++ b/src/dialogs/PreviewDialog.test.tsx
@@ -28,29 +28,6 @@ const previewNormalize = vi.mocked(commands.previewNormalize);
 const openUrlMock = vi.mocked(openUrl);
 const showMock = vi.mocked(notifications.show);
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
-// jsdom has no matchMedia / ResizeObserver; Mantine needs both.
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??= ResizeObserverStub;
-
 const TEXT = 'Вызови getUserData() через API';
 
 interface HarnessProps {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,38 @@
+// Shared vitest setup, wired via `test.setupFiles` in vite.config.ts.
+//
+// jsdom lacks several browser APIs that Mantine components touch at render
+// time (matchMedia, ResizeObserver); React's `act` also wants an explicit
+// opt-in flag. Stub them here once instead of re-declaring the same
+// preamble in every component test file.
+//
+// Pure unit tests run in the node environment, where `window` is undefined
+// — the DOM-dependent parts must stay no-ops there.
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+// jsdom has no ResizeObserver; Mantine's ScrollArea needs it.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??=
+  ResizeObserverStub;
+
+if (typeof window !== 'undefined') {
+  // jsdom has no matchMedia; Mantine providers need it.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -5,6 +6,13 @@ const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig(() => ({
   plugins: [react()],
+
+  // Shared stubs for browser APIs jsdom lacks (matchMedia, ResizeObserver);
+  // see src/test/setup.ts. Applies to every test file, so the setup itself
+  // must stay a no-op outside the jsdom environment.
+  test: {
+    setupFiles: ["src/test/setup.ts"],
+  },
 
   // react-rnd's Draggable reads `process.env.DRAGGABLE_DEBUG` at render
   // time (its `log()` helper). The webview has no Node `process` global, so


### PR DESCRIPTION
Closes #247

## Summary

- Every jsdom component test hand-declared the same preamble — `IS_REACT_ACT_ENVIRONMENT`, a `window.matchMedia` stub, and (all but Player) a `ResizeObserver` stub. Seven copies by now (the issue counted six; `GenerationParamsDialog.test.tsx` grew one since), ~120 lines of duplicated boilerplate.
- The stubs now live in `src/test/setup.ts`, wired via `test.setupFiles` in `vite.config.ts`. The DOM-dependent parts are guarded, so the setup is a no-op for pure unit tests running in the node environment. Per-file `// @vitest-environment jsdom` pragmas stay.
- Dedup only: the manual `createRoot`/`act` harness is untouched, no testing-library conversion.

## Verification

- `pnpm test:unit` — 26 files / 246 tests green; `pnpm typecheck`, `pnpm lint`, `pnpm knip` clean.
- Pre-existing `act(...)` console noise in `QueueList.test.tsx` is byte-identical to main (107 occurrences before and after).