### PR TITLE
fix(linux): depend on mpv in the deb package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follo
 - **WAV audio export** — «Сохранить аудио как…» gains a format chooser in the save dialog (WAV default, Ogg Opus alternative), converting an Opus recording to editable 16-bit PCM WAV on export; the cache keeps the Opus original (#252).
 - **Voiceover parameters in the history** — the queue context menu gains «Параметры записи…», a read-only view of the source, engine, voice, sample rate, model and settings that produced each recording (#243).
 - **Linux AppImage auto-updates** — AppImage installs now check GitHub releases in-app and self-update with signature verification; .deb and source builds get no update UI (#226).
+- **Linux packages need `mpv`** — the .deb installs the player binary automatically as a dependency; AppImage users install it once via the system package manager (`sudo apt install mpv`). Bundling `mpv` into the AppImage is planned for 0.5.1 (#265).
 
 ### Changed
 - **Playback speed up to 3.0× and restored on startup** — the speed limit

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -9,6 +9,11 @@
       "resources/espeak-ng-data": "espeak-ng-data",
       "resources/libonnxruntime.so": "libonnxruntime.so"
     },
-    "createUpdaterArtifacts": false
+    "createUpdaterArtifacts": false,
+    "linux": {
+      "deb": {
+        "depends": ["mpv"]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Part of #265 (the .deb half): the .deb package now declares `mpv` in its
`Depends`, so a clean-system `apt install ./RuVox_0.5.0_amd64.deb` pulls the
player binary automatically and the app no longer panics on startup
("mpv init failed … Is mpv installed and in your PATH?").

Tauri merges user-provided `bundle.linux.deb.depends` with its computed
defaults (libwebkit2gtk-4.1-0, libgtk-3-0, libayatana-appindicator3-1), so the
single entry is sufficient. Verified against tauri-cli 2.x sources
(`depends_deb = config.linux.deb.depends.unwrap_or_default()` + pushes).

The CHANGELOG 0.5.0 section gains a note that AppImage users need `mpv`
installed once; bundling `mpv` into the AppImage is deferred to 0.5.1 (the
open half of #265).

After merge: delete the old `v0.5.0` tag and draft release, re-tag, and let
`release.yml` rebuild the draft.

## Test plan

- Green CI on this PR.
- Post-merge tag rebuild, then verify the new .deb's `Depends` includes both
  `mpv` and the Tauri defaults, and that it installs + starts on a clean
  Ubuntu 24.04 VM **without** a manual `apt install mpv`.
