### PR TITLE
chore(release): version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ Notable changes in RuVox, in chronological order.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follow [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [0.5.0] — 2026-08-30 — Localization, import and export
 
 ### Added
+- **Russian and English interface** — the whole UI is localized; the language
+  is picked in Settings (Russian by default), and backend and engine errors
+  are shown as readable localized messages instead of raw error strings (#240).
+- **Import from files and web pages** — «Добавить» becomes a split button with
+  «Файл…», «Файл с кодировкой…» and «По ссылке…», and dragging a .txt/.md/.html
+  file or a link onto the window adds a new entry; text encoding is
+  auto-detected (BOM, UTF-8, then CP1251/KOI8-R/CP866 and other Cyrillic
+  encodings) with a manual override for misdetected files (#224).
 - **Auto-detected source format in the preview dialog** — the format selector now defaults to «Авто», which classifies pasted text as HTML, Markdown or plain instead of always assuming Markdown; file and URL imports still preselect the format they know.
 - **"Save audio as…" audio export** — the queue context menu exports an entry's audio to any folder via the native save dialog (#225).
 - **WAV audio export** — «Сохранить аудио как…» gains a format chooser in the save dialog (WAV default, Ogg Opus alternative), converting an Opus recording to editable 16-bit PCM WAV on export; the cache keeps the Opus original (#252).
@@ -14,6 +22,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follo
 - **Linux AppImage auto-updates** — AppImage installs now check GitHub releases in-app and self-update with signature verification; .deb and source builds get no update UI (#226).
 
 ### Changed
+- **Playback speed up to 3.0× and restored on startup** — the speed limit
+  rises from 2.0× to 3.0×, and the saved speech rate is applied to the player
+  itself on startup, not just to the slider (#227).
 - **Regeneration asks before overwriting** — «Перегенерировать аудио» now opens the normalization preview first: the old audio is deleted only after you confirm, cancelling keeps it, and «Читать сейчас» plays the fresh audio.
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvox",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3941,7 +3941,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ruvox-tauri"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruvox-tauri"
-version = "0.4.0"
+version = "0.5.0"
 description = "RuVox — desktop app for reading technical texts aloud"
 authors = []
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "RuVox",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.ruvox.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Release-prep commit for v0.5.0. Renames `## [Unreleased]` to
`## [0.5.0] — 2026-08-30 — Localization, import and export`, folding in the
three highlight entries that landed without changelog notes (RU/EN
localization #240, file/URL import #224, playback speed #227), and bumps the
version to 0.5.0 in `package.json`, `src-tauri/Cargo.toml`, `Cargo.lock` and
`src-tauri/tauri.conf.json`.

Merging this PR is immediately followed by tagging `v0.5.0`, which triggers
`release.yml` (Windows NSIS + Linux .deb/.AppImage + updater manifest → draft
release).

## Test plan

- Green CI on this PR (rust + typescript jobs).
- The tag guard in `release.yml` re-checks tag vs `tauri.conf.json` before
  the expensive build.
