### PR TITLE
docs(install): verify non-Nix install on a fresh Ubuntu VM, add CI guard (#230)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       nix: ${{ steps.filter.outputs.nix }}
       openspec: ${{ steps.filter.outputs.openspec }}
       windows: ${{ steps.filter.outputs.windows }}
+      nonnix: ${{ steps.filter.outputs.nonnix }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v4
@@ -59,6 +60,17 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
               - 'scripts/fetch-windows-resources.sh'
+            nonnix:
+              - 'src-tauri/**'
+              - 'silero-native/**'
+              - 'src/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig.json'
+              - 'vite.config.ts'
+              - 'index.html'
+              - 'docs/install.md'
+              - '.github/workflows/ci.yml'
 
   # Compile-only guard for the Windows port: catches cfg/platform breakage
   # on the real MSVC toolchain without bundling (no resource downloads, no
@@ -92,6 +104,54 @@ jobs:
           # cache key includes the job id, so the release rebuilt all ~600 deps
           # from scratch on every run (~8.5 min lost).
           shared-key: win-msvc
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm tauri build --no-bundle
+
+
+  # End-to-end guard for docs/install.md (the non-Nix build path, #230):
+  # builds the app on a stock ubuntu-24.04 runner with the same system
+  # packages the guide prescribes, so drift between the doc and the real
+  # dependency set fails CI instead of a user's machine. Bundling is
+  # skipped (--no-bundle) to keep the job lean (no AppImage bundler
+  # downloads); the deb/AppImage bundle path is covered by release.yml.
+  nonnix-build:
+    name: Non-Nix build (Ubuntu 24.04)
+    needs: changes
+    if: needs.changes.outputs.nonnix == 'true'
+    runs-on: ubuntu-24.04
+    # Cold run: ~5 min apt + ~20 min cold release build + frontend install.
+    # Warm apt/cargo caches cut it roughly in half.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install the system packages from docs/install.md (Ubuntu block)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: build-essential pkg-config cmake clang libclang-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev libmpv-dev libopus-dev libssl-dev libasound2-dev libpulse-dev libpipewire-0.3-dev libfontconfig1-dev libfreetype6-dev libgl-dev libdrm-dev libwayland-dev libxkbcommon-dev wayland-protocols espeak-ng espeak-ng-data curl file git
+          version: 1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri\nsilero-native"
+          # Own cache namespace: this job builds release binaries while the
+          # rust job builds debug test artifacts — a shared key would make
+          # each job thrash the other's cache.
+          shared-key: nonnix-gnu
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: ONNX Runtime dylib (Piper engine, dlopened at run time)
+        run: |
+          ORT_VERSION=1.20.1
+          mkdir -p "$HOME/.local/onnxruntime"
+          curl -L -o /tmp/onnxruntime.tgz \
+            "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+          tar -xzf /tmp/onnxruntime.tgz -C "$HOME/.local/onnxruntime" --strip-components=1
+          echo "ORT_DYLIB_PATH=$HOME/.local/onnxruntime/lib/libonnxruntime.so" >> "$GITHUB_ENV"
       - run: pnpm install --frozen-lockfile
       - run: pnpm tauri build --no-bundle
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,24 +119,24 @@ jobs:
     needs: changes
     if: needs.changes.outputs.nonnix == 'true'
     runs-on: ubuntu-24.04
-    # Cold run: ~5 min apt + ~20 min cold release build + frontend install.
-    # Warm apt/cargo caches cut it roughly in half.
-    timeout-minutes: 45
+    # Cold run, unmeasured estimate: ~5 min apt + ~20 min cold release
+    # build + frontend install; 60 min gives the house 2-3x headroom.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
       - name: Install the system packages from docs/install.md (Ubuntu block)
+        # cache-apt-pkgs for the same reason as the rust job below (#204:
+        # throttled apt mirrors turned a raw install into a 40-60 min hang).
+        # The list must stay a mirror of the doc's Ubuntu block — mpv
+        # included: it is exactly the kind of drift this job exists to catch.
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: build-essential pkg-config cmake clang libclang-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev libmpv-dev libopus-dev libssl-dev libasound2-dev libpulse-dev libpipewire-0.3-dev libfontconfig1-dev libfreetype6-dev libgl-dev libdrm-dev libwayland-dev libxkbcommon-dev wayland-protocols espeak-ng espeak-ng-data curl file git
+          packages: build-essential pkg-config cmake clang libclang-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev libmpv-dev mpv libopus-dev libssl-dev libasound2-dev libpulse-dev libpipewire-0.3-dev libfontconfig1-dev libfreetype6-dev libgl-dev libdrm-dev libwayland-dev libxkbcommon-dev wayland-protocols espeak-ng espeak-ng-data curl file git
           version: 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "src-tauri\nsilero-native"
-          # Own cache namespace: this job builds release binaries while the
-          # rust job builds debug test artifacts — a shared key would make
-          # each job thrash the other's cache.
-          shared-key: nonnix-gnu
       - uses: pnpm/action-setup@v6
         with:
           version: 10

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,7 +41,7 @@ sudo dnf install -y \
   alsa-lib-devel pulseaudio-libs-devel pipewire-devel \
   fontconfig-devel freetype-devel mesa-libGL-devel libdrm-devel \
   wayland-devel libxkbcommon-devel wayland-protocols-devel \
-  espeak-ng espeak-ng-data \
+  espeak-ng \
   curl file
 ```
 
@@ -143,9 +143,11 @@ depends on the distribution:
 - **Ubuntu 24.04 / Debian 13:** the apt package ships the data under the
   multiarch lib dir, so point the variable at
   `/usr/lib/x86_64-linux-gnu`.
-- **Fedora / Arch:** check `dpkg -L espeak-ng-data` equivalent
-  (`rpm -ql espeak-ng-data`, `pacman -Ql espeak-ng`) and use the parent
-  of the `espeak-ng-data` directory.
+- **Fedora / RHEL:** the data ships inside the single `espeak-ng`
+  package at `/usr/share/espeak-ng-data`, so the parent is
+  `/usr/share`.
+- **Arch:** check `pacman -Ql espeak-ng` and use the parent of the
+  `espeak-ng-data` directory.
 
 ```bash
 # Ubuntu 24.04 / Debian 13:

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,21 +20,24 @@ sudo apt update
 sudo apt install -y \
   build-essential pkg-config cmake clang libclang-dev \
   libwebkit2gtk-4.1-dev libsoup-3.0-dev libgtk-3-dev librsvg2-dev \
-  libayatana-appindicator3-dev libmpv-dev libopus-dev libssl-dev \
+  libayatana-appindicator3-dev libmpv-dev mpv libopus-dev libssl-dev \
   libasound2-dev libpulse-dev libpipewire-0.3-dev \
   libfontconfig1-dev libfreetype6-dev libgl-dev libdrm-dev \
   libwayland-dev libxkbcommon-dev wayland-protocols \
   espeak-ng espeak-ng-data \
-  curl file
+  curl file git
 ```
+
+> `libmpv-dev` provides the headers to compile against; `mpv` is the
+> player binary the app drives at run time — both are required.
 
 ### Fedora 40+ / RHEL 10+
 
 ```bash
 sudo dnf install -y \
-  gcc gcc-c++ pkgconf-pkg-config cmake clang clang-devel \
+  gcc gcc-c++ pkgconf-pkg-config cmake clang clang-devel git \
   webkit2gtk4.1-devel libsoup3-devel gtk3-devel librsvg2-devel \
-  libayatana-appindicator-gtk3-devel mpv-libs-devel opus-devel openssl-devel \
+  libayatana-appindicator-gtk3-devel mpv-libs-devel mpv opus-devel openssl-devel \
   alsa-lib-devel pulseaudio-libs-devel pipewire-devel \
   fontconfig-devel freetype-devel mesa-libGL-devel libdrm-devel \
   wayland-devel libxkbcommon-devel wayland-protocols-devel \
@@ -42,11 +45,14 @@ sudo dnf install -y \
   curl file
 ```
 
+> The `mpv` player binary lives in RPM Fusion on Fedora/RHEL — enable
+> the repo if `dnf` cannot find it.
+
 ### Arch Linux
 
 ```bash
 sudo pacman -S --needed \
-  base-devel cmake clang \
+  base-devel cmake clang git \
   webkit2gtk-4.1 libsoup3 gtk3 librsvg libayatana-appindicator \
   mpv opus openssl \
   alsa-lib libpulse pipewire \
@@ -81,10 +87,12 @@ source ~/.bashrc
 ## 3. Rust toolchain
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
-cargo install tauri-cli --version '^2.0' --locked
 ```
+
+The Tauri CLI comes from the repo's dev dependencies (`pnpm tauri …`), so
+there is nothing else to install globally.
 
 ## 4. Node 20 + pnpm
 
@@ -93,8 +101,14 @@ Ubuntu's stock `nodejs` lags behind; use NodeSource:
 ```bash
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt install -y nodejs
-corepack enable pnpm
+sudo corepack enable pnpm
 ```
+
+`sudo` is required: `corepack enable` writes symlinks into `/usr/bin`.
+The first `pnpm` invocation asks to download the pnpm release — answer
+«Y» in a terminal; scripted/non-interactive setups should export
+`COREPACK_ENABLE_DOWNLOAD_PROMPT=0` (or install pnpm via
+`sudo npm install -g pnpm` instead of corepack).
 
 ## 5. (Optional) Python 3.12 + uv — for the Python Silero engine (`ttsd`)
 
@@ -121,13 +135,21 @@ single distributable binary on Ubuntu is out of scope for this guide
 
 ## 6. Configure espeak-ng data directory
 
-`piper-rs` looks for `espeak-ng-data/` under
-`PIPER_ESPEAKNG_DATA_DIRECTORY`. On Ubuntu, the apt package ships the
-data at `/usr/share/espeak-ng-data/`, so point the variable at the
-parent:
+`piper-rs` looks for `espeak-ng-data/` **under**
+`PIPER_ESPEAKNG_DATA_DIRECTORY` — the variable points at the parent
+directory, not at `espeak-ng-data` itself. Where that parent lives
+depends on the distribution:
+
+- **Ubuntu 24.04 / Debian 13:** the apt package ships the data under the
+  multiarch lib dir, so point the variable at
+  `/usr/lib/x86_64-linux-gnu`.
+- **Fedora / Arch:** check `dpkg -L espeak-ng-data` equivalent
+  (`rpm -ql espeak-ng-data`, `pacman -Ql espeak-ng`) and use the parent
+  of the `espeak-ng-data` directory.
 
 ```bash
-echo 'export PIPER_ESPEAKNG_DATA_DIRECTORY=/usr/share' >> ~/.bashrc
+# Ubuntu 24.04 / Debian 13:
+echo 'export PIPER_ESPEAKNG_DATA_DIRECTORY=/usr/lib/x86_64-linux-gnu' >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -149,6 +171,8 @@ Outputs:
 - `src-tauri/target/release/ruvox-tauri` — the binary.
 - `src-tauri/target/release/bundle/deb/*.deb` — installable package
   (`sudo dpkg -i`).
+- `src-tauri/target/release/bundle/appimage/*.AppImage` — portable
+  AppImage.
 
 ### Release artifacts & self-updates
 
@@ -161,6 +185,9 @@ not self-updating — reinstall the new version yourself.
 
 ## Troubleshooting
 
+- **`mpv init failed … Is mpv installed and in your PATH?` on
+  startup** — the headers (`libmpv-dev`) are installed but the player
+  binary is missing. Install the `mpv` package (step 1).
 - **`failed to run custom build command for espeak-rs-sys`** — you are
   missing `cmake` or `libclang-dev`. Re-run step 1.
 - **`libonnxruntime.so: cannot open shared object file`** —
@@ -176,7 +203,16 @@ not self-updating — reinstall the new version yourself.
 
 ## Verifying
 
-This guide is derived from `nix/devshell.nix` (the Nix dev shell, which
-is the source of truth for build dependencies). It has not been
-end-to-end tested on a fresh Ubuntu install — if a step fails on your
-machine, please open an issue or PR with the correction.
+The **Ubuntu 24.04** path was verified end-to-end (2026-08-30) on a
+fresh desktop install in a VM: the step-1 package list, ONNX Runtime
+download, rustup, Node 20 + pnpm, the espeak-ng data directory, the
+clone + `pnpm tauri build` (producing the binary, the .deb and the
+AppImage), and launching the built binary (first-run Silero download
+prompt renders; the app starts once `mpv` is installed).
+
+The Debian / Fedora / RHEL / Arch blocks are derived from
+`nix/devshell.nix` (the source of truth for build dependencies) and
+package-name equivalences — they have not been run on those
+distributions. The Piper stress fix (step 6) was verified at the
+path-layout level, not by listening to synthesized speech. If a step
+fails on your machine, please open an issue or PR with the correction.


### PR DESCRIPTION
Closes #230

## What

A fresh Ubuntu 24.04 desktop VM ran `docs/install.md` end to end: the apt
package list, ONNX Runtime, rustup, Node 20 + pnpm, the espeak-ng data
directory, clone + `pnpm tauri build` (binary, .deb, AppImage), and a GUI
launch of the built binary. Every gap the run exposed is folded back into
the guide:

- the `mpv` player binary was missing (the app compiled but panicked at
  startup with only `libmpv-dev`), plus a troubleshooting entry;
- `git` was missing from the package lists despite the `git clone` step;
- rustup runs with `-y` so scripted/CI use works; `corepack enable pnpm`
  needs sudo and shows a download prompt (notes added);
- the espeak-ng data directory for Ubuntu 24.04 / Debian 13 is
  `/usr/lib/x86_64-linux-gnu`, not `/usr/share`; Fedora/RHEL get their
  explicit parent; Fedora's non-existent `espeak-ng-data` dnf package
  removed;
- the redundant global `cargo install tauri-cli` dropped (the repo's dev
  deps provide the CLI).

A new `nonnix-build` CI job on ubuntu-24.04 installs the doc's exact
Ubuntu package list and runs `pnpm tauri build --no-bundle`, paths-gated
on code + `docs/install.md` itself — doc/dependency drift now fails CI
instead of a user's machine. The Verifying section now states what was
VM-verified vs derived.

## Testing

- Fresh-VM run: all guide sections executed in order; build produced the
  binary, the .deb and the AppImage; the built app launched on the VM
  desktop (first-run Silero prompt rendered).
- `ruvox-reviewer` findings (mpv parity in the CI list, Fedora package
  names, timeout sizing, rust-cache rationale, #204 comment) applied in
  61b7a0a; local gates green.
