### PR TITLE
fix(nix): refresh pnpmDeps.hash after plugin-log bump

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,7 @@
             pname = "ruvox";
             inherit (finalAttrs) version src;
             fetcherVersion = 4;
-            hash = "sha256-HklG+W0l1E+mjwaXw0dxtIpH8Fdqf8gxGs3nQKwuz6k=";
+            hash = "sha256-ZCBAVbFe8q2buKc61vGVoLc0XBsA7osy2cRyGLp7xws=";
           };
 
           nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
Closes #274

## Problem

`@tauri-apps/plugin-log@2.9.0` entered `package.json` / `pnpm-lock.yaml`
with the CSP hardening change (9f3dc27), but the offline pnpm store
pinned by `pnpmDeps.hash` in `flake.nix` predates it. Local
`nix build .#ruvox` (and `just build`) failed with
`ERR_PNPM_NO_OFFLINE_TARBALL`. Release builds were unaffected (standard
Linux builder), but every local nix build on `main` was broken.

## Changes

- Recomputed `pnpmDeps.hash` via the `fetchPnpmDeps` recipe
  (empty hash → `got:` value): `sha256-ZCBAVbFe8q2buKc61vGVoLc0XBsA7osy2cRyGLp7xws=`.
- No other changes. Both `.#ruvox` and `.#ruvox-with-silero` share this
  single fixed-output derivation (pinned pname), so one hash covers both.

## Testing

- `nix build .#ruvox` completes and produces `ruvox-0.2.0` (previously
  failed at the pnpm deps fetch with hash mismatch / missing tarball).