### PR TITLE
chore(release): version 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes in RuVox, in chronological order.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follow [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [0.5.1] — 2026-08-30
 
 ### Added
 - **Linux AppImage bundles the `mpv` player** — the AppImage now works on a

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ruvox",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3941,7 +3941,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ruvox-tauri"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aho-corasick",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruvox-tauri"
-version = "0.5.0"
+version = "0.5.1"
 description = "RuVox — desktop app for reading technical texts aloud"
 authors = []
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "RuVox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.ruvox.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Release prep for 0.5.1: the AppImage ships the bundled mpv player (#265, #268).

- CHANGELOG: `(Unreleased)` → `[0.5.1] — 2026-08-30`
- versions → 0.5.1 (package.json, Cargo.toml/lock, tauri.conf.json)

Tag `v0.5.1` follows the merge.