### PR TITLE
fix(build): make scripts/build-linux-packages.sh robust

### DIFF
--- a/scripts/build-linux-packages.sh
+++ b/scripts/build-linux-packages.sh
@@ -59,6 +59,9 @@ docker run --rm -i \
     -v "$out":/out \
     ruvox-build bash -s <<'EOF'
 set -euo pipefail
+# codegen-units=1 + the big tauri crate occasionally overflows rustc's
+# default stack in LLVM (hit 2026-08-29); raise it.
+export RUST_MIN_STACK=16777216
 case "$BUNDLES" in
     both) BUNDLES="deb appimage" ;;
 esac

--- a/scripts/build-linux-packages.sh
+++ b/scripts/build-linux-packages.sh
@@ -75,6 +75,9 @@ pnpm config set store-dir /pnpm-store
 echo "[pnpm] install"
 pnpm install --frozen-lockfile
 
+echo "[frontend] build (tauri-codegen needs dist/ during cargo build)"
+pnpm build
+
 echo "[espeak] rlib build produces vendored espeak-ng-data"
 cargo rustc --release --lib --crate-type=rlib --features tauri/custom-protocol --manifest-path src-tauri/Cargo.toml
 src=$(ls -d /target/release/build/espeak-rs-sys-*/out/share/espeak-ng-data | head -1)
@@ -84,8 +87,8 @@ mkdir -p src-tauri/resources/espeak-ng-data
 cp -r "$src/." src-tauri/resources/espeak-ng-data/
 test -f src-tauri/resources/espeak-ng-data/ru_dict
 
-echo "[onnxruntime] fetch pinned libonnxruntime"
-bash scripts/fetch-linux-onnxruntime.sh
+echo "[onnxruntime] pinned libonnxruntime (download only when absent)"
+bash scripts/fetch-linux-onnxruntime.sh --check || bash scripts/fetch-linux-onnxruntime.sh
 
 echo "[tauri] build --bundles $BUNDLES"
 pnpm tauri build --bundles $BUNDLES


### PR DESCRIPTION
Three fixes to the Linux package build script, found while building the .deb/.AppImage for VM testing of #252/#254:

1. **Frontend build step.** The script ran cargo before the frontend was built, but tauri's codegen reads `dist/` during `cargo build`. An explicit `pnpm build` now runs before the cargo steps.
2. **Idempotent onnxruntime fetch.** `fetch-linux-onnxruntime.sh --check` runs first and the download only happens when the pinned lib is absent, so repeat builds (and rate-limited networks — release-assets throttling stalled the in-container curl on 2026-08-29) reuse the already-fetched lib.
3. **Rustc stack size.** `codegen-units=1` plus the large tauri crate intermittently overflowed rustc's default LLVM stack in-container (hit 2026-08-29); the script now exports `RUST_MIN_STACK=16777216`.

Tooling-only change — no OpenSpec delta (workflow §6.1).