### PR TITLE
fix(piper): disable ORT memory patterns to cut plateau memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follo
   runs in sentence-bounded chunks instead of one inference, so pasting long
   documents no longer risks a system-wide freeze with the Piper engine;
   paragraph breaks in the text now get a distinct silence pause (#155).
+- **Piper uses less memory on long texts** — ORT's memory-pattern cache is
+  disabled for the Piper session; it retained a pattern per chunk shape and
+  added ~200 MB to the memory plateau during narration (#155).
 - **Cancelling synthesis is explicit** — a confirmation toast appears and the
   entry gets its own `Отменено` status instead of silently returning to
   `Ожидание` while the spinner toast kept hanging (#155).

--- a/src-tauri/src/tts/piper/engine.rs
+++ b/src-tauri/src/tts/piper/engine.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Failure mapping
 //! - voice files missing → `TtsError::Ttsd { code: "voice_not_installed", … }`
-//! - config JSON parse / load failure → `TtsError::Ttsd { code: "piper_load_failed", … }`
+//! - voice load failure (config read/parse, ORT session build) → `TtsError::Ttsd { code: "piper_load_failed", … }`
 //! - phonemizer / ONNX inference failure → `TtsError::Ttsd { code: "piper_*_failed", … }`
 //! - cancelled between chunks → `TtsError::Ttsd { code: "piper_cancelled", … }`
 //! - WAV write failure → `TtsError::Ipc(io::Error)`
@@ -457,7 +457,7 @@ fn load_voice_blocking(config_path: &Path) -> Result<(Piper, f32, f32, u32), Tts
     // almost every call, so the cache grows to ~200 MB over a long synthesis
     // (`piper_variable_shape_memory_probe`: plateau ~1.0 GB with patterns vs
     // ~0.8 GB without). Patterns only pay off when the same shape recurs,
-    // which never happens across variable-length chunks.
+    // which rarely happens across variable-length chunks.
     let session = ort::session::Session::builder()
         .map_err(|e| TtsError::Ttsd {
             code: "piper_load_failed".to_string(),

--- a/src-tauri/src/tts/piper/engine.rs
+++ b/src-tauri/src/tts/piper/engine.rs
@@ -438,9 +438,8 @@ impl TtsEngine for PiperEngine {
 /// per-voice tuning (`noise_scale`, `noise_w`, `sample_rate`) from the
 /// `.onnx.json` config that ships alongside the `.onnx` model.
 fn load_voice_blocking(config_path: &Path) -> Result<(Piper, f32, f32, u32), TtsError> {
-    // `Piper::new` wants the `.onnx` model path and the `.onnx.json` config
-    // path separately; rhasspy's naming convention is the config path with
-    // its trailing `.json` extension stripped.
+    // The `.onnx` model path is the `.onnx.json` config path with its
+    // trailing `.json` extension stripped (rhasspy's file naming convention).
     let model_path = config_path.with_extension("");
 
     let cfg_text = std::fs::read_to_string(config_path).map_err(|e| TtsError::Ttsd {
@@ -452,17 +451,35 @@ fn load_voice_blocking(config_path: &Path) -> Result<(Piper, f32, f32, u32), Tts
         message: format!("failed to parse piper config: {e}"),
     })?;
 
-    let piper = Piper::new(&model_path, config_path).map_err(|e| TtsError::Ttsd {
-        code: "piper_load_failed".to_string(),
-        message: format!("piper-rs Piper::new failed: {e}"),
-    })?;
+    // The session is built by hand instead of `Piper::new` to disable ORT's
+    // memory-pattern cache. ORT keeps one pattern per distinct input shape,
+    // and chunked synthesis feeds the model a different (chunk-length) shape
+    // almost every call, so the cache grows to ~200 MB over a long synthesis
+    // (`piper_variable_shape_memory_probe`: plateau ~1.0 GB with patterns vs
+    // ~0.8 GB without). Patterns only pay off when the same shape recurs,
+    // which never happens across variable-length chunks.
+    let session = ort::session::Session::builder()
+        .map_err(|e| TtsError::Ttsd {
+            code: "piper_load_failed".to_string(),
+            message: format!("failed to create ORT session builder: {e}"),
+        })?
+        .with_memory_pattern(false)
+        .map_err(|e| TtsError::Ttsd {
+            code: "piper_load_failed".to_string(),
+            message: format!("failed to configure ORT session: {e}"),
+        })?
+        .commit_from_file(&model_path)
+        .map_err(|e| TtsError::Ttsd {
+            code: "piper_load_failed".to_string(),
+            message: format!("failed to load piper model {}: {e}", model_path.display()),
+        })?;
 
-    Ok((
-        piper,
-        cfg.inference.noise_scale,
-        cfg.inference.noise_w,
-        cfg.audio.sample_rate,
-    ))
+    let noise_scale = cfg.inference.noise_scale;
+    let noise_w = cfg.inference.noise_w;
+    let sample_rate = cfg.audio.sample_rate;
+    let piper = Piper::from_session(session, cfg);
+
+    Ok((piper, noise_scale, noise_w, sample_rate))
 }
 
 /// WAV format for streamed chunk audio: mono 32-bit float at the voice's

--- a/src-tauri/tests/piper_chunk_limit_probe.rs
+++ b/src-tauri/tests/piper_chunk_limit_probe.rs
@@ -116,10 +116,11 @@ fn memory_kb() -> (u64, u64) {
 }
 
 /// A/B memory probe over ~45 variable-length chunks (the real long-text
-/// synthesis shape). Session A is `Piper::new` — the production path, default
-/// ORT options; session B disables ORT's memory-pattern cache, which retains
-/// a pattern per distinct input shape and was suspected of the "RSS grows
-/// until synthesis ends" observation. Whichever curve plateaus names the fix.
+/// synthesis shape). Session A uses `Piper::new` — default ORT options;
+/// session B disables ORT's memory-pattern cache, which retains a pattern
+/// per distinct input shape. Measured (ruslan): the B curve plateaus ~200 MB
+/// lower, so the engine loader (`load_voice_blocking`) now always disables
+/// patterns; this probe stays as the measurement behind that decision.
 #[test]
 #[ignore = "manual probe: needs a downloaded Piper voice and RUVOX_PIPER_LIMIT_PROBE=1"]
 fn piper_variable_shape_memory_probe() {


### PR DESCRIPTION
## Summary

Follow-up to #155. ORT caches one memory pattern per distinct input shape, and chunked Piper synthesis feeds the model a different chunk-length shape almost every call — over a long synthesis the pattern cache grows to ~200 MB on top of the synthesis plateau (`piper_variable_shape_memory_probe`: ~1.0 GB with patterns vs ~0.8 GB without).

`load_voice_blocking` now builds the ORT session with `with_memory_pattern(false)` and hands it to `Piper::from_session` (piper-rs's `Piper::new` is just config-parse plus a default session build). Patterns only pay off when the same shape recurs, which rarely happens across variable-length chunks.

## Testing

- fmt/clippy clean; full Rust suite green in the CI-equivalent docker builder
- the patterns-disabled construction path was exercised end-to-end by the A/B probe
- manual check: synthesizing `tmp/manual-test-data/01-long-technical-ru.txt` with Piper should now plateau ~200 MB lower