### PR TITLE
chore(test): exclude the repo-local tmp/ dir from vitest discovery

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { configDefaults } from "vitest/config";
 
 const host = process.env.TAURI_DEV_HOST;
 
@@ -12,6 +13,11 @@ export default defineConfig(() => ({
   // must stay a no-op outside the jsdom environment.
   test: {
     setupFiles: ["src/test/setup.ts"],
+    // tmp/ holds git worktrees (tmp/wt/<task>/) and scratch data; their test
+    // files resolve against their own node_modules and fail with dual React.
+    // Spread the defaults — a bare exclude array REPLACES them and drags
+    // node_modules test files in (#259). Mirrors server.watch.ignored below.
+    exclude: [...configDefaults.exclude, "**/tmp/**"],
   },
 
   // react-rnd's Draggable reads `process.env.DRAGGABLE_DEBUG` at render


### PR DESCRIPTION
## Summary
- Vitest's default include glob scans the repo root and does not respect `.gitignore`, so git worktrees under the sanctioned `tmp/wt/<task>/` location had their test copies collected and run against the main tree's setup, producing dual-React failures (#259).
- Extend `test.exclude` with `**/tmp/**`, spreading `configDefaults.exclude` — a bare array *replaces* vitest's defaults and drags ~880 dependency test files into the run (verified: 909 files collected, 52 failing to load with the naive config).
- Mirrors the existing `server.watch.ignored: ["**/tmp/**"]` entry for the dev server.

## Verification
- With a probe test file under `tmp/wt/fake-probe/src/`: before the fix it was collected by `vitest list`; after — not collected.
- `nix develop -c just test-ts` green: 26 files / 257 tests.
- `tsc --noEmit` typecheck unaffected (already scoped to `src`).

Closes #259.